### PR TITLE
Fix proofs restore on melt failure

### DIFF
--- a/helper/cashu/pay.ts
+++ b/helper/cashu/pay.ts
@@ -181,10 +181,24 @@ export async function sendLightning({
     })(store.getState());
 
     console.log('[sendLightning] counter2', { counter2, meltQuote, proofsToSend });
-    const { change } = await wallet.meltProofs(meltQuote, proofsToSend, {
-      counter: counter2, // it's going up forever, laura
-      keysetId,
-    });
+    let change;
+    try {
+      ({ change } = await wallet.meltProofs(meltQuote, proofsToSend, {
+        counter: counter2, // it's going up forever, laura
+        keysetId,
+      }));
+    } catch (meltError) {
+      if (meltError.message !== 'keyset id inactive.') {
+        store.dispatch(
+          appendProofsV2({
+            profileId,
+            mintUrl,
+            proofs: proofsToSend,
+          })
+        );
+      }
+      throw meltError;
+    }
 
     store.dispatch(
       increaseCounterV2({


### PR DESCRIPTION
## Summary
- add error handling around `meltProofs` to restore proofs when it fails

## Testing
- `yarn pretty` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_6843bf62647c8325a2528be385a0033d