### PR TITLE
Centralize Sovran API endpoints

### DIFF
--- a/app/(drawer)/(tabs)/myEsims.tsx
+++ b/app/(drawer)/(tabs)/myEsims.tsx
@@ -16,9 +16,8 @@ import { convertTimeData } from 'helper/time';
 import { showMessage } from 'helper/popup/popups';
 import { ButtonHandler } from 'components/common/ButtonHandler';
 import { Tabs } from 'components/common/Tabs';
+import { fetchProducts } from 'helper/api/sovran';
 
-// Constants
-const API_URL = 'https://esim.sovran.cash/api/products';
 
 // Separate component for eSIM item
 const EsimItem = ({ esim, navigation }) => {
@@ -127,8 +126,7 @@ function EsimsScreen() {
   // Fetch packages from API
   const fetchPackages = async () => {
     try {
-      const response = await fetch(API_URL);
-      const data = await response.json();
+      const data = await fetchProducts();
 
       if (data.success && data.obj?.packageList) {
         setPackageList(data.obj.packageList);

--- a/app/(drawer)/(tabs)/myVpns.tsx
+++ b/app/(drawer)/(tabs)/myVpns.tsx
@@ -15,6 +15,7 @@ import { memoizedGetTheme } from 'helper/redux/settings';
 import { ButtonHandler } from 'components/common/ButtonHandler';
 import { Tabs } from 'components/common/Tabs';
 import { showMessage } from 'helper/popup/popups';
+import { fetchVpnCountries } from 'helper/api/sovran';
 
 function TabTwoScreen() {
   const theme = useSelector(memoizedGetTheme);
@@ -51,8 +52,7 @@ function TabTwoScreen() {
 
   const fetchPackages = async () => {
     try {
-      const response = await fetch('https://esim.sovran.cash/api/vpn/countries');
-      const data = await response.json();
+      const data = await fetchVpnCountries();
 
       if (data) {
         setFetchingPackages(data);

--- a/app/contacts.tsx
+++ b/app/contacts.tsx
@@ -16,6 +16,7 @@ import { setSearch } from 'helper/redux/nostr';
 // Import the base TextInput from React Native instead
 import { TextInput as RNTextInput } from 'react-native';
 import { withSheetProvider } from 'components/hocs/withSheetProvider';
+import { searchUsers as apiSearchUsers } from 'helper/api/sovran';
 
 function ModalScreen() {
   const theme = useSelector(memoizedGetTheme);
@@ -43,10 +44,7 @@ function ModalScreen() {
     setHasSearched(true); // Set this to true when search is initiated
 
     try {
-      const response = await fetch(
-        `https://esim.sovran.cash/api/search?query=${encodeURIComponent(query)}&limit=10`
-      );
-      const data = await response.json();
+      const data = await apiSearchUsers({ query, limit: 10 });
 
       if (data.results && Array.isArray(data.results)) {
         const formattedResults = data.results.map((result) => {

--- a/app/esim.tsx
+++ b/app/esim.tsx
@@ -17,6 +17,7 @@ import React from 'react';
 import { ButtonHandler } from 'components/common/ButtonHandler';
 import { Section } from 'components/common/Section';
 import { withSheetProvider } from 'components/hocs/withSheetProvider';
+import { fetchOrderData, fetchEsimData } from 'helper/api/sovran';
 
 // Move utility function outside of component
 export function convertDataUsage(data) {
@@ -56,28 +57,7 @@ export function convertDataUsage(data) {
   };
 }
 
-// API functions moved out of component for cleaner organization
-const fetchOrderData = async (esim) => {
-  const baseUrl = 'https://esim.sovran.cash/api/order';
-  const params = new URLSearchParams({
-    request: esim.request,
-    packageCode: esim.package.packageCode,
-  });
 
-  if (esim.type === 'TOPUP' && esim?.iccid) {
-    params.append('slug', esim.package.slug);
-    params.append('iccid', esim.iccid);
-    params.append('type', 'TOPUP');
-  }
-
-  const response = await fetch(`${baseUrl}?${params}`);
-  return response.json();
-};
-
-const fetchEsimData = async (orderNo) => {
-  const response = await fetch(`https://esim.sovran.cash/api/order/query?orderNo=${orderNo}`);
-  return response.json();
-};
 
 function ModalScreen() {
   const [loadingEsim, setLoadingEsim] = useState(false);
@@ -94,7 +74,13 @@ function ModalScreen() {
   const fetchAndUpdateEsims = async (esim) => {
     try {
       setLoadingEsim(true);
-      const orderData = await fetchOrderData(esim);
+      const orderData = await fetchOrderData({
+        request: esim.request,
+        packageCode: esim.package.packageCode,
+        slug: esim.package.slug,
+        iccid: esim.iccid,
+        type: esim.type === 'TOPUP' ? 'TOPUP' : undefined,
+      });
       const orderNo = orderData?.obj?.orderNo || esim.order.orderNo;
       if (orderNo) {
         const esimData = await fetchEsimData(orderNo);

--- a/app/esimsDataPlan.tsx
+++ b/app/esimsDataPlan.tsx
@@ -15,6 +15,7 @@ import { memoizedGetTheme } from 'helper/redux/settings';
 import { useTypedRoute } from 'helper/navigation';
 import { ButtonHandler } from 'components/common/ButtonHandler';
 import { withSheetProvider } from 'components/hocs/withSheetProvider';
+import { fetchQuote } from 'helper/api/sovran';
 
 function ModalScreen() {
   const theme = useSelector(memoizedGetTheme);
@@ -74,13 +75,7 @@ function ModalScreen() {
     setLoading(true);
     const currentPackage = packages.find((p) => p.packageCode === selectedPackage);
 
-    const path =
-      type === 'TOPUP'
-        ? `https://esim.sovran.cash/api/quote?packageCode=${currentPackage.packageCode}&type=TOPUP&iccid=${iccid}`
-        : `https://esim.sovran.cash/api/quote?packageCode=${currentPackage.packageCode}`;
-
-    fetch(path)
-      .then((response) => response.json())
+    fetchQuote({ packageCode: currentPackage.packageCode, iccid, type })
       .then((data) => {
         const esim = {
           package: {

--- a/app/vpn.tsx
+++ b/app/vpn.tsx
@@ -17,6 +17,7 @@ import { showMessage } from 'helper/popup/popups';
 import { ButtonHandler } from 'components/common/ButtonHandler';
 import { Section } from 'components/common/Section';
 import { withSheetProvider } from 'components/hocs/withSheetProvider';
+import { activateVpn } from 'helper/api/sovran';
 
 export function convertDataUsage(data) {
   const totalVolume = data.totalVolume; // in bytes
@@ -69,21 +70,15 @@ function ModalScreen() {
   console.log(129837, params);
   //
   const activateVPN = async () => {
-    const response = await fetch(
-      `https://esim.sovran.cash/api/vpn/activate?paymentHash=${params.payment_hash}&location=${params.cc}`
-    );
+    try {
+      const data = await activateVpn({
+        paymentHash: params.payment_hash,
+        location: params.cc,
+      });
 
-    if (!response.ok) {
-      showMessage('activation_failed', {}, { emoji: '🚨' });
-      return;
-    }
-
-    const data = await response.json();
-    //
-
-    const orderedAt = new Date();
-    let expiryDate;
-    switch (params.duration) {
+      const orderedAt = new Date();
+      let expiryDate;
+      switch (params.duration) {
       case '1 hour':
         expiryDate = new Date(orderedAt.getTime() + 60 * 60 * 1000);
         break;
@@ -107,6 +102,9 @@ function ModalScreen() {
       ordered_at: orderedAt.toISOString(),
       expiry_date: expiryDate.toISOString(),
     });
+    } catch (error) {
+      showMessage('activation_failed', {}, { emoji: '🚨' });
+    }
   };
 
   const downloadAndShareVPN = async () => {

--- a/app/vpns.tsx
+++ b/app/vpns.tsx
@@ -14,6 +14,7 @@ import { useRoute } from '@react-navigation/native';
 import { ButtonHandler } from 'components/common/ButtonHandler';
 import { withSheetProvider } from 'components/hocs/withSheetProvider';
 import { getCountry } from './esimCountrySelection';
+import { fetchVpnInvoice } from 'helper/api/sovran';
 
 function ModalScreen() {
   const theme = useSelector(memoizedGetTheme);
@@ -107,17 +108,7 @@ function ModalScreen() {
       (p) => p.packageCode === selectedPackage
     )?.duration_code;
     try {
-      const response = await fetch(
-        `https://esim.sovran.cash/api/vpn/invoice?duration=${selectedPackageDurationCode}`
-      );
-
-      console.log(response);
-
-      if (!response.ok) {
-        throw new Error(`Failed to fetch VPN invoice: ${response.status} ${response.statusText}`);
-      }
-
-      const data = await response.json();
+      const data = await fetchVpnInvoice({ duration: selectedPackageDurationCode });
 
       setVpn({
         location: country,

--- a/helper/api/sovran.ts
+++ b/helper/api/sovran.ts
@@ -1,0 +1,92 @@
+const BASE_URL = 'https://esim.sovran.cash/api';
+
+export interface ProductPackage {
+  packageCode: number | string;
+  slug: string;
+  name: string;
+  price: number;
+  currencyCode: string;
+  volume: number;
+  smsStatus: string;
+  dataType: string;
+  unusedValidTime: number;
+  duration: number;
+  durationUnit: string;
+  location: string;
+  description: string;
+  activeType: string;
+  favourite: boolean;
+  retailPrice: number;
+  speed: string;
+}
+
+export interface QuoteResponse {
+  sats: number;
+  request: string;
+}
+
+export interface OrderResponse {
+  obj?: {
+    orderNo: string;
+    esimList?: any[];
+  };
+  [key: string]: any;
+}
+
+export interface SearchResult {
+  profileEvent: string;
+  [key: string]: any;
+}
+
+export const fetchProducts = async () => {
+  const res = await fetch(`${BASE_URL}/products`);
+  return res.json() as Promise<{ success: boolean; obj?: { packageList: ProductPackage[] } }>;
+};
+
+export const fetchQuote = async ({ packageCode, iccid, type }: { packageCode: string | number; iccid?: string; type?: 'TOPUP' | 'BASE' }) => {
+  const params = new URLSearchParams({ packageCode: String(packageCode) });
+  if (type === 'TOPUP' && iccid) {
+    params.append('type', 'TOPUP');
+    params.append('iccid', iccid);
+  }
+  const res = await fetch(`${BASE_URL}/quote?${params}`);
+  return res.json() as Promise<QuoteResponse>;
+};
+
+export const fetchOrderData = async ({ request, packageCode, slug, iccid, type }: { request: string; packageCode: string | number; slug?: string; iccid?: string; type?: 'TOPUP' }) => {
+  const params = new URLSearchParams({ request, packageCode: String(packageCode) });
+  if (type === 'TOPUP' && slug && iccid) {
+    params.append('slug', slug);
+    params.append('iccid', iccid);
+    params.append('type', 'TOPUP');
+  }
+  const res = await fetch(`${BASE_URL}/order?${params}`);
+  return res.json() as Promise<OrderResponse>;
+};
+
+export const fetchEsimData = async ({ orderNo }: { orderNo: string }) => {
+  const res = await fetch(`${BASE_URL}/order/query?orderNo=${orderNo}`);
+  return res.json() as Promise<OrderResponse>;
+};
+
+export const searchUsers = async ({ query, limit = 10 }: { query: string; limit?: number }) => {
+  const params = new URLSearchParams({ query, limit: String(limit) });
+  const res = await fetch(`${BASE_URL}/search?${params}`);
+  return res.json() as Promise<{ results: SearchResult[] }>;
+};
+
+export const fetchVpnInvoice = async ({ duration }: { duration: string | number }) => {
+  const res = await fetch(`${BASE_URL}/vpn/invoice?duration=${duration}`);
+  return res.json() as Promise<{ payment_hash: string; payment_request: string }>;
+};
+
+export const fetchVpnCountries = async () => {
+  const res = await fetch(`${BASE_URL}/vpn/countries`);
+  return res.json() as Promise<any>;
+};
+
+export const activateVpn = async ({ paymentHash, location }: { paymentHash: string; location: string }) => {
+  const params = new URLSearchParams({ paymentHash, location });
+  const res = await fetch(`${BASE_URL}/vpn/activate?${params}`);
+  return res.json() as Promise<any>;
+};


### PR DESCRIPTION
## Summary
- create `helper/api/sovran.ts` with typed API helpers
- use those helpers in screens that call sovran.cash endpoints

## Testing
- `npm test` *(fails: jest not found)*
- `npm run pretty` *(fails: cannot find prettier-plugin-tailwindcss)*
