### PR TITLE
Handle long press for redeemed tokens

### DIFF
--- a/app/MessagePage/EcashComponent.tsx
+++ b/app/MessagePage/EcashComponent.tsx
@@ -4,31 +4,51 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { getDecodedToken } from '@cashu/cashu-ts';
 import { greys, shades } from 'helper/colors';
 import { Button } from 'components/common/Button';
-import { receiveEcash } from 'components/cashu';
+import { cancelEcashTransaction, receiveEcash } from 'components/cashu';
 import { showMessage } from 'helper/popup/popups';
 import { useCashu } from 'helper/redux/cashu';
+import { useTypedNavigation } from 'helper/navigation';
+import { convertTime } from 'helper/time';
 import opacity from 'hex-color-opacity';
 
 interface Props {
   token: string;
   theme: string;
   isReceived: boolean;
+  date?: string;
 }
 
-const CashuTokenComponent = ({ token, theme, isReceived }: Props) => {
+const EcashComponent = ({ token, theme, isReceived, date }: Props) => {
   const styles = createStyles(theme, isReceived);
   const { transactions } = useCashu();
+  const navigation = useTypedNavigation();
 
   const decoded = getDecodedToken(token);
   const amount = decoded.proofs.reduce((a, p) => a + p.amount, 0);
   const unit = decoded.unit;
 
-  const isClaimed = transactions.some((t) => t.token === token);
+  const sendTx = transactions.find(
+    (t) => t.token === token && t.transactionType === 'send'
+  );
+  const receiveTx = transactions.find(
+    (t) => t.token === token && t.transactionType === 'receive'
+  );
+
+  const isClaimed = isReceived ? Boolean(receiveTx) : Boolean(sendTx?.paid);
 
   const handleRedeem = async () => {
     try {
       await receiveEcash({ token, unit });
       showMessage('funds_received', { amount, unit }, { emoji: '🎉' });
+    } catch (error) {
+      showMessage(error.message, {}, { emoji: '🚨' });
+    }
+  };
+
+  const handleCancel = async () => {
+    if (!sendTx) return;
+    try {
+      await cancelEcashTransaction(sendTx, navigation);
     } catch (error) {
       showMessage(error.message, {}, { emoji: '🚨' });
     }
@@ -62,11 +82,18 @@ const CashuTokenComponent = ({ token, theme, isReceived }: Props) => {
           </View>
         </View>
         <Button
-          text={isClaimed ? 'Redeemed' : 'Redeem'}
+          text={
+            isClaimed
+              ? 'Redeemed'
+              : isReceived
+              ? 'Redeem'
+              : 'Cancel'
+          }
           variant="primary"
           disabled={isClaimed}
-          onPress={handleRedeem}
+          onPress={isReceived ? handleRedeem : handleCancel}
         />
+        {date && <Text style={styles.timestamp}>{convertTime(new Date(date))}</Text>}
       </LinearGradient>
     </View>
   );
@@ -129,6 +156,14 @@ const createStyles = (theme: string, isReceived: boolean) =>
       color: greys(theme)[0],
       opacity: 0.75,
     },
+    timestamp: {
+      color: greys(theme)[0],
+      opacity: 0.75,
+      fontFamily: 'OverpassBold',
+      fontSize: 12,
+      textAlign: 'right',
+      marginTop: 8,
+    },
   });
 
-export default CashuTokenComponent;
+export default EcashComponent;

