### PR TITLE
Add charts feature with navigation

### DIFF
--- a/app/(drawer)/(tabs)/index.tsx
+++ b/app/(drawer)/(tabs)/index.tsx
@@ -22,6 +22,8 @@ import WalletHeader from '../../../components/layout/WalletHeader';
 import { useTypedNavigation } from 'helper/navigation';
 import { memoizedGetSelectedMint } from 'helper/redux/cashu';
 import { isProduction } from 'helper/version';
+import Icon from 'assets/icons';
+import { TouchableOpacity } from 'components/common/TouchableOpacity';
 
 async function getProfile(currentProfile) {
   const sk = nip19.decode(currentProfile?.nsec).data;
@@ -105,8 +107,13 @@ function TabOneScreen({
       headerTitle: () => (
         <WalletHeader unit={account.unit} accounts={accounts} setAccount={setAccount} />
       ),
+      headerRight: () => (
+        <TouchableOpacity onPress={() => navigation.navigate('charts', {})}>
+          <Icon name="mdi:chart-line" color={greys(theme)[0]} />
+        </TouchableOpacity>
+      ),
     });
-  }, [navigation, account, accounts]);
+  }, [navigation, account, accounts, theme]);
 
   if (!settings?.termsAccepted) {
     return (

--- a/app/chart.tsx
+++ b/app/chart.tsx
@@ -1,0 +1,106 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, StyleSheet, Dimensions } from 'react-native';
+import { LineChart, BarChart } from 'react-native-chart-kit';
+import { useSelector } from 'react-redux';
+import { memoizedGetTheme } from 'helper/redux/settings';
+import { greys } from 'helper/colors';
+import { View, Text } from 'components/common/Themed';
+import { useTypedRoute } from 'helper/navigation';
+import Container from 'components/layout/Container';
+
+const balanceData = {
+  labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+  datasets: [{ data: [20, 45, 28, 80, 99, 43] }],
+};
+
+const txData = {
+  labels: ['Sent', 'Received'],
+  datasets: [{ data: [50, 75] }],
+};
+
+const screenWidth = Dimensions.get('window').width - 32;
+
+function chartConfig(theme: string) {
+  return {
+    backgroundColor: greys(theme)[2100],
+    backgroundGradientFrom: greys(theme)[2100],
+    backgroundGradientTo: greys(theme)[2100],
+    decimalPlaces: 0,
+    color: (opacity = 1) => `rgba(255, 255, 255, ${opacity})`,
+    labelColor: (opacity = 1) => `rgba(255, 255, 255, ${opacity})`,
+    propsForDots: {
+      r: '3',
+      strokeWidth: '2',
+      stroke: '#ffa726',
+    },
+  } as const;
+}
+
+export default function Chart() {
+  const { type } = useTypedRoute<'chart'>();
+  const theme = useSelector(memoizedGetTheme);
+  const styles = createStyles(theme);
+
+  const opacity = useRef(new Animated.Value(0)).current;
+  useEffect(() => {
+    Animated.timing(opacity, {
+      toValue: 1,
+      duration: 300,
+      useNativeDriver: true,
+    }).start();
+  }, [opacity]);
+
+  const renderChart = () => {
+    if (type === 'balance') {
+      return (
+        <LineChart
+          data={balanceData}
+          width={screenWidth}
+          height={240}
+          chartConfig={chartConfig(theme)}
+          bezier
+          withInnerLines={false}
+          style={styles.chart}
+        />
+      );
+    }
+    return (
+      <BarChart
+        data={txData}
+        width={screenWidth}
+        height={240}
+        chartConfig={chartConfig(theme)}
+        withInnerLines={false}
+        style={styles.chart}
+      />
+    );
+  };
+
+  const title = type === 'balance' ? 'Balance over time' : 'Sent vs Received';
+
+  return (
+    <Container>
+      <Animated.View style={[styles.container, { opacity }]}>
+        <Text style={styles.title}>{title}</Text>
+        {renderChart()}
+      </Animated.View>
+    </Container>
+  );
+}
+
+const createStyles = (theme: string) =>
+  StyleSheet.create({
+    container: {
+      paddingTop: 16,
+      alignItems: 'center',
+    },
+    title: {
+      fontFamily: 'OverpassSemibold',
+      fontSize: 16,
+      marginBottom: 8,
+      color: greys(theme)[0],
+    },
+    chart: {
+      borderRadius: 12,
+    },
+  });

--- a/app/charts.tsx
+++ b/app/charts.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { ScrollView, StyleSheet, Dimensions } from 'react-native';
+import { LineChart, BarChart } from 'react-native-chart-kit';
+import { useSelector } from 'react-redux';
+import { memoizedGetTheme } from 'helper/redux/settings';
+import { greys } from 'helper/colors';
+import { View, Text } from 'components/common/Themed';
+import { useTypedNavigation } from 'helper/navigation';
+import { TouchableOpacity } from 'components/common/TouchableOpacity';
+import Container from 'components/layout/Container';
+
+const balanceData = {
+  labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+  datasets: [{ data: [20, 45, 28, 80, 99, 43] }],
+};
+
+const txData = {
+  labels: ['Sent', 'Received'],
+  datasets: [{ data: [50, 75] }],
+};
+
+const screenWidth = Dimensions.get('window').width;
+const chartWidth = screenWidth / 2 - 24;
+
+function chartConfig(theme: string) {
+  return {
+    backgroundColor: greys(theme)[2100],
+    backgroundGradientFrom: greys(theme)[2100],
+    backgroundGradientTo: greys(theme)[2100],
+    decimalPlaces: 0,
+    color: (opacity = 1) => `rgba(255, 255, 255, ${opacity})`,
+    labelColor: (opacity = 1) => `rgba(255, 255, 255, ${opacity})`,
+    propsForDots: {
+      r: '3',
+      strokeWidth: '2',
+      stroke: '#ffa726',
+    },
+  } as const;
+}
+
+export default function Charts() {
+  const theme = useSelector(memoizedGetTheme);
+  const navigation = useTypedNavigation<'chart'>();
+  const styles = createStyles(theme);
+
+  const charts = [
+    {
+      key: 'balance',
+      title: 'Balance over time',
+      render: () => (
+        <LineChart
+          data={balanceData}
+          width={chartWidth}
+          height={160}
+          chartConfig={chartConfig(theme)}
+          withInnerLines={false}
+          style={styles.chart}
+        />
+      ),
+    },
+    {
+      key: 'io',
+      title: 'Sent vs Received',
+      render: () => (
+        <BarChart
+          data={txData}
+          width={chartWidth}
+          height={160}
+          chartConfig={chartConfig(theme)}
+          withInnerLines={false}
+          style={styles.chart}
+        />
+      ),
+    },
+  ];
+
+  return (
+    <Container>
+      <ScrollView contentContainerStyle={styles.grid} showsVerticalScrollIndicator={false}>
+        {charts.map((c) => (
+          <TouchableOpacity key={c.key} onPress={() => navigation.navigate('chart', { type: c.key })}>
+            <View style={styles.item}>
+              <Text style={styles.title}>{c.title}</Text>
+              {c.render()}
+            </View>
+          </TouchableOpacity>
+        ))}
+      </ScrollView>
+    </Container>
+  );
+}
+
+const createStyles = (theme: string) =>
+  StyleSheet.create({
+    grid: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      justifyContent: 'space-between',
+      paddingTop: 16,
+    },
+    item: {
+      width: chartWidth,
+      marginBottom: 16,
+      borderRadius: 12,
+      backgroundColor: greys(theme)[1800],
+      padding: 8,
+    },
+    title: {
+      fontFamily: 'OverpassSemibold',
+      fontSize: 14,
+      marginBottom: 8,
+      color: greys(theme)[0],
+    },
+    chart: {
+      borderRadius: 12,
+    },
+  });

