### PR TITLE
Add contacts to messaging and payments

### DIFF
--- a/app/(drawer)/(tabs)/payments.tsx
+++ b/app/(drawer)/(tabs)/payments.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { StyleSheet, ScrollView, Dimensions, VirtualizedList } from 'react-native';
 import { Text, View } from 'components/common/Themed';
-import { memoizedIsMuted, useNostr } from 'helper/redux/nostr';
+import { useNostr } from 'helper/redux/nostr';
 import { memoizedGetTransactions, useCashu } from 'helper/redux/cashu';
 import { formatCurrency } from 'helper/currency';
 import Modal from 'components/layout/Modal';
@@ -54,10 +54,9 @@ const Section = () => {
   const theme = useSelector(memoizedGetTheme);
   const styles = createStyles(theme);
   const navigation = useTypedNavigation();
-  const { profiles, search, currentProfile, messages, follows } = useNostr();
+  const { profiles, search, currentProfile, messages, contacts } = useNostr();
   const { transactions } = useCashu();
   const [selectedTab, setSelectedTab] = useState('Recent activity');
-  const [following, setFollowing] = useState([]);
 
   const filteredProfiles = profiles.filter((p) => p.pubkey !== currentProfile?.pubkey);
   const filteredSearch = search.filter((s) => s.pubkey !== currentProfile?.pubkey);
@@ -86,7 +85,7 @@ const Section = () => {
       .filter(
         (profile, index, self) => index === self.findIndex((t) => t.pubkey === profile.pubkey)
       ),
-    ...following.map((f) => ({ pubkey: f.pubkey, ...f.profile })),
+    ...contacts.map((f) => ({ pubkey: f.pubkey, ...f.profile })),
   ];
 
   const groupedMessages = messages.reduce((acc, message) => {
@@ -136,7 +135,7 @@ const Section = () => {
 
   const onPageSelected = useCallback((event) => {
     const pageIndex = event.nativeEvent.position;
-    const tabNames = ['Recent activity', 'Following'];
+    const tabNames = ['Recent activity', 'Contacts'];
     setSelectedTab(tabNames[pageIndex]);
   }, []);
 
@@ -145,7 +144,7 @@ const Section = () => {
     pagerRef.current?.setPage(index);
   };
 
-  const tabs = ['Recent activity', 'Following'].filter(Boolean);
+  const tabs = ['Recent activity', 'Contacts'].filter(Boolean);
 
   const getItem = (data, index) => data[index];
 
@@ -157,7 +156,12 @@ const Section = () => {
         style={{
           paddingHorizontal: 16,
         }}>
-        <Tabs tabs={tabs} selectedTab={selectedTab} handleTabPress={handleTabPress} />
+        <Tabs
+          tabs={tabs}
+          selectedTab={selectedTab}
+          handleTabPress={handleTabPress}
+          amounts={[enrichedContacts.length, contacts.length]}
+        />
       </View>
       <View
         style={{
@@ -175,7 +179,7 @@ const Section = () => {
             marginHorizontal: -16,
           }}
           initialPage={0}
-          scrollEnabled={follows.length > 0}>
+          scrollEnabled={contacts.length > 0}>
           <ScrollView
             key="1"
             style={{
@@ -207,7 +211,7 @@ const Section = () => {
               overflow: 'hidden',
             }}>
             <VirtualizedList
-              data={follows}
+              data={contacts}
               initialNumToRender={1}
               renderItem={(item) => <RenderContactItem {...item} />}
               keyExtractor={(item) => item.pubkey}

--- a/app/MessagePage/Header.tsx
+++ b/app/MessagePage/Header.tsx
@@ -9,8 +9,8 @@ import CachedImage from 'components/common/Image';
 import { useTypedNavigation } from 'helper/navigation';
 import { TouchableOpacity } from 'components/common/TouchableOpacity';
 import { SheetManager } from 'react-native-actions-sheet';
-import { muteUser, reportUser } from 'helper/redux/nostr';
-import { useDispatch } from 'react-redux';
+import { muteUser, reportUser, addContact, removeContact } from 'helper/redux/nostr';
+import { useDispatch, useSelector } from 'react-redux';
 import { showMessage } from 'helper/popup/popups';
 
 const Header = ({ theme, combinedSearchAndProfiles, params, profiles }) => {
@@ -29,6 +29,8 @@ const Header = ({ theme, combinedSearchAndProfiles, params, profiles }) => {
     'Unknown User';
 
   const dispatch = useDispatch();
+  const contacts = useSelector((state) => state.nostr.contacts || []);
+  const isContact = contacts.some((c) => c.pubkey === params.pubkey);
 
   const handleGoBack = () => {
     if (navigation.canGoBack()) {
@@ -92,6 +94,19 @@ const Header = ({ theme, combinedSearchAndProfiles, params, profiles }) => {
             SheetManager.show('button-handler', {
               payload: {
                 buttons: [
+                  {
+                    icon: isContact ? 'la:user-minus' : 'la:user-plus',
+                    text: isContact ? 'Remove Contact' : 'Add Contact',
+                    onPress: async () => {
+                      if (isContact) {
+                        dispatch(removeContact(params.pubkey));
+                        await showMessage('Contact removed');
+                      } else {
+                        dispatch(addContact({ pubkey: params.pubkey, profile }));
+                        await showMessage('Contact added');
+                      }
+                    },
+                  },
                   {
                     icon: 'la:user-slash',
                     text: 'Mute User',

--- a/helper/redux/nostr/actionTypes.ts
+++ b/helper/redux/nostr/actionTypes.ts
@@ -7,3 +7,5 @@ export const ADD_MESSAGE = 'ADD_MESSAGE';
 export const APPEND_QUERY = 'APPEND_QUERY';
 export const MUTE_USER = 'MUTE_USER';
 export const REPORT_USER = 'REPORT_USER';
+export const ADD_CONTACT = 'ADD_CONTACT';
+export const REMOVE_CONTACT = 'REMOVE_CONTACT';

--- a/helper/redux/nostr/actions.ts
+++ b/helper/redux/nostr/actions.ts
@@ -8,6 +8,8 @@ import {
   APPEND_QUERY,
   MUTE_USER,
   REPORT_USER,
+  ADD_CONTACT,
+  REMOVE_CONTACT,
 } from './actionTypes';
 
 export const muteUser = (pubkey: string) => ({
@@ -53,4 +55,14 @@ export const updateMessageStatus = (pubkey, messageId, status) => ({
 export const addMessage = (pubkey, message) => ({
   type: ADD_MESSAGE,
   payload: { pubkey, message },
+});
+
+export const addContact = (contact) => ({
+  type: ADD_CONTACT,
+  payload: contact,
+});
+
+export const removeContact = (pubkey) => ({
+  type: REMOVE_CONTACT,
+  payload: pubkey,
 });

--- a/helper/redux/nostr/hooks.ts
+++ b/helper/redux/nostr/hooks.ts
@@ -6,6 +6,8 @@ import {
   updateMessageStatus,
   setFollows,
   setSearch,
+  addContact,
+  removeContact,
 } from './actions';
 
 export const useNostr = () => {
@@ -15,9 +17,10 @@ export const useNostr = () => {
   const profiles = useSelector((state) => state.nostr.profiles);
   const messages = useSelector((state) => state.nostr.messages);
   const follows = useSelector((state) => state.nostr.follows);
+  const contacts = useSelector((state) => state.nostr.contacts);
 
   return {
-    search: [...search, ...Object.values(follows).flat()],
+    search: [...search, ...Object.values(follows).flat(), ...(contacts || [])],
     currentProfile,
     profiles: profiles || [],
     messages: [...(messages[currentProfile.pubkey] || []), ...(messages['loaded_messages'] || [])],
@@ -29,6 +32,9 @@ export const useNostr = () => {
     },
     setFollows: (follows) => dispatch(setFollows(follows)),
     follows: [...(follows[currentProfile.pubkey] || [])],
+    contacts: contacts || [],
+    addContact: (contact) => dispatch(addContact(contact)),
+    removeContact: (pubkey) => dispatch(removeContact(pubkey)),
     setSearch: (search) => dispatch(setSearch(search)),
   };
 };

--- a/helper/redux/nostr/reducer.ts
+++ b/helper/redux/nostr/reducer.ts
@@ -9,6 +9,8 @@ import {
   APPEND_QUERY,
   MUTE_USER,
   REPORT_USER,
+  ADD_CONTACT,
+  REMOVE_CONTACT,
 } from './actionTypes';
 
 const initialState = {
@@ -85,6 +87,7 @@ const initialState = {
     loaded_messages: [],
   },
   follows: {},
+  contacts: [],
 };
 
 export const nostrReducer = (state = initialState, action) => {
@@ -172,6 +175,28 @@ export const nostrReducer = (state = initialState, action) => {
           }
           return s;
         }),
+      };
+    }
+
+    case ADD_CONTACT: {
+      const existing = state.contacts.find(
+        (c) => c.pubkey === action.payload.pubkey
+      );
+      if (existing) {
+        return {
+          ...state,
+          contacts: state.contacts.map((c) =>
+            c.pubkey === action.payload.pubkey ? action.payload : c
+          ),
+        };
+      }
+      return { ...state, contacts: [...state.contacts, action.payload] };
+    }
+
+    case REMOVE_CONTACT: {
+      return {
+        ...state,
+        contacts: state.contacts.filter((c) => c.pubkey !== action.payload),
       };
     }
 

--- a/helper/redux/store/index.ts
+++ b/helper/redux/store/index.ts
@@ -265,13 +265,16 @@ const migrations = {
       state
     );
   },
+  73: (state: RootState) => {
+    return _.set(state, ['nostr', 'contacts'], []);
+  },
 };
 
 const persistConfig = {
   key: 'SOVRAN',
   storage: AsyncStorage,
   timeout: null,
-  version: 72,
+  version: 73,
   migrate: createMigrate(migrations, { debug: true }),
 };
 


### PR DESCRIPTION
## Summary
- allow users to add or remove contacts from the message screen
- track contacts in Redux store and expose helpers
- display contacts on the payments screen with counts in the tabs
- rename "Following" tab to "Contacts"
- persist new contacts state with migration

## Testing
- `yarn test` *(fails: Connect Timeout Error)*