--- a/app/MessagePage/LightningTransactionComponent.tsx
+++ b/app/MessagePage/LightningTransactionComponent.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { formatCurrency } from 'helper/currency';
+import { convertTime } from 'helper/time';
+import { greys, shades } from 'helper/colors';
+
+const LightningTransactionComponent = ({ transaction, theme, isReceived }) => {
+  const styles = createStyles(theme);
+
+  const gradientColors = isReceived
+    ? [greys(theme)[1000], greys(theme)[1200]]
+    : [shades[100], shades[300]];
+
+  const arrowBackgroundColor = isReceived ? greys(theme)[1200] : shades[300];
+
+  const formattedAmount =
+    transaction.unit &&
+    formatCurrency(
+      {
+        currency: transaction.unit === 'sat' ? 'BTC' : transaction.unit.toUpperCase(),
+        value: transaction.amount,
+        denomination: transaction.unit === 'sat' ? 'sats' : transaction.unit,
+      },
+      {
+        locale: 'en-US',
+        precision: transaction.unit === 'sat' ? 0 : 2,
+        currencyDisplay: transaction.unit === 'sat' ? 'name' : 'symbol',
+        denomination: transaction.unit === 'sat' ? 'sats' : transaction.unit,
+      }
+    );
+
+  return (
+    <View
+      style={[styles.transactionWrapper, { alignSelf: isReceived ? 'flex-start' : 'flex-end' }]}>
+      <View
+        style={[
+          styles.arrow,
+          {
+            backgroundColor: arrowBackgroundColor,
+            left: isReceived ? 16 : 'auto',
+            right: isReceived ? 'auto' : 16,
+          },
+        ]}
+      />
+      <LinearGradient colors={gradientColors} style={[styles.transactionContainer]}>
+        <View style={styles.transactionTypeContainer}>
+          <Text style={styles.transactionTypeText}>{isReceived ? 'You received' : 'You sent'}</Text>
+        </View>
+        <Text style={styles.transactionText}>{formattedAmount}</Text>
+        <Text style={styles.timestamp}>
+          {transaction?.date ? convertTime(new Date(transaction.date)) : null}
+        </Text>
+      </LinearGradient>
+    </View>
+  );
+};
+
+const createStyles = (theme) =>
+  StyleSheet.create({
+    transactionWrapper: {
+      marginVertical: 8,
+      position: 'relative',
+      backgroundColor: 'transparent',
+    },
+    transactionContainer: {
+      padding: 16,
+      borderRadius: 16,
+      maxWidth: '75%',
+    },
+    arrow: {
+      position: 'absolute',
+      bottom: -4,
+      width: 8,
+      height: 8,
+      transform: [{ rotate: '45deg' }],
+    },
+    transactionTypeContainer: {
+      backgroundColor: 'rgba(0,0,0,0.25)',
+      padding: 4,
+      marginBottom: 4,
+      borderRadius: 16,
+    },
+    transactionTypeText: {
+      fontFamily: 'OverpassBold',
+      fontSize: 14,
+      textAlign: 'center',
+      color: greys(theme)[0],
+    },
+    transactionText: {
+      fontFamily: 'OverpassHeavy',
+      fontSize: 16,
+      marginBottom: 8,
+      color: greys(theme)[0],
+    },
+    timestamp: {
+      color: greys(theme)[0],
+      opacity: 0.75,
+      fontFamily: 'OverpassBold',
+      fontSize: 12,
+      textAlign: 'right',
+    },
+  });
+
+export default LightningTransactionComponent;

--- a/app/MessagePage/TimeLine.tsx
+++ b/app/MessagePage/TimeLine.tsx
@@ -5,7 +5,7 @@ import TransactionComponent from './TransactionComponent';
 import { useNostr } from 'helper/redux/nostr';
 import EventComponent from './EventsComponent';
 import VpnComponent from './VpnComponent';
