### PR TITLE
Add expo-updates reload after resetting app

### DIFF
--- a/components/layout/sheets/delete/routes/routeA.tsx
+++ b/components/layout/sheets/delete/routes/routeA.tsx
@@ -2,29 +2,20 @@ import { Button } from 'components/common/Button';
 import { Card } from 'components/common/Card';
 import { View, Text } from 'components/common/Themed';
 import { greys } from 'helper/colors';
-import { useTypedNavigation } from 'helper/navigation';
 import { memoizedGetTheme } from 'helper/redux/settings';
 import { resetApp } from 'helper/redux/store/reducer';
+import * as Updates from 'expo-updates';
 import React from 'react';
 import { RouteScreenProps } from 'react-native-actions-sheet';
 import { useDispatch, useSelector } from 'react-redux';
 
 const RouteA = ({ router }: RouteScreenProps<'example-sheet-with-router', 'route-a'>) => {
   const theme = useSelector(memoizedGetTheme);
-  const navigation = useTypedNavigation();
   const dispatch = useDispatch();
   const handleDeleteProfile = async () => {
     try {
       await dispatch(resetApp());
-      router?.close();
-      navigation.navigate(
-        'index',
-        {},
-        {
-          current: 'drawer',
-          closeCurrentAndParents: true,
-        }
-      );
+      await Updates.reloadAsync();
     } catch (error) {}
   };
 

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "expo-standard-web-crypto": "^2.0.1",
     "expo-status-bar": "~2.2.3",
     "expo-system-ui": "~5.0.7",
+    "expo-updates": "~0.23.0",
     "expo-task-manager": "~13.1.5",
     "expo-testflight": "^0.3.0",
     "expo-video": "~2.1.8",


### PR DESCRIPTION
## Summary
- ensure the app restarts after deleting account by importing `expo-updates` and reloading the bundle
- add `expo-updates` dependency

## Testing
- `yarn test` *(fails: Error when performing the request to https://registry.yarnpkg.com/...)*
- `yarn pretty` *(fails: Error when performing the request to https://registry.yarnpkg.com/...)*

------
https://chatgpt.com/codex/tasks/task_b_6843b655ae7083259098f05ce6e6b317