### PR TITLE
Handle long press for redeemed tokens

### DIFF
--- a/app/MessagePage/EcashTransactionComponent.tsx
+++ b/app/MessagePage/EcashTransactionComponent.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { formatCurrency } from 'helper/currency';
+import { convertTime } from 'helper/time';
+import { greys, shades } from 'helper/colors';
+import opacity from 'hex-color-opacity';
+
+interface Props {
+  transaction: any;
+  theme: string;
+  isReceived: boolean;
+}
+
+const EcashTransactionComponent = ({ transaction, theme, isReceived }: Props) => {
+  const styles = createStyles(theme, isReceived);
+
+  const gradientColors = isReceived
+    ? [greys(theme)[1000], greys(theme)[1200]]
+    : [shades[100], shades[300]];
+
+  const formattedAmount =
+    transaction.unit &&
+    formatCurrency(
+      {
+        currency: transaction.unit === 'sat' ? 'BTC' : transaction.unit.toUpperCase(),
+        value: transaction.amount,
+        denomination: transaction.unit === 'sat' ? 'sats' : transaction.unit,
+      },
+      {
+        locale: 'en-US',
+        precision: transaction.unit === 'sat' ? 0 : 2,
+        currencyDisplay: transaction.unit === 'sat' ? 'name' : 'symbol',
+        denomination: transaction.unit === 'sat' ? 'sats' : transaction.unit,
+      }
+    );
+
+  return (
+    <View style={[styles.wrapper, { alignSelf: isReceived ? 'flex-start' : 'flex-end' }]}>
+      <View
+        style={[
+          styles.arrow,
+          {
+            backgroundColor: isReceived ? greys(theme)[1200] : shades[300],
+            left: isReceived ? 16 : 'auto',
+            right: isReceived ? 'auto' : 16,
+          },
+        ]}
+      />
+      <LinearGradient colors={gradientColors} style={styles.container}>
+        <Text style={styles.mintText}>{transaction.mintUrl}</Text>
+        <View style={styles.footer}>
+          <View>
+            <Text style={styles.amountText}>{formattedAmount}</Text>
+            {transaction.memo && <Text style={styles.memoText}>{transaction.memo}</Text>}
+          </View>
+        </View>
+        <Text style={styles.timestamp}>
+          {transaction?.date ? convertTime(new Date(transaction.date)) : null}
+        </Text>
+      </LinearGradient>
+    </View>
+  );
+};
+
+const createStyles = (theme: string, isReceived: boolean) =>
+  StyleSheet.create({
+    wrapper: {
+      marginVertical: 8,
+      position: 'relative',
+      backgroundColor: 'transparent',
+      width: '100%',
+    },
+    container: {
+      padding: 16,
+      borderRadius: 16,
+      width: '100%',
+    },
+    arrow: {
+      position: 'absolute',
+      bottom: -4,
+      width: 8,
+      height: 8,
+      transform: [{ rotate: '45deg' }],
+    },
+    amountText: {
+      fontFamily: 'OverpassHeavy',
+      fontSize: 24,
+      color: greys(theme)[0],
+      marginBottom: 0,
+    },
+    footer: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+    },
+    memoText: {
+      fontFamily: 'OverpassRegular',
+      fontSize: 12,
+      color: greys(theme)[0],
+      backgroundColor: opacity(greys(theme)[0], 0.1),
+      padding: 16,
+      borderRadius: 8,
+    },
+    mintText: {
+      fontFamily: 'OverpassBold',
+      fontSize: 12,
+      color: greys(theme)[0],
+      opacity: 0.75,
+    },
+    timestamp: {
+      color: greys(theme)[0],
+      opacity: 0.75,
+      fontFamily: 'OverpassBold',
+      fontSize: 12,
+      textAlign: 'right',
+      marginTop: 8,
+    },
+  });
+
+export default EcashTransactionComponent;

