### PR TITLE
Add button to open pending lightning websocket connections

### DIFF
--- a/app/settings/websocketConnections.tsx
+++ b/app/settings/websocketConnections.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { View, ScrollView } from 'react-native';
 import Container from 'components/layout/Container';
 import { Text } from 'components/common/Themed';
+import { Button } from 'components/common/Button';
 import { memoizedGetTheme } from 'helper/redux/settings';
 import { greys } from 'helper/colors';
 import { useTransactions } from 'components/providers/TransactionsProvider';
@@ -10,7 +11,7 @@ import { Transaction } from 'components/layout/Transaction';
 
 export default function ModalScreen() {
   const theme = useSelector(memoizedGetTheme);
-  const { activeConnections = [], transactions = [] } = useTransactions();
+  const { activeConnections = [], transactions = [], listenToTransaction } = useTransactions();
 
   const connectionsWithTx = activeConnections.map((conn: any) => {
     const reqs = String(conn.id).split('_');
@@ -18,12 +19,27 @@ export default function ModalScreen() {
     return { id: conn.id, txs };
   });
 
+  const openPendingLightning = () => {
+    const pendingLightning = transactions.filter(
+      (tx: any) => tx.type === 'lightning' && tx.transactionType === 'receive' && !tx.paid
+    );
+    if (pendingLightning.length) {
+      listenToTransaction(pendingLightning);
+    }
+  };
+
   return (
     <Container>
       <ScrollView>
         <Text style={{ color: greys(theme)[0], fontFamily: 'OverpassBold', marginBottom: 12 }}>
           Open Connections: {activeConnections.length}
         </Text>
+        <Button
+          variant="primary"
+          text="Open Pending Lightning"
+          onPress={openPendingLightning}
+          style={{ marginBottom: 16 }}
+        />
         {connectionsWithTx.map(({ id, txs }) => (
           <View key={id} style={{ marginBottom: 24 }}>
             <Text


### PR DESCRIPTION
## Summary
- add UI to websocket connections page to allow connecting to all pending lightning transactions at once

## Testing
- `yarn pretty` *(fails: Error when performing the request to registry)*
- `yarn test` *(fails: Error when performing the request to registry)*

------
https://chatgpt.com/codex/tasks/task_b_683f965540c483258305380bd0f4c2f1