### PR TITLE
Handle long press for redeemed tokens

### DIFF
--- a/app/MessagePage/index.tsx
+++ b/app/MessagePage/index.tsx
@@ -37,6 +37,7 @@ import { Button } from 'components/common/Button';
 import ndk from 'components/ndk';
 import { BITREFILL_NOSTR_PUBKEY } from '../bitrefill';
 import { ButtonHandler } from 'components/common/ButtonHandler';
+import { isValidEcashToken } from 'components/cashu';
 import { SheetManager } from 'react-native-actions-sheet';
 import { convertNpub } from 'app/(drawer)/(tabs)/payments';
 
@@ -233,7 +234,12 @@ export default function ModalScreen() {
     let cancelButtonIndex = 0;
     let destructiveButtonIndex = -1;
 
-    if (item.order || item?.request) {
+    const redeemedToken =
+      item?.content &&
+      isValidEcashToken(item.content) &&
+      transactions.some((t) => t.token === item.content);
+
+    if (item.order || item?.request || redeemedToken) {
       options = ['View Details', 'Cancel'];
       destructiveButtonIndex = 0;
       cancelButtonIndex = 1;
@@ -253,6 +259,14 @@ export default function ModalScreen() {
               navigation.navigate('vpn', { ...item });
             } else {
               navigation.navigate('esim', { ...p, ...item, ...o });
+            }
+          } else if (redeemedToken) {
+            const tx = transactions.find((t) => t.token === item.content);
+            if (tx) {
+              navigation.navigate('transaction', {
+                id: tx.token,
+                transactionType: tx.transactionType,
+              });
             }
           } else {
             navigation.navigate('transaction', {

--- a/helper/cashu/pay.ts
+++ b/helper/cashu/pay.ts
@@ -214,6 +214,7 @@ export async function sendLightning({
     })
   );
 
+
   return transaction;
 }
 
@@ -270,6 +271,7 @@ export async function receiveLightning({
       transaction,
     })
   );
+
 
   return transaction;
 }
@@ -398,6 +400,14 @@ export async function sendEcash({
       transaction,
     })
   );
+  if (to) {
+    try {
+      const { sendNutzap } = await import("../nostr/nutzap");
+      await sendNutzap({ token: encodedToken, recipient: to, content: memo || "" });
+    } catch (e) {
+      console.error("Failed to send nutzap", e);
+    }
+  }
 
   return transaction;
 }

--- a/helper/navigation/hooks/useEncryptedDirectMessage.ts
+++ b/helper/navigation/hooks/useEncryptedDirectMessage.ts
@@ -1,5 +1,5 @@
 import { sendEcash } from 'helper/cashu/pay';
-import { decodePaymentRequest, getDecodedToken } from '@cashu/cashu-ts';
+import { decodePaymentRequest } from '@cashu/cashu-ts';
 import { bytesToHex } from '@noble/hashes/utils';
 import { NDKEvent, NDKKind, NDKPrivateKeySigner, ProfilePointer } from '@nostr-dev-kit/ndk';
 import { useNDK } from '@nostr-dev-kit/ndk-mobile';
@@ -39,21 +39,10 @@ export const useSendEncryptedDirectMessage = () => {
 
     const pubkey: string = (result.data as ProfilePointer).pubkey;
 
-    const token = await sendEcash({
+    await sendEcash({
       unit: decodedRequest.unit as string,
       amount: decodedRequest.amount as number,
       to: pubkey,
-    });
-
-    const decodedToken = getDecodedToken(token);
-    sendEncryptedDirectMessage({
-      message: JSON.stringify({
-        mint: decodedToken.mint,
-        unit: decodedToken.unit,
-        proofs: decodedToken.proofs,
-        id: decodedRequest.id,
-      }),
-      recipient: pubkey,
     });
   };
 

--- a/helper/nostr/nutzap.ts
+++ b/helper/nostr/nutzap.ts
@@ -1,0 +1,68 @@
+import { finalizeEvent, SimplePool, nip19 } from 'nostr-tools';
+import { getDecodedToken } from '@cashu/cashu-ts';
+import { store } from 'helper/redux/store';
+
+const relays = [
+  'wss://purplepag.es',
+  'wss://relay.primal.net',
+  'wss://nostr.thank.eu',
+  'wss://relay.vanderwarker.family',
+  'wss://nostr-relay.bitcoin.ninja',
+  'wss://lnbits.btc-payserver.eu/nostrrelay/1',
+  'wss://relay.damus.io',
+  'wss://nostr.girino.org',
+  'wss://relay.8333.space/',
+  'wss://relay.snort.social',
+  'wss://nostr.mutinywallet.com',
+  'wss://nos.lol',
+];
+
+function convertToHex(pubkey: string): string {
+  if (!pubkey) return '';
+  if (pubkey.startsWith('npub')) {
+    const { data } = nip19.decode(pubkey);
+    return typeof data === 'string' ? data : '';
+  }
+  if (pubkey.startsWith('02') && pubkey.length === 66) {
+    return pubkey.slice(2);
+  }
+  return pubkey;
+}
+
+export async function sendNutzap({
+  token,
+  recipient,
+  content = '',
+}: {
+  token: string;
+  recipient: string;
+  content?: string;
+}): Promise<void> {
+  try {
+    const { nostr } = store.getState() as any;
+    const currentProfile = nostr?.currentProfile;
+    if (!currentProfile?.pubkey || !currentProfile?.nsec) return;
+    const senderPub = convertToHex(currentProfile.pubkey);
+    const { data: privKeyBytes } = nip19.decode(currentProfile.nsec);
+    if (!(privKeyBytes instanceof Uint8Array)) return;
+
+    const decoded = getDecodedToken(token);
+    const event = {
+      kind: 9321,
+      tags: [
+        ...decoded.proofs.map((p: any) => ['proof', JSON.stringify(p)]),
+        ['u', decoded.mint],
+        ['p', convertToHex(recipient)],
+      ],
+      pubkey: senderPub,
+      content,
+      created_at: Math.floor(Date.now() / 1000),
+    } as any;
+
+    const pool = new SimplePool();
+    await pool.publish(relays, finalizeEvent(event, privKeyBytes));
+    pool.close(relays);
+  } catch (e) {
+    console.error('sendNutzap failed', e);
+  }
+}


### PR DESCRIPTION
## Summary
- open transaction details when long-pressing a redeemed token message
- send locked ecash tokens as a nutzap event instead of an encrypted DM
- update payment request flow for nutzaps

## Testing
- `yarn test` *(fails: network unreachable)*
- `npx prettier --write helper/nostr/nutzap.ts helper/cashu/pay.ts helper/navigation/hooks/useEncryptedDirectMessage.ts` *(fails: cannot find prettier-plugin-tailwindcss)*