--- a/app/MessagePage/LightningTransactionComponent.tsx
+++ b/app/MessagePage/LightningTransactionComponent.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { formatCurrency } from 'helper/currency';
+import { convertTime } from 'helper/time';
+import { greys, shades } from 'helper/colors';
+
+const LightningTransactionComponent = ({ transaction, theme, isReceived }) => {
+  const styles = createStyles(theme);
+
+  const gradientColors = isReceived
+    ? [greys(theme)[1000], greys(theme)[1200]]
+    : [shades[100], shades[300]];
+
+  const arrowBackgroundColor = isReceived ? greys(theme)[1200] : shades[300];
+
+  const formattedAmount =
+    transaction.unit &&
+    formatCurrency(
+      {
+        currency: transaction.unit === 'sat' ? 'BTC' : transaction.unit.toUpperCase(),
+        value: transaction.amount,
+        denomination: transaction.unit === 'sat' ? 'sats' : transaction.unit,
+      },
+      {
+        locale: 'en-US',
+        precision: transaction.unit === 'sat' ? 0 : 2,
+        currencyDisplay: transaction.unit === 'sat' ? 'name' : 'symbol',
+        denomination: transaction.unit === 'sat' ? 'sats' : transaction.unit,
+      }
+    );
+
+  return (
+    <View
+      style={[styles.transactionWrapper, { alignSelf: isReceived ? 'flex-start' : 'flex-end' }]}>
+      <View
+        style={[
+          styles.arrow,
+          {
+            backgroundColor: arrowBackgroundColor,
+            left: isReceived ? 16 : 'auto',
+            right: isReceived ? 'auto' : 16,
+          },
+        ]}
+      />
+      <LinearGradient colors={gradientColors} style={[styles.transactionContainer]}>
+        <View style={styles.transactionTypeContainer}>
+          <Text style={styles.transactionTypeText}>{isReceived ? 'You received' : 'You sent'}</Text>
+        </View>
+        <Text style={styles.transactionText}>{formattedAmount}</Text>
+        <Text style={styles.timestamp}>
+          {transaction?.date ? convertTime(new Date(transaction.date)) : null}
+        </Text>
+      </LinearGradient>
+    </View>
+  );
+};
+
+const createStyles = (theme) =>
+  StyleSheet.create({
+    transactionWrapper: {
+      marginVertical: 8,
+      position: 'relative',
+      backgroundColor: 'transparent',
+    },
+    transactionContainer: {
+      padding: 16,
+      borderRadius: 16,
+      maxWidth: '75%',
+    },
+    arrow: {
+      position: 'absolute',
+      bottom: -4,
+      width: 8,
+      height: 8,
+      transform: [{ rotate: '45deg' }],
+    },
+    transactionTypeContainer: {
+      backgroundColor: 'rgba(0,0,0,0.25)',
+      padding: 4,
+      marginBottom: 4,
+      borderRadius: 16,
+    },
+    transactionTypeText: {
+      fontFamily: 'OverpassBold',
+      fontSize: 14,
+      textAlign: 'center',
+      color: greys(theme)[0],
+    },
+    transactionText: {
+      fontFamily: 'OverpassHeavy',
+      fontSize: 16,
+      marginBottom: 8,
+      color: greys(theme)[0],
+    },
+    timestamp: {
+      color: greys(theme)[0],
+      opacity: 0.75,
+      fontFamily: 'OverpassBold',
+      fontSize: 12,
+      textAlign: 'right',
+    },
+  });
+
+export default LightningTransactionComponent;

--- a/app/MessagePage/TransactionComponent.tsx
+++ b/app/MessagePage/TransactionComponent.tsx
@@ -1,105 +1,31 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
-import { LinearGradient } from 'expo-linear-gradient';
-import { formatCurrency } from 'helper/currency';
-import { convertTime } from 'helper/time';
-import { greys, shades } from 'helper/colors';
+import EcashTransactionComponent from './EcashTransactionComponent';
+import LightningTransactionComponent from './LightningTransactionComponent';
 
