### PR TITLE
Fix keyboard avoidance on create profile buttons

### DIFF
--- a/app/onboard/new.tsx
+++ b/app/onboard/new.tsx
@@ -295,15 +295,15 @@ const RecoveryScreen = () => {
   };
 
   return (
-    <>
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        style={{ flex: 1 }}>
-        <Container>
-          <ScrollView
-            contentContainerStyle={styles.scrollContainer}
-            keyboardShouldPersistTaps="handled">
-            <View style={styles.container}>
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      style={{ flex: 1 }}>
+      <Container contentContainerStyle={{ flex: 1 }}>
+        <ScrollView
+          style={{ flex: 1 }}
+          contentContainerStyle={styles.scrollContainer}
+          keyboardShouldPersistTaps="handled">
+          <View style={styles.container}>
               <Text weight="bold" size={24} style={styles.headerTitle}>
                 Create Sovran Profile
               </Text>
@@ -325,19 +325,17 @@ const RecoveryScreen = () => {
                 styles={styles}
                 theme={theme}
               />
-            </View>
-          </ScrollView>
-        </Container>
-      </KeyboardAvoidingView>
-
-      <ButtonBar
-        handleCreateProfile={handleCreateProfile}
-        handleExistingAccount={handleExistingAccount}
-        isSubmitting={isSubmitting}
-        styles={styles}
-        theme={theme}
-      />
-    </>
+          </View>
+        </ScrollView>
+        <ButtonBar
+          handleCreateProfile={handleCreateProfile}
+          handleExistingAccount={handleExistingAccount}
+          isSubmitting={isSubmitting}
+          styles={styles}
+          theme={theme}
+        />
+      </Container>
+    </KeyboardAvoidingView>
   );
 };
 


### PR DESCRIPTION
## Summary
- ensure the "Create Sovran Account" and "I already have a Sovran account" buttons move when the keyboard is visible

## Testing
- `yarn test` *(fails: Request was cancelled)*
- `yarn pretty` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_68441c6b86948325970a633f27ed1ed6