### PR TITLE
Improve charts with interactive dots

### DIFF
--- a/app/(drawer)/(tabs)/index.tsx
+++ b/app/(drawer)/(tabs)/index.tsx
@@ -22,6 +22,8 @@ import WalletHeader from '../../../components/layout/WalletHeader';
 import { useTypedNavigation } from 'helper/navigation';
 import { memoizedGetSelectedMint } from 'helper/redux/cashu';
 import { isProduction } from 'helper/version';
+import Icon from 'assets/icons';
+import { TouchableOpacity } from 'components/common/TouchableOpacity';
 
 async function getProfile(currentProfile) {
   const sk = nip19.decode(currentProfile?.nsec).data;
@@ -105,8 +107,13 @@ function TabOneScreen({
       headerTitle: () => (
         <WalletHeader unit={account.unit} accounts={accounts} setAccount={setAccount} />
       ),
+      headerRight: () => (
+        <TouchableOpacity onPress={() => navigation.navigate('charts', {})}>
+          <Icon name="mdi:chart-line" color={greys(theme)[0]} />
+        </TouchableOpacity>
+      ),
     });
-  }, [navigation, account, accounts]);
+  }, [navigation, account, accounts, theme]);
 
   if (!settings?.termsAccepted) {
     return (

--- a/app/chart.tsx
+++ b/app/chart.tsx
@@ -1,0 +1,202 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Animated, StyleSheet, Dimensions, View as RNView } from 'react-native';
+import { LineChart, BarChart } from 'react-native-chart-kit';
+import { useSelector } from 'react-redux';
+import { memoizedGetTheme } from 'helper/redux/settings';
+import { greys, greens, reds } from 'helper/colors';
+import { View, Text } from 'components/common/Themed';
+import { TouchableOpacity } from 'components/common/TouchableOpacity';
+import { useTypedRoute } from 'helper/navigation';
+import Container from 'components/layout/Container';
+
+const balancePoints = [
+  { label: 'Jan', value: 20, incoming: true },
+  { label: 'Feb', value: 45, incoming: true },
+  { label: 'Mar', value: 28, incoming: false },
+  { label: 'Apr', value: 80, incoming: true },
+  { label: 'May', value: 99, incoming: false },
+  { label: 'Jun', value: 43, incoming: true },
+];
+
+const balanceData = {
+  labels: balancePoints.map((p) => p.label),
+  datasets: [
+    {
+      data: balancePoints.map((p) => p.value),
+      color: () => '#ffffff',
+    },
+  ],
+};
+
+const txData = {
+  labels: ['Sent', 'Received'],
+  datasets: [{ data: [50, 75] }],
+};
+
+const screenWidth = Dimensions.get('window').width - 32;
+
+function chartConfig(theme: string) {
+  return {
+    backgroundColor: greys(theme)[2300],
+    backgroundGradientFrom: greys(theme)[2300],
+    backgroundGradientTo: greys(theme)[2300],
+    decimalPlaces: 0,
+    color: () => '#ffffff',
+    labelColor: () => '#ffffff',
+    propsForDots: {
+      r: '4',
+    },
+  } as const;
+}
+
+export default function Chart() {
+  const { type } = useTypedRoute<'chart'>();
+  const theme = useSelector(memoizedGetTheme);
+  const styles = createStyles(theme);
+
+  const [activePoint, setActivePoint] = useState<{ x: number; value: number } | null>(null);
+  const [range, setRange] = useState('1w');
+
+  const opacity = useRef(new Animated.Value(0)).current;
+  useEffect(() => {
+    Animated.timing(opacity, {
+      toValue: 1,
+      duration: 300,
+      useNativeDriver: true,
+    }).start();
+  }, [opacity]);
+
+  const renderChart = () => {
+    if (type === 'balance') {
+      return (
+        <RNView>
+          <LineChart
+            data={balanceData}
+            width={screenWidth}
+            height={240}
+            withShadow={false}
+            chartConfig={chartConfig(theme)}
+            bezier
+            withInnerLines={false}
+            withDots={false}
+            renderDotContent={({ x, y, index }) => (
+              <RNView
+                key={index}
+                style={{
+                  position: 'absolute',
+                  left: x - 4,
+                  top: y - 4,
+                  width: 8,
+                  height: 8,
+                  borderRadius: 4,
+                  backgroundColor: balancePoints[index].incoming ? greens[400] : reds[400],
+                }}
+              />
+            )}
+            onDataPointClick={({ x, value }) => setActivePoint({ x, value })}
+            style={styles.chart}
+          />
+          {activePoint && (
+            <RNView pointerEvents="none" style={[styles.indicator, { left: activePoint.x }]}/>
+          )}
+        </RNView>
+      );
+    }
+    return (
+      <BarChart
+        data={txData}
+        width={screenWidth}
+        height={240}
+        chartConfig={chartConfig(theme)}
+        withInnerLines={false}
+        style={styles.chart}
+      />
+    );
+  };
+
+  const ranges = ['1d', '1w', '1m', '1y', 'max'];
+
+  return (
+    <Container>
+      <Animated.View style={[styles.container, { opacity }]}>
+        <View style={styles.headerRow}>
+          <Text style={styles.label}>Total balance</Text>
+          <Text style={styles.balance}>1234 sats</Text>
+        </View>
+        <Text style={styles.updated}>last update {new Date().toLocaleDateString()}</Text>
+        <RNView style={styles.chartWrapper}>{renderChart()}</RNView>
+        <RNView style={styles.rangeRow}>
+          {ranges.map((r) => (
+            <TouchableOpacity key={r} onPress={() => setRange(r)} style={[styles.rangeBtn, range === r && styles.rangeBtnActive]}>
+              <Text style={[styles.rangeText, range === r && styles.rangeTextActive]}>{r}</Text>
+            </TouchableOpacity>
+          ))}
+        </RNView>
+      </Animated.View>
+    </Container>
+  );
+}
+
+const createStyles = (theme: string) =>
+  StyleSheet.create({
+    container: {
+      paddingTop: 16,
+      paddingBottom: 24,
+    },
+    headerRow: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      marginBottom: 4,
+    },
+    label: {
+      fontFamily: 'OverpassRegular',
+      color: greys(theme)[600],
+      fontSize: 13,
+    },
+    balance: {
+      fontFamily: 'OverpassSemibold',
+      color: greys(theme)[0],
+      fontSize: 16,
+    },
+    updated: {
+      fontFamily: 'OverpassRegular',
+      color: greys(theme)[600],
+      fontSize: 12,
+      marginBottom: 12,
+    },
+    chart: {
+      borderRadius: 12,
+    },
+    chartWrapper: {
+      position: 'relative',
+    },
+    rangeRow: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      marginTop: 12,
+    },
+    rangeBtn: {
+      paddingHorizontal: 8,
+      paddingVertical: 4,
+      borderRadius: 8,
+    },
+    rangeBtnActive: {
+      backgroundColor: greys(theme)[2100],
+    },
+    rangeText: {
+      color: greys(theme)[600],
+      fontFamily: 'OverpassRegular',
+      fontSize: 12,
+    },
+    rangeTextActive: {
+      color: greys(theme)[0],
+    },
+    indicator: {
+      position: 'absolute',
+      top: 0,
+      bottom: 0,
+      width: 1,
+      backgroundColor: '#ffffff50',
+    },
+  });