-const TransactionComponent = ({ transaction, theme, isReceived }) => {
-  const styles = createStyles(theme);
+interface Props {
+  transaction: any;
+  theme: string;
+  isReceived: boolean;
+}
 
-  const gradientColors = isReceived
-    ? [greys(theme)[1000], greys(theme)[1200]]
-    : [shades[100], shades[300]];
-
-  const arrowBackgroundColor = isReceived ? greys(theme)[1200] : shades[300];
-
-  const formattedAmount =
-    transaction.unit &&
-    formatCurrency(
-      {
-        currency: transaction.unit === 'sat' ? 'BTC' : transaction.unit.toUpperCase(),
-        value: transaction.amount,
-        denomination: transaction.unit === 'sat' ? 'sats' : transaction.unit,
-      },
-      {
-        locale: 'en-US',
-        precision: transaction.unit === 'sat' ? 0 : 2,
-        currencyDisplay: transaction.unit === 'sat' ? 'name' : 'symbol',
-        denomination: transaction.unit === 'sat' ? 'sats' : transaction.unit,
-      }
+const TransactionComponent = ({ transaction, theme, isReceived }: Props) => {
+  if (transaction?.type === 'ecash') {
+    return (
+      <EcashTransactionComponent
+        transaction={transaction}
+        theme={theme}
+        isReceived={isReceived}
+      />
     );
+  }
 
   return (
-    <View
-      style={[styles.transactionWrapper, { alignSelf: isReceived ? 'flex-start' : 'flex-end' }]}>
-      <View
-        style={[
-          styles.arrow,
-          {
-            backgroundColor: arrowBackgroundColor,
-            left: isReceived ? 16 : 'auto',
-            right: isReceived ? 'auto' : 16,
-          },
-        ]}
-      />
-      <LinearGradient colors={gradientColors} style={[styles.transactionContainer]}>
-        <View style={styles.transactionTypeContainer}>
-          <Text style={styles.transactionTypeText}>{isReceived ? 'You received' : 'You sent'}</Text>
-        </View>
-        <Text style={styles.transactionText}>{formattedAmount}</Text>
-        <Text style={styles.timestamp}>
-          {transaction?.date ? convertTime(new Date(transaction.date)) : null}
-        </Text>
-      </LinearGradient>
-    </View>
+    <LightningTransactionComponent
+      transaction={transaction}
+      theme={theme}
+      isReceived={isReceived}
+    />
   );
 };
-
-const createStyles = (theme) =>
-  StyleSheet.create({
-    transactionWrapper: {
-      marginVertical: 8,
-      position: 'relative',
-      backgroundColor: 'transparent',
-    },
-    transactionContainer: {
-      padding: 16,
-      borderRadius: 16,
-      maxWidth: '75%',
-    },
-    arrow: {
-      position: 'absolute',
-      bottom: -4,
-      width: 8,
-      height: 8,
-      transform: [{ rotate: '45deg' }],
-    },
-    transactionTypeContainer: {
-      backgroundColor: 'rgba(0,0,0,0.25)',
-      padding: 4,
-      marginBottom: 4,
-      borderRadius: 16,
-    },
-    transactionTypeText: {
-      fontFamily: 'OverpassBold',
-      fontSize: 14,
-      textAlign: 'center',
-      color: greys(theme)[0],
-    },
-    transactionText: {
-      fontFamily: 'OverpassHeavy',
-      fontSize: 16,
-      marginBottom: 8,
-      color: greys(theme)[0],
-    },
-    timestamp: {
-      color: greys(theme)[0],
-      opacity: 0.75,
-      fontFamily: 'OverpassBold',
-      fontSize: 12,
-      textAlign: 'right',
-    },
-  });
 
 export default TransactionComponent;

--- a/app/MessagePage/index.tsx
+++ b/app/MessagePage/index.tsx
@@ -37,6 +37,7 @@ import { Button } from 'components/common/Button';
 import ndk from 'components/ndk';
 import { BITREFILL_NOSTR_PUBKEY } from '../bitrefill';
 import { ButtonHandler } from 'components/common/ButtonHandler';
+import { isValidEcashToken } from 'components/cashu';
 import { SheetManager } from 'react-native-actions-sheet';
 import { convertNpub } from 'app/(drawer)/(tabs)/payments';
 
@@ -233,7 +234,12 @@ export default function ModalScreen() {
     let cancelButtonIndex = 0;
     let destructiveButtonIndex = -1;
 
-    if (item.order || item?.request) {
+    const redeemedToken =
+      item?.content &&
+      isValidEcashToken(item.content) &&
+      transactions.some((t) => t.token === item.content);
+
+    if (item.order || item?.request || redeemedToken) {
       options = ['View Details', 'Cancel'];
       destructiveButtonIndex = 0;
       cancelButtonIndex = 1;
@@ -253,6 +259,14 @@ export default function ModalScreen() {
               navigation.navigate('vpn', { ...item });
             } else {
               navigation.navigate('esim', { ...p, ...item, ...o });
+            }
+          } else if (redeemedToken) {
+            const tx = transactions.find((t) => t.token === item.content);
+            if (tx) {
+              navigation.navigate('transaction', {
+                id: tx.token,
+                transactionType: tx.transactionType,
+              });
             }
           } else {
             navigation.navigate('transaction', {


### PR DESCRIPTION
## Summary
- open transaction details when long-pressing a redeemed token message
- support ecash and lightning transaction types with dedicated components

## Testing
- `yarn test` *(fails: network unreachable)*
- `npx prettier --write app/MessagePage/TransactionComponent.tsx app/MessagePage/EcashTransactionComponent.tsx app/MessagePage/LightningTransactionComponent.tsx` *(fails: cannot find prettier-plugin-tailwindcss)*