### PR TITLE
Handle long press for redeemed tokens

### DIFF
--- a/app/MessagePage/index.tsx
+++ b/app/MessagePage/index.tsx
@@ -37,6 +37,7 @@ import { Button } from 'components/common/Button';
 import ndk from 'components/ndk';
 import { BITREFILL_NOSTR_PUBKEY } from '../bitrefill';
 import { ButtonHandler } from 'components/common/ButtonHandler';
+import { isValidEcashToken } from 'components/cashu';
 import { SheetManager } from 'react-native-actions-sheet';
 import { convertNpub } from 'app/(drawer)/(tabs)/payments';
 
@@ -233,7 +234,12 @@ export default function ModalScreen() {
     let cancelButtonIndex = 0;
     let destructiveButtonIndex = -1;
 
-    if (item.order || item?.request) {
+    const redeemedToken =
+      item?.content &&
+      isValidEcashToken(item.content) &&
+      transactions.some((t) => t.token === item.content);
+
+    if (item.order || item?.request || redeemedToken) {
       options = ['View Details', 'Cancel'];
       destructiveButtonIndex = 0;
       cancelButtonIndex = 1;
@@ -253,6 +259,14 @@ export default function ModalScreen() {
               navigation.navigate('vpn', { ...item });
             } else {
               navigation.navigate('esim', { ...p, ...item, ...o });
+            }
+          } else if (redeemedToken) {
+            const tx = transactions.find((t) => t.token === item.content);
+            if (tx) {
+              navigation.navigate('transaction', {
+                id: tx.token,
+                transactionType: tx.transactionType,
+              });
             }
           } else {
             navigation.navigate('transaction', {

--- a/app/currency.tsx
+++ b/app/currency.tsx
@@ -23,6 +23,8 @@ import { SheetManager, SheetProvider } from 'react-native-actions-sheet';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { greys } from 'helper/colors';
 import { maybeConvertNpub } from 'helper/cashu/pay';
+import { useSendEncryptedDirectMessage } from 'helper/navigation/hooks/useEncryptedDirectMessage';
+import { convertNpub } from 'app/(drawer)/(tabs)/payments';
 import { TouchableOpacity } from 'components/common/TouchableOpacity';
 import Image from 'components/common/Image';
 import Icon from 'assets/icons';
@@ -91,6 +93,8 @@ function ModalScreen() {
     });
   };
 
+  const { sendEncryptedDirectMessage } = useSendEncryptedDirectMessage();
+
   const handleEcashSend = async ({ message }) => {
     console.log('[handleEcashSend]', unit === 'sat' ? amount : amount * 100, unit, message, params);
     const transaction = await sendEcash({
@@ -106,6 +110,17 @@ function ModalScreen() {
           }
         : {}),
     });
+
+    if (params?.profile?.npub) {
+      try {
+        await sendEncryptedDirectMessage({
+          message: transaction.token,
+          recipient: convertNpub(params.profile.npub),
+        });
+      } catch (e) {
+        console.error('Failed to send ecash token over Nostr', e);
+      }
+    }
 
     navigation.replace(params.to, {
       ...params,


### PR DESCRIPTION
## Summary
- open transaction details when long-pressing a redeemed token message
- send locked ecash token to recipient via Nostr

## Testing
- `yarn test` *(fails: network unreachable)*
- `npx prettier --write app/currency.tsx` *(fails: cannot find prettier-plugin-tailwindcss)*