--- a/app/charts.tsx
+++ b/app/charts.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { ScrollView, StyleSheet, Dimensions, View as RNView } from 'react-native';
+import { LineChart, BarChart } from 'react-native-chart-kit';
+import { useSelector } from 'react-redux';
+import { memoizedGetTheme } from 'helper/redux/settings';
+import { greys, greens, reds } from 'helper/colors';
+import { View, Text } from 'components/common/Themed';
+import { useTypedNavigation } from 'helper/navigation';
+import { TouchableOpacity } from 'components/common/TouchableOpacity';
+import Container from 'components/layout/Container';
+
+const balancePoints = [
+  { label: 'Jan', value: 20, incoming: true },
+  { label: 'Feb', value: 45, incoming: true },
+  { label: 'Mar', value: 28, incoming: false },
+  { label: 'Apr', value: 80, incoming: true },
+  { label: 'May', value: 99, incoming: false },
+  { label: 'Jun', value: 43, incoming: true },
+];
+
+const balanceData = {
+  labels: balancePoints.map((p) => p.label),
+  datasets: [
+    {
+      data: balancePoints.map((p) => p.value),
+      color: () => '#ffffff',
+    },
+  ],
+};
+
+const txData = {
+  labels: ['Sent', 'Received'],
+  datasets: [{ data: [50, 75] }],
+};
+
+const screenWidth = Dimensions.get('window').width;
+const chartWidth = screenWidth / 2 - 24;
+
+function chartConfig(theme: string) {
+  return {
+    backgroundColor: greys(theme)[2300],
+    backgroundGradientFrom: greys(theme)[2300],
+    backgroundGradientTo: greys(theme)[2300],
+    decimalPlaces: 0,
+    color: () => '#ffffff',
+    labelColor: () => '#ffffff',
+    propsForDots: { r: '4' },
+  } as const;
+}
+
+export default function Charts() {
+  const theme = useSelector(memoizedGetTheme);
+  const navigation = useTypedNavigation<'chart'>();
+  const styles = createStyles(theme);
+
+  const charts = [
+    {
+      key: 'balance',
+      title: 'Balance over time',
+      render: () => (
+        <LineChart
+          data={balanceData}
+          width={chartWidth}
+          height={160}
+          withShadow={false}
+          chartConfig={chartConfig(theme)}
+          withInnerLines={false}
+          withDots={false}
+          renderDotContent={({ x, y, index }) => (
+            <RNView
+              key={index}
+              style={{
+                position: 'absolute',
+                left: x - 3,
+                top: y - 3,
+                width: 6,
+                height: 6,
+                borderRadius: 3,
+                backgroundColor: balancePoints[index].incoming ? greens[400] : reds[400],
+              }}
+            />
+          )}
+          style={styles.chart}
+        />
+      ),
+    },
+    {
+      key: 'io',
+      title: 'Sent vs Received',
+      render: () => (
+        <BarChart
+          data={txData}
+          width={chartWidth}
+          height={160}
+          chartConfig={chartConfig(theme)}
+          withInnerLines={false}
+          style={styles.chart}
+        />
+      ),
+    },
+  ];
+
+  return (
+    <Container>
+      <ScrollView contentContainerStyle={styles.grid} showsVerticalScrollIndicator={false}>
+        {charts.map((c) => (
+          <TouchableOpacity key={c.key} onPress={() => navigation.navigate('chart', { type: c.key })}>
+            <View style={styles.item}>
+              <Text style={styles.title}>{c.title}</Text>
+              {c.render()}
+            </View>
+          </TouchableOpacity>
+        ))}
+      </ScrollView>
+    </Container>
+  );
+}
+
+const createStyles = (theme: string) =>
+  StyleSheet.create({
+    grid: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      justifyContent: 'space-between',
+      paddingTop: 16,
+    },
+    item: {
+      width: chartWidth,
+      marginBottom: 16,
+      borderRadius: 12,
+      backgroundColor: greys(theme)[1800],
+      padding: 8,
+    },
+    title: {
+      fontFamily: 'OverpassSemibold',
+      fontSize: 14,
+      marginBottom: 8,
+      color: greys(theme)[0],
+    },
+    chart: {
+      borderRadius: 12,
+    },
+  });