-import CashuTokenComponent from './CashuTokenComponent';
+import EcashComponent from './EcashComponent';
 import { isValidEcashToken } from 'components/cashu';
 
 const TimelineItem = ({ item, theme }) => {
@@ -32,7 +32,7 @@ const TimelineItem = ({ item, theme }) => {
   if (isMessage) {
     if (isTokenMessage) {
       return (
-        <CashuTokenComponent token={item.content} theme={theme} isReceived={isMessageReceived} />
+        <EcashComponent token={item.content} theme={theme} isReceived={isMessageReceived} />
       );
     }
     return <MessageComponent message={item} theme={theme} isReceived={isMessageReceived} />;

--- a/app/MessagePage/TransactionComponent.tsx
+++ b/app/MessagePage/TransactionComponent.tsx
@@ -1,105 +1,26 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
-import { LinearGradient } from 'expo-linear-gradient';
-import { formatCurrency } from 'helper/currency';
-import { convertTime } from 'helper/time';
-import { greys, shades } from 'helper/colors';
+import EcashComponent from './EcashComponent';
+import LightningTransactionComponent from './LightningTransactionComponent';
 
 const TransactionComponent = ({ transaction, theme, isReceived }) => {
-  const styles = createStyles(theme);
-
-  const gradientColors = isReceived
-    ? [greys(theme)[1000], greys(theme)[1200]]
-    : [shades[100], shades[300]];
-
-  const arrowBackgroundColor = isReceived ? greys(theme)[1200] : shades[300];
-
-  const formattedAmount =
-    transaction.unit &&
-    formatCurrency(
-      {
-        currency: transaction.unit === 'sat' ? 'BTC' : transaction.unit.toUpperCase(),
-        value: transaction.amount,
-        denomination: transaction.unit === 'sat' ? 'sats' : transaction.unit,
-      },
-      {
-        locale: 'en-US',
-        precision: transaction.unit === 'sat' ? 0 : 2,
-        currencyDisplay: transaction.unit === 'sat' ? 'name' : 'symbol',
-        denomination: transaction.unit === 'sat' ? 'sats' : transaction.unit,
-      }
+  if (transaction.type === 'ecash') {
+    return (
+      <EcashComponent
+        token={transaction.token}
+        theme={theme}
+        isReceived={isReceived}
+        date={transaction.date}
+      />
     );
+  }
 
   return (
-    <View
-      style={[styles.transactionWrapper, { alignSelf: isReceived ? 'flex-start' : 'flex-end' }]}>
-      <View
-        style={[
-          styles.arrow,
-          {
-            backgroundColor: arrowBackgroundColor,
-            left: isReceived ? 16 : 'auto',
-            right: isReceived ? 'auto' : 16,
-          },
-        ]}
-      />
-      <LinearGradient colors={gradientColors} style={[styles.transactionContainer]}>
-        <View style={styles.transactionTypeContainer}>
-          <Text style={styles.transactionTypeText}>{isReceived ? 'You received' : 'You sent'}</Text>
-        </View>
-        <Text style={styles.transactionText}>{formattedAmount}</Text>
-        <Text style={styles.timestamp}>
-          {transaction?.date ? convertTime(new Date(transaction.date)) : null}
-        </Text>
-      </LinearGradient>
-    </View>
+    <LightningTransactionComponent
+      transaction={transaction}
+      theme={theme}
+      isReceived={isReceived}
+    />
   );
 };
-
-const createStyles = (theme) =>
-  StyleSheet.create({
-    transactionWrapper: {
-      marginVertical: 8,
-      position: 'relative',
-      backgroundColor: 'transparent',
-    },
-    transactionContainer: {
-      padding: 16,
-      borderRadius: 16,
-      maxWidth: '75%',
-    },
-    arrow: {
-      position: 'absolute',
-      bottom: -4,
-      width: 8,
-      height: 8,
-      transform: [{ rotate: '45deg' }],
-    },
-    transactionTypeContainer: {
-      backgroundColor: 'rgba(0,0,0,0.25)',
-      padding: 4,
-      marginBottom: 4,
-      borderRadius: 16,
-    },
-    transactionTypeText: {
-      fontFamily: 'OverpassBold',
-      fontSize: 14,
-      textAlign: 'center',
-      color: greys(theme)[0],
-    },
-    transactionText: {
-      fontFamily: 'OverpassHeavy',
-      fontSize: 16,
-      marginBottom: 8,
-      color: greys(theme)[0],
-    },
-    timestamp: {
-      color: greys(theme)[0],
-      opacity: 0.75,
-      fontFamily: 'OverpassBold',
-      fontSize: 12,
-      textAlign: 'right',
-    },
-  });
 
 export default TransactionComponent;

--- a/app/MessagePage/index.tsx
+++ b/app/MessagePage/index.tsx
@@ -37,6 +37,7 @@ import { Button } from 'components/common/Button';
 import ndk from 'components/ndk';
 import { BITREFILL_NOSTR_PUBKEY } from '../bitrefill';
 import { ButtonHandler } from 'components/common/ButtonHandler';
+import { isValidEcashToken } from 'components/cashu';
 import { SheetManager } from 'react-native-actions-sheet';
 import { convertNpub } from 'app/(drawer)/(tabs)/payments';
 
@@ -233,7 +234,12 @@ export default function ModalScreen() {
     let cancelButtonIndex = 0;
     let destructiveButtonIndex = -1;
 
-    if (item.order || item?.request) {
+    const redeemedToken =
+      item?.content &&
+      isValidEcashToken(item.content) &&
+      transactions.some((t) => t.token === item.content);
+
+    if (item.order || item?.request || redeemedToken) {
       options = ['View Details', 'Cancel'];
       destructiveButtonIndex = 0;
       cancelButtonIndex = 1;
@@ -253,6 +259,14 @@ export default function ModalScreen() {
               navigation.navigate('vpn', { ...item });
             } else {
               navigation.navigate('esim', { ...p, ...item, ...o });
+            }
+          } else if (redeemedToken) {
+            const tx = transactions.find((t) => t.token === item.content);
+            if (tx) {
+              navigation.navigate('transaction', {
+                id: tx.token,
+                transactionType: tx.transactionType,
+              });
             }
           } else {
             navigation.navigate('transaction', {

--- a/app/currency.tsx
+++ b/app/currency.tsx
@@ -6,7 +6,15 @@ import Modal from 'components/layout/Modal';
 import { NumberInput } from '../components/common/NumberInput';
 import { getInvoiceFromLnurl } from 'helper/third-party/lnurl';
 import { memoizedGetBalance, memoizedGetSelectedMint } from 'helper/redux/cashu';
-import { getMeltQuote, isValidLNURL, receiveLightning, sendEcash } from 'components/cashu';
+import {
+  getMeltQuote,
+  isValidLNURL,
+  receiveLightning,
+  sendEcash,
+} from 'components/cashu';
+import { useNostr } from 'helper/redux/nostr';
+import { finalizeEvent, nip04, nip19, SimplePool } from 'nostr-tools';
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
 import { useRoute } from '@react-navigation/native';
 import CustomKeyboard from 'components/layout/CustomKeyboard';
 import { memoizedGetTheme } from 'helper/redux/settings';
@@ -36,11 +44,44 @@ interface ScanningData {
   type?: string;
 }
 
+async function sendDM(priv: string, pub: string, toPubkey: string, message: string, relays: string[]) {
+  const encryptMessage = async (privKey: string, recipientPubKey: string, msg: string) => {
+    return nip04.encrypt(privKey, recipientPubKey, msg);
+  };
+
+  const signEventAsync = async (privKey: string, event: any) => {
+    return finalizeEvent(event, hexToBytes(privKey));
+  };
+
+  const content = await encryptMessage(priv, toPubkey, message);
+  const event = {
+    kind: 4,
+    tags: [['p', toPubkey]],
+    content,
+    pubkey: pub,
+    created_at: Math.floor(Date.now() / 1000),
+    id: '',
+    sig: '',
+  };
+
+  const signedEvent = await signEventAsync(priv, event);
+  return new Promise((resolve, reject) => {
+    const pool = new SimplePool();
+    const pubs = pool.publish(relays, signedEvent);
+
+    Promise.any(pubs)
+      .then(() => resolve(signedEvent))
+      .catch((error) => reject(`Failed to publish: ${error}`))
+      .finally(() => pool.close(relays));
+  });
+}
+
 function ModalScreen() {
   const theme = useSelector(memoizedGetTheme);
   const styles = createStyles(theme);
   const dispatch = useDispatch();
   const profileId = useSelector((state) => state.nostr?.currentProfile?.id);
+  const { currentProfile } = useNostr();
   const { params } = useRoute();
   const navigation = useTypedNavigation();
 
@@ -106,6 +147,32 @@ function ModalScreen() {
           }
         : {}),
     });
+
+    if (params?.profile?.npub) {
+      try {
+        const { data: privKeyBytes } = nip19.decode(currentProfile.nsec);
+        const privKeyHex = bytesToHex(privKeyBytes as Uint8Array);
+        const { data: recipientHex } = nip19.decode(params.profile.npub);
+        const recipient = bytesToHex(recipientHex as Uint8Array);
+        const relays = [
+          'wss://relay1.nostrchat.io',
+          'wss://relay2.nostrchat.io',
+          'wss://relay.damus.io',
+          'wss://relay.snort.social',
+          'wss://nos.lol',
+          'wss://purplepag.es',
+          'wss://relay.primal.net',
+          'wss://nostr.thank.eu',
+          'wss://relay.vanderwarker.family',
+          'wss://nostr-relay.bitcoin.ninja',
+          'wss://lnbits.btc-payserver.eu/nostrrelay/1',
+          'wss://nostr.girino.org',
+        ];
+        await sendDM(privKeyHex, currentProfile.pubkey, recipient, transaction.token, relays);
+      } catch (e) {
+        console.error('Failed to send token DM', e);
+      }
+    }
 
     navigation.replace(params.to, {
       ...params,


### PR DESCRIPTION
## Summary
- open transaction details when long-pressing a redeemed token message
- use unified component to render ecash messages and transactions
- add lightning-specific transaction component
- send ecash token via Nostr after locking

## Testing
- `yarn test` *(fails: network unreachable)*
- `npx prettier --write app/MessagePage/EcashComponent.tsx app/MessagePage/TimeLine.tsx app/MessagePage/TransactionComponent.tsx app/MessagePage/LightningTransactionComponent.tsx app/currency.tsx` *(fails: cannot find prettier-plugin-tailwindcss)*