### PR TITLE
Add BTC sat display option

### DIFF
--- a/assets/icons/index.tsx
+++ b/assets/icons/index.tsx
@@ -877,6 +877,17 @@ export function BtcIcon({ height = 34, width = 34, color, weight }) {
   return <Icon name={iconName} color={color || greys(theme)[0]} size={width} />;
 }
 
+export function BtcUnit({ color, width = '24', height = '24' }) {
+  const theme = useSelector(memoizedGetTheme);
+  return (
+    <Icon
+      name="material-symbols:currency-bitcoin"
+      color={color || greys(theme)[0]}
+      size={width}
+    />
+  );
+}
+
 export function ShareIcon() {
   const theme = useSelector(memoizedGetTheme);
 

--- a/components/layout/PrimaryBalance.tsx
+++ b/components/layout/PrimaryBalance.tsx
@@ -15,7 +15,7 @@ interface Account {
 }
 
 type CurrencyUnit = 'sat' | 'usd' | 'eur' | string;
-type DisplayBtcMode = 0 | 1 | 2;
+type DisplayBtcMode = 0 | 1 | 2 | 3;
 type FontWeight = 'heavy' | 'medium' | 'regular' | 'light';
 
 interface PrimaryBalanceProps {
@@ -39,7 +39,7 @@ export function PrimaryBalance({ account }: PrimaryBalanceProps): React.ReactEle
 
   const toggleUnit = useCallback(() => {
     Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-    setDisplayBitcoin(((settings.display_btc + 1) % 3) as DisplayBtcMode);
+    setDisplayBitcoin(((settings.display_btc + 1) % 4) as DisplayBtcMode);
   }, [settings.display_btc, setDisplayBitcoin]);
 
   return (
@@ -136,6 +136,26 @@ export function AmountFormatter({
           }}>
           {formatCurrencyWrapper(amount, unit, displayBtc)}
         </Text>
+      )}
+
+      {displayBtc === 3 && (
+        <>
+          <View
+            style={{ marginLeft: weight === 'heavy' ? -7 : -4, backgroundColor: 'transparent' }}>
+            <BtcIcon weight={weight} height={size} width={size * 1.4} color={currentColor} />
+          </View>
+          <Text
+            size={size}
+            weight={weight}
+            style={{
+              color: currentColor,
+              marginLeft: weight === 'heavy' ? -7 : -4,
+              margin: 0,
+              zIndex: 2,
+            }}>
+            {formatCurrencyWrapper(amount, unit, displayBtc)}
+          </Text>
+        </>
       )}
     </View>
   );

--- a/components/layout/Transaction.tsx
+++ b/components/layout/Transaction.tsx
@@ -1,7 +1,7 @@
 import { UntranslatedText, View } from 'components/common/Themed';
 import { useMemo } from 'react';
 import { formatCurrency } from 'helper/currency';
-import Icon, { LightningUnit } from 'assets/icons';
+import Icon, { LightningUnit, BtcUnit } from 'assets/icons';
 import { convertTime } from 'helper/time';
 import { greens, greys, reds, shades } from 'helper/colors';
 import { useNostr } from 'helper/redux/nostr';
@@ -322,7 +322,10 @@ export function Transaction({ tx, transactions, account }: TransactionProps): JS
   const renderAmountDetails = (): JSX.Element => {
     const sign = isSend ? '-' : isReceive ? '+' : '';
     const precision = tx.unit === 'sat' ? (settings.display_btc === 0 ? 8 : 0) : 2;
-    const currencyDisplay = settings.display_btc === 1 && tx.unit === 'sat' ? 'none' : 'name';
+    const currencyDisplay =
+      tx.unit === 'sat' && [0, 1, 3].includes(settings.display_btc)
+        ? 'none'
+        : 'name';
     const denomination =
       tx.unit === 'sat' ? (settings.display_btc === 0 ? 'btc' : 'sats') : tx.unit;
 
@@ -377,6 +380,9 @@ export function Transaction({ tx, transactions, account }: TransactionProps): JS
 
           {settings.display_btc === 1 && tx.unit === 'sat' && (
             <LightningUnit width={'10'} height="10" color={isSend ? reds[300] : greens[300]} />
+          )}
+          {[0, 3].includes(settings.display_btc) && tx.unit === 'sat' && (
+            <BtcUnit width={'10'} height="10" color={isSend ? reds[300] : greens[300]} />
           )}
         </View>
         {relatedAmount && (

--- a/helper/currency.ts
+++ b/helper/currency.ts
@@ -164,7 +164,7 @@ export function formatCurrency(currency: Currency, options: FormatOptions): stri
  * Simplified wrapper for formatCurrency with sensible defaults
  * @param amount - Amount to format
  * @param unit - Currency unit (e.g., 'sat', 'usd')
- * @param display - Display style: 0 (BTC value), 1 (default - sats with no symbol), 2 (sats with name)
+ * @param display - Display style: 0 (BTC value), 1 (default - sats with no symbol), 2 (sats with name), 3 (sats with BTC icon)
  * @returns Formatted currency string
  */
 export const formatCurrencyWrapper = (amount: number, unit: string, display = 1): string => {


### PR DESCRIPTION
## Summary
- support a fourth bitcoin display mode
- add `BtcUnit` icon for inline use
- allow toggling through all four display modes
- render satoshi values with a BTC icon in transactions
- document new display mode in currency helper

## Testing
- `npm test` *(fails: jest not found)*