--- a/assets/icons/index.tsx
+++ b/assets/icons/index.tsx
@@ -80,6 +80,7 @@ export const icons = [
   'fluent:add-24-filled',
   'material-symbols:refresh-rounded',
   'ic:round-refresh',
+  'mdi:chart-line',
 ];
 
 export default ({

--- a/helper/navigation/screens.tsx
+++ b/helper/navigation/screens.tsx
@@ -402,4 +402,18 @@ export const MODAL_SCREENS_ALT: ModalConfig[] = [
       presentation: 'modal',
     },
   },
+  {
+    name: 'charts',
+    title: 'Charts',
+    options: {
+      headerLargeTitle: true,
+    },
+  },
+  {
+    name: 'chart',
+    title: 'Chart',
+    options: {
+      headerLargeTitle: true,
+    },
+  },
 ];

--- a/helper/navigation/types/NavigationParams.ts
+++ b/helper/navigation/types/NavigationParams.ts
@@ -64,6 +64,11 @@ export type NavigationParams = {
     type: 'vpn' | 'esim';
   };
 
+  charts: {};
+  chart: {
+    type: string;
+  };
+
   // Add other endpoints here
   // exampleEndpoint: { param1: string; param2: number };
 };

--- a/metro.config.js
+++ b/metro.config.js
@@ -74,6 +74,7 @@ const configWithMonicon = withMonicon(config, {
     'fluent:add-24-filled',
     'material-symbols:refresh-rounded',
     'ic:round-refresh',
+    'mdi:chart-line',
   ]
 });
 


### PR DESCRIPTION
## Summary
- color-code balance chart dots as green for incoming and red for outgoing
- show vertical indicator on selected point and add range selector
- style chart details with total balance header and last update text

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc --noEmit` *(fails: missing dependencies)*