### PR TITLE
Add passcode lock

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -39,6 +39,7 @@ import { MODAL_SCREENS, MODAL_SCREENS_ALT } from 'helper/navigation/screens';
 import { TransactionProvider } from 'components/providers/TransactionsProvider';
 import { WalletsProvider } from 'components/providers/WalletsProviders';
 import { registerAllSheets } from 'components/layout/sheets/registerSheets';
+import PasscodeGate from 'components/passcode/PasscodeGate';
 
 registerAllSheets({ context: 'global' });
 
@@ -317,7 +318,9 @@ export default function RootLayout() {
                   <View onLayout={onLayoutRootView} style={{ flex: 1 }}>
                     <WalletsProvider>
                       <TransactionProvider>
-                        <MainStack />
+                        <PasscodeGate>
+                          <MainStack />
+                        </PasscodeGate>
                       </TransactionProvider>
                     </WalletsProvider>
                   </View>

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -237,6 +237,13 @@ const ModalScreen: React.FC<{}> = () => {
             }}
             isFirst
           />
+          <RowButton
+            label="Passcode"
+            onPress={() => {
+              navigation.navigate('settings/passcode');
+            }}
+            isFirst
+          />
         </Section>
         {/* <Section title="npub.cash Settings">
         <View style={styles.rowWrapper}>

--- a/app/settings/passcode.tsx
+++ b/app/settings/passcode.tsx
@@ -1,0 +1,116 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import { useSelector } from 'react-redux';
+import { useTypedNavigation } from 'helper/navigation';
+import { memoizedGetTheme, useSettings } from 'helper/redux/settings';
+import { greys } from 'helper/colors';
+import NumericKeyboard from 'components/passcode/NumericKeyboard';
+import Container from 'components/layout/Container';
+
+const PASSCODE_LENGTH = 4;
+
+const PasscodeSettings: React.FC = () => {
+  const theme = useSelector(memoizedGetTheme);
+  const { setPasscode } = useSettings();
+  const navigation = useTypedNavigation();
+  const [step, setStep] = useState<'create' | 'confirm'>('create');
+  const [code, setCode] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [keyIdx, setKeyIdx] = useState(0);
+  const styles = createStyles(theme);
+
+  const handlePress = (val: string) => {
+    if (step === 'create') {
+      if (val.length <= PASSCODE_LENGTH) {
+        setCode(val);
+        if (val.length === PASSCODE_LENGTH) {
+          setStep('confirm');
+          setKeyIdx((k) => k + 1);
+        }
+      }
+    } else {
+      if (val.length <= PASSCODE_LENGTH) {
+        setConfirm(val);
+        if (val.length === PASSCODE_LENGTH) {
+          if (val === code) {
+            setPasscode(val);
+            navigation.goBack();
+          } else {
+            setStep('create');
+            setCode('');
+            setConfirm('');
+            setKeyIdx((k) => k + 1);
+          }
+        }
+      }
+    }
+  };
+
+  const currentValue = step === 'create' ? code : confirm;
+
+  return (
+    <Container>
+      <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
+        <View style={styles.container}>
+          <View style={styles.content}>
+            <Text style={styles.title}>
+              {step === 'create' ? 'Enter new passcode' : 'Confirm passcode'}
+            </Text>
+            <View style={styles.dotsContainer}>
+              {Array.from({ length: PASSCODE_LENGTH }).map((_, i) => (
+                <View
+                  key={i}
+                  style={currentValue.length > i ? styles.dotActive : styles.dot}
+                />
+              ))}
+            </View>
+          </View>
+          <NumericKeyboard key={keyIdx} onKeyPress={handlePress} />
+        </View>
+      </ScrollView>
+    </Container>
+  );
+};
+
+const createStyles = (theme: any) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      paddingVertical: 32,
+    },
+    content: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    title: {
+      color: greys(theme)[0],
+      fontSize: 20,
+      marginBottom: 20,
+      fontFamily: 'OverpassBold',
+      textAlign: 'center',
+    },
+    dotsContainer: {
+      flexDirection: 'row',
+      marginBottom: 20,
+    },
+    dot: {
+      width: 12,
+      height: 12,
+      borderRadius: 6,
+      borderWidth: 1,
+      borderColor: greys(theme)[0],
+      marginHorizontal: 6,
+    },
+    dotActive: {
+      width: 12,
+      height: 12,
+      borderRadius: 6,
+      backgroundColor: greys(theme)[0],
+      marginHorizontal: 6,
+    },
+  });
+
+export default PasscodeSettings;

--- a/components/passcode/NumericKeyboard.tsx
+++ b/components/passcode/NumericKeyboard.tsx
@@ -1,0 +1,83 @@
+import React, { useCallback, useState } from 'react';
+import { View, Text, TouchableOpacity } from 'react-native';
+import { useSelector } from 'react-redux';
+import { memoizedGetTheme } from 'helper/redux/settings';
+import { greys } from 'helper/colors';
+import Haptics from 'components/common/Haptics';
+
+interface Props {
+  onKeyPress: (value: string) => void;
+}
+
+type KeyVal = string | number;
+
+const NumericKeyboard: React.FC<Props> = ({ onKeyPress }) => {
+  const [inputValue, setInputValue] = useState('');
+  const theme = useSelector(memoizedGetTheme);
+
+  const handlePress = useCallback(
+    (value: KeyVal) => {
+      setInputValue((prev) => {
+        let newValue = prev;
+        if (String(value) === '<') {
+          Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+          newValue = prev.slice(0, -1);
+        } else {
+          Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+          newValue = prev + String(value);
+        }
+        onKeyPress(newValue);
+        return newValue;
+      });
+    },
+    [onKeyPress]
+  );
+
+  const renderButton = useCallback(
+    (value: KeyVal) => (
+      <TouchableOpacity
+        key={String(value)}
+        className="mx-0.5 w-1/3 items-center justify-center overflow-hidden"
+        style={{ backgroundColor: greys(theme)[2300] }}
+        onPress={() => handlePress(value)}
+      >
+        {value === '<' ? (
+          <Text style={{ color: 'white', fontSize: 24 }}>⌫</Text>
+        ) : (
+          <Text
+            style={{
+              padding: 16,
+              paddingHorizontal: 24,
+              fontSize: 24,
+              color: 'white',
+              fontWeight: 'bold',
+              fontFamily: 'OverpassBold',
+            }}
+          >
+            {value}
+          </Text>
+        )}
+      </TouchableOpacity>
+    ),
+    [handlePress, theme]
+  );
+
+  const buttons: KeyVal[][] = [
+    ['1', '2', '3'],
+    ['4', '5', '6'],
+    ['7', '8', '9'],
+    ['', '0', '<'],
+  ];
+
+  return (
+    <View className="items-center justify-center bg-transparent">
+      {buttons.map((row, rowIndex) => (
+        <View key={rowIndex} className="mb-0.25 flex-row justify-between">
+          {row.map(renderButton)}
+        </View>
+      ))}
+    </View>
+  );
+};
+
+export default NumericKeyboard;

--- a/components/passcode/PasscodeGate.tsx
+++ b/components/passcode/PasscodeGate.tsx
@@ -1,0 +1,23 @@
+import React, { useState, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { selectPasscode } from 'helper/redux/settings/selectors';
+import PasscodeScreen from './PasscodeScreen';
+
+const PasscodeGate: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const storedPasscode = useSelector(selectPasscode);
+  const [unlocked, setUnlocked] = useState(!storedPasscode);
+
+  useEffect(() => {
+    if (!storedPasscode) setUnlocked(true);
+  }, [storedPasscode]);
+
+  if (storedPasscode && !unlocked) {
+    return (
+      <PasscodeScreen passcode={storedPasscode} onSuccess={() => setUnlocked(true)} />
+    );
+  }
+
+  return <>{children}</>;
+};
+
+export default PasscodeGate;

--- a/components/passcode/PasscodeScreen.tsx
+++ b/components/passcode/PasscodeScreen.tsx
@@ -1,0 +1,90 @@
+import React, { useState, useRef } from 'react';
+import { View, Text, StyleSheet, Animated } from 'react-native';
+import { useSelector } from 'react-redux';
+import { memoizedGetTheme } from 'helper/redux/settings';
+import { greys } from 'helper/colors';
+import NumericKeyboard from './NumericKeyboard';
+
+interface Props {
+  passcode: string;
+  onSuccess: () => void;
+}
+
+const PasscodeScreen: React.FC<Props> = ({ passcode, onSuccess }) => {
+  const theme = useSelector(memoizedGetTheme);
+  const [value, setValue] = useState('');
+  const [keyIdx, setKeyIdx] = useState(0);
+  const opacity = useRef(new Animated.Value(1)).current;
+  const styles = createStyles(theme);
+
+  const handlePress = (val: string) => {
+    if (val.length > passcode.length) return;
+    setValue(val);
+    if (val.length === passcode.length) {
+      if (val === passcode) {
+        Animated.timing(opacity, {
+          toValue: 0,
+          duration: 300,
+          useNativeDriver: true,
+        }).start(() => onSuccess());
+      } else {
+        setTimeout(() => {
+          setValue('');
+          setKeyIdx((k) => k + 1);
+        }, 200);
+      }
+    }
+  };
+
+  return (
+    <Animated.View style={[styles.container, { opacity }]}>
+      <Text style={styles.title}>Enter Passcode</Text>
+      <View style={styles.dotsContainer}>
+        {Array.from({ length: passcode.length }).map((_, i) => (
+          <View
+            key={i}
+            style={value.length > i ? styles.dotActive : styles.dot}
+          />
+        ))}
+      </View>
+      <NumericKeyboard key={keyIdx} onKeyPress={handlePress} />
+    </Animated.View>
+  );
+};
+
+const createStyles = (theme: any) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: greys(theme)[2300],
+    },
+    title: {
+      color: greys(theme)[0],
+      fontSize: 20,
+      marginBottom: 20,
+      fontFamily: 'OverpassBold',
+    },
+    dotsContainer: {
+      flexDirection: 'row',
+      marginBottom: 20,
+    },
+    dot: {
+      width: 12,
+      height: 12,
+      borderRadius: 6,
+      borderWidth: 1,
+      borderColor: greys(theme)[0],
+      marginHorizontal: 6,
+    },
+    dotActive: {
+      width: 12,
+      height: 12,
+      borderRadius: 6,
+      backgroundColor: greys(theme)[0],
+      marginHorizontal: 6,
+    },
+  });
+
+export default PasscodeScreen;

--- a/helper/navigation/screens.tsx
+++ b/helper/navigation/screens.tsx
@@ -355,6 +355,10 @@ export const MODAL_SCREENS_ALT: ModalConfig[] = [
     title: 'Verify Seed Phrase',
   },
   {
+    name: 'settings/passcode',
+    title: 'Passcode',
+  },
+  {
     name: 'settings/profile',
     title: 'Profile',
   },

--- a/helper/redux/settings/actionTypes.ts
+++ b/helper/redux/settings/actionTypes.ts
@@ -3,3 +3,4 @@ export const SET_LANGUAGE = 'SET_LANGUAGE';
 export const SET_THEME = 'SET_THEME';
 export const TERMS_ACCEPTED = 'TERMS_ACCEPTED';
 export const SET_EXPERIMENTAL = 'SET_EXPERIMENTAL';
+export const SET_PASSCODE = 'SET_PASSCODE';

--- a/helper/redux/settings/actions.ts
+++ b/helper/redux/settings/actions.ts
@@ -1,4 +1,10 @@
-import { SET_DISPLAY_BITCOIN, SET_LANGUAGE, SET_THEME, SET_EXPERIMENTAL } from './actionTypes';
+import {
+  SET_DISPLAY_BITCOIN,
+  SET_LANGUAGE,
+  SET_THEME,
+  SET_EXPERIMENTAL,
+  SET_PASSCODE,
+} from './actionTypes';
 
 export const setLanguage = (lang: string) => ({
   type: SET_LANGUAGE,
@@ -18,4 +24,9 @@ export const setDisplayBitcoin = (display: number) => ({
 export const setExperimental = (experimental: boolean) => ({
   type: SET_EXPERIMENTAL,
   payload: experimental,
+});
+
+export const setPasscode = (passcode: string) => ({
+  type: SET_PASSCODE,
+  payload: passcode,
 });

--- a/helper/redux/settings/hooks.ts
+++ b/helper/redux/settings/hooks.ts
@@ -1,6 +1,6 @@
 import { useDispatch, useSelector } from 'react-redux';
-import { setLanguage, setTheme, setDisplayBitcoin } from './actions';
-import { selectSettings, selectTheme, selectLanguage, selectDisplayBitcoin } from './selectors';
+import { setLanguage, setTheme, setDisplayBitcoin, setPasscode } from './actions';
+import { selectSettings, selectTheme, selectLanguage, selectDisplayBitcoin, selectPasscode } from './selectors';
 
 export const useSettings = () => {
   const dispatch = useDispatch();
@@ -8,14 +8,17 @@ export const useSettings = () => {
   const theme = useSelector(selectTheme);
   const lang = useSelector(selectLanguage);
   const displayBtc = useSelector(selectDisplayBitcoin);
+  const passcode = useSelector(selectPasscode);
 
   return {
     settings,
     theme,
     lang,
     displayBtc,
+    passcode,
     setTheme: (theme: string) => dispatch(setTheme(theme)),
     setLanguage: (lang: string) => dispatch(setLanguage(lang)),
     setDisplayBitcoin: (display: number) => dispatch(setDisplayBitcoin(display)),
+    setPasscode: (code: string) => dispatch(setPasscode(code)),
   };
 };

--- a/helper/redux/settings/reducer.ts
+++ b/helper/redux/settings/reducer.ts
@@ -4,6 +4,7 @@ import {
   SET_THEME,
   TERMS_ACCEPTED,
   SET_EXPERIMENTAL,
+  SET_PASSCODE,
 } from './actionTypes';
 
 const initialState = {
@@ -11,6 +12,7 @@ const initialState = {
     lang: 'en',
     theme: 'dark',
     display_btc: 1,
+    passcode: '',
   },
 };
 
@@ -61,6 +63,15 @@ export const settingsReducer = (state = initialState, action) => {
         settings: {
           ...state.settings,
           experimental: action.payload,
+        },
+      };
+    }
+    case SET_PASSCODE: {
+      return {
+        ...state,
+        settings: {
+          ...state.settings,
+          passcode: action.payload,
         },
       };
     }

--- a/helper/redux/settings/selectors.ts
+++ b/helper/redux/settings/selectors.ts
@@ -12,6 +12,11 @@ export const selectDisplayBitcoin = createSelector(
   (settings) => settings.display_btc
 );
 
+export const selectPasscode = createSelector(
+  [selectSettings],
+  (settings) => settings.passcode
+);
+
 export const memoizedGetTheme = createSelector(
   [
     (state: RootState) => {


### PR DESCRIPTION
## Summary
- add passcode state to redux settings
- create numeric keyboard and passcode gate components
- add passcode screen and settings screen to manage passcode
- integrate passcode gate in the root layout
- improve keyboard alignment and haptics
- fade out passcode screen when unlocking

## Testing
- `yarn test` *(fails: fetch failed due to network)*