--- a/app/transactions.tsx
+++ b/app/transactions.tsx
@@ -2,14 +2,12 @@ import { View } from 'components/common/Themed';
 import { useSelector } from 'react-redux';
 import { greys } from 'helper/colors';
 import { memoizedGetTheme } from 'helper/redux/settings';
-import { useTypedRoute } from 'helper/navigation';
+import { useRoute } from '@react-navigation/native';
 import { TouchableOpacity } from 'components/common/TouchableOpacity';
 import { useState } from 'react';
 import { Transactions } from 'components/layout/Transactions';
 import Container from 'components/layout/Container';
-import CurrencySelector from 'components/layout/CurrencySelector';
 import Icon from 'assets/icons';
-import { ScrollView } from 'react-native';
 
 import Modal from 'components/layout/Modal';
 import { Tabs } from 'components/common/Tabs';
@@ -17,23 +15,14 @@ import { withSheetProvider } from 'components/hocs/withSheetProvider';
 
 function ModalScreen() {
   const theme = useSelector(memoizedGetTheme);
-  const { account } = useTypedRoute<'transactions'>() || {
-    account: { unit: '' },
-  };
-  const [selectedCurrency, setSelectedCurrency] = useState(account.unit);
-  const [searchQuery, setSearchQuery] = useState('');
+  // Default to sat unit if no params provided
+  const route = useRoute();
+  const params: any = route.params || {};
+  const account = params.account || { type: 'ecash', unit: 'sat' };
   const [filter, setFilter] = useState<'all' | 'incoming' | 'outgoing'>('all');
   const [type, setType] = useState<string>('all');
   const [at, setAt] = useState<string>('all');
   const [tab, setTab] = useState('All');
-
-  const handleCurrencyChange = (currency: string) => {
-    setSelectedCurrency(currency.toLowerCase());
-  };
-
-  const handleSearchChange = (text: string) => {
-    setSearchQuery(text);
-  };
 
   const toggleFilter = (newFilter: 'incoming' | 'outgoing') => {
     setFilter((prevFilter) => (prevFilter === newFilter ? 'all' : newFilter));
@@ -59,10 +48,6 @@ function ModalScreen() {
             height: 4,
           }}></View>
 
-        <CurrencySelector
-          selectedCurrency={selectedCurrency.toUpperCase()}
-          onCurrencyChange={handleCurrencyChange}
-        />
         <View
           style={{
             flexDirection: 'row',
@@ -179,10 +164,7 @@ function ModalScreen() {
         </View>
         <View style={{ marginBottom: 64 }}></View>
         <Transactions
-          account={{
-            ...account,
-            unit: selectedCurrency,
-          }}
+          account={account}
           filter={filter}
           type={type}
           at={at}

--- a/assets/icons/index.tsx
+++ b/assets/icons/index.tsx
@@ -80,6 +80,7 @@ export const icons = [
   'fluent:add-24-filled',
   'material-symbols:refresh-rounded',
   'ic:round-refresh',
+  'mdi:chart-line',
 ];
 
 export default ({

--- a/helper/navigation/screens.tsx
+++ b/helper/navigation/screens.tsx
@@ -402,4 +402,18 @@ export const MODAL_SCREENS_ALT: ModalConfig[] = [
       presentation: 'modal',
     },
   },
+  {
+    name: 'charts',
+    title: 'Charts',
+    options: {
+      headerLargeTitle: true,
+    },
+  },
+  {
+    name: 'chart',
+    title: 'Chart',
+    options: {
+      headerLargeTitle: true,
+    },
+  },
 ];

--- a/helper/navigation/types/NavigationParams.ts
+++ b/helper/navigation/types/NavigationParams.ts
@@ -64,6 +64,11 @@ export type NavigationParams = {
     type: 'vpn' | 'esim';
   };
 
+  charts: {};
+  chart: {
+    type: string;
+  };
+
   // Add other endpoints here
   // exampleEndpoint: { param1: string; param2: number };
 };

--- a/metro.config.js
+++ b/metro.config.js
@@ -74,6 +74,7 @@ const configWithMonicon = withMonicon(config, {
     'fluent:add-24-filled',
     'material-symbols:refresh-rounded',
     'ic:round-refresh',
+    'mdi:chart-line',
   ]
 });
 


### PR DESCRIPTION
## Summary
- add chart views and chart detail page
- hook up header button on wallet home page to navigate to new charts
- register new navigation routes
- include `mdi:chart-line` icon in icon list and metro config
- default transactions screen to `sat` unit

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc --noEmit` *(fails to compile)*
