### PR TITLE
Add reusable TransactionIcon

### DIFF
--- a/components/common/BalanceUpdate.tsx
+++ b/components/common/BalanceUpdate.tsx
@@ -1,17 +1,12 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { Text, View } from 'components/common/Themed';
-import Icon from 'assets/icons';
 import { useSelector } from 'react-redux';
-import { useNostr } from 'helper/redux/nostr';
 import { greens, greys, shades } from 'helper/colors';
 import opacity from 'hex-color-opacity';
-import { useEsims } from 'helper/redux/esim';
-
-import CachedImage from 'components/common/Image';
 import { memoizedGetTheme } from 'helper/redux/settings';
 import { AmountFormatter } from 'components/common/AmountFormatter';
-import { find, get, some } from 'lodash';
 import { formatCurrency } from 'helper/currency';
+import TransactionIcon, { TransactionData } from './TransactionIcon';
 
 interface BalanceUpdateProps {
   transactionType: 'send' | 'receive' | string;
@@ -35,27 +30,6 @@ export function BalanceUpdate({
   cancelled,
 }: BalanceUpdateProps): JSX.Element {
   const theme = useSelector(memoizedGetTheme);
-  const { search, profiles } = useNostr();
-  const { esims } = useEsims();
-
-  const profilePicture = useMemo(() => {
-    const getPicture = (arr?: any[]) => {
-      const item = find(arr, { pubkey });
-      return (
-        get(item, 'profile.picture') ||
-        get(item, 'picture') ||
-        get(item, 'profile.image') ||
-        get(item, 'image')
-      );
-    };
-
-    return getPicture(search) || getPicture(profiles);
-  }, [search, profiles, pubkey]);
-
-  const isEsimRequest = useMemo(
-    () => some(esims, (e) => e?.request && e.request === request),
-    [esims, request]
-  );
 
   const isSend = transactionType === 'send';
   const isReceive = transactionType === 'receive';
@@ -89,76 +63,14 @@ export function BalanceUpdate({
       );
     return null;
   };
-
-  const ArrowIcon = () => (
-    <View
-      className="absolute -bottom-2 -right-2 z-10 rounded-full"
-      style={{
-        backgroundColor: greys(theme)[1800],
-        borderRadius: 100,
-        height: 16,
-        width: 16,
-        padding: 3,
-        borderColor: greys(theme)[1300],
-        borderWidth: 0.2,
-      }}>
-      {isReceive ? (
-        <Icon name="fluent:arrow-download-16-filled" color={greys(theme)[100]} size={10} />
-      ) : transaction?.isCancel ? (
-        <Icon name="mdi:cancel" color={greys(theme)[100]} size={10} />
-      ) : (
-        <Icon name="fluent:arrow-upload-16-filled" color={greys(theme)[100]} size={10} />
-      )}
-    </View>
-  );
-
-  const renderRightIcon = () => {
-    if (profilePicture) {
-      return (
-        <View className="relative h-7 w-7 bg-transparent">
-          <ArrowIcon />
-          <CachedImage
-            style={{
-              width: 28,
-              height: 28,
-              borderRadius: 1000,
-              borderColor: greys(theme)[1300],
-              borderWidth: 0.2,
-            }}
-            source={{ uri: profilePicture }}
-          />
-        </View>
-      );
-    }
-
-    if (isReceive) {
-      return (
-        <View className="relative h-7 w-7 bg-transparent">
-          <Icon name="fluent:arrow-download-16-filled" color={greys(theme)[100]} />
-        </View>
-      );
-    }
-
-    if (isEsimRequest) {
-      return (
-        <View className="relative h-7 w-7 bg-transparent">
-          <ArrowIcon />
-          <Icon name="fluent:sim-24-filled" color={greys(theme)[100]} />
-        </View>
-      );
-    }
-
-    console.log(transaction, 198273);
-
-    return (
-      <View className="relative h-7 w-7 bg-transparent">
-        {cancelled ? (
-          <Icon name="mdi:cancel" color={greys(theme)[100]} />
-        ) : (
-          <Icon name="fluent:arrow-upload-16-filled" color={greys(theme)[100]} />
-        )}
-      </View>
-    );
+  const txData: TransactionData = {
+    transactionType,
+    amount,
+    unit,
+    request,
+    isCancel: cancelled || transaction?.isCancel,
+    ...(pubkey ? { nostr: { pubkey } } : {}),
+    ...((transaction as any)?.fromNIP05 ? { fromNIP05: (transaction as any).fromNIP05 } : {}),
   };
 
   return (
@@ -211,7 +123,7 @@ export function BalanceUpdate({
         </Text>
       </View>
       <View className="bg-transparent p-4" style={{ transform: [{ scale: 1.25 }] }}>
-        {renderRightIcon()}
+        <TransactionIcon transaction={txData} />
       </View>
     </View>
   );

--- a/components/common/TransactionIcon.tsx
+++ b/components/common/TransactionIcon.tsx
@@ -1,0 +1,150 @@
+import React, { useMemo } from 'react';
+import { View } from 'components/common/Themed';
+import Icon from 'assets/icons';
+import CachedImage from 'components/common/Image';
+import { useSelector } from 'react-redux';
+import { memoizedGetTheme } from 'helper/redux/settings';
+import { greys } from 'helper/colors';
+import { useNostr } from 'helper/redux/nostr';
+import { useEsims } from 'helper/redux/esim';
+import { find, get, some } from 'lodash';
+
+export interface TransactionData {
+  id?: string;
+  txid?: string;
+  request?: string;
+  token?: string;
+  unit: string;
+  amount: number;
+  date?: string;
+  transactionType: 'send' | 'receive' | string;
+  type?: string;
+  isBuy?: string;
+  isSell?: boolean;
+  paid?: boolean;
+  isCancel?: boolean;
+  unifiedRequest?: string;
+  paymentRequest?: string;
+  from?: string;
+  to?: string;
+  fromNIP05?: string;
+  status?: { block_time: number; [key: string]: any };
+  nostr?: { pubkey: string; [key: string]: any };
+}
+
+interface TransactionIconProps {
+  transaction: TransactionData;
+}
+
+export default function TransactionIcon({
+  transaction,
+}: TransactionIconProps): JSX.Element {
+  const theme = useSelector(memoizedGetTheme);
+  const { search, profiles } = useNostr();
+  const { esims } = useEsims();
+
+  const isSend = transaction.transactionType === 'send';
+  const isReceive = transaction.transactionType === 'receive';
+
+  const profilePicture = useMemo(() => {
+    const getPicture = (arr?: any[]) => {
+      const item = find(arr, {
+        pubkey: transaction?.nostr?.pubkey || transaction?.fromNIP05?.split('@')[0],
+      });
+      return (
+        get(item, 'profile.picture') ||
+        get(item, 'picture') ||
+        get(item, 'profile.image') ||
+        get(item, 'image')
+      );
+    };
+
+    return getPicture(search) || getPicture(profiles);
+  }, [search, profiles, transaction?.nostr?.pubkey, transaction?.fromNIP05]);
+
+  const isEsimRequest = useMemo(
+    () => some(esims, (e) => e?.request && e.request === transaction.request),
+    [esims, transaction.request]
+  );
+
+  const StatusIndicator = () => (
+    <View
+      className="absolute -bottom-2 -right-2 z-10 rounded-full"
+      style={{
+        backgroundColor: greys(theme)[1800],
+        borderRadius: 100,
+        height: 16,
+        width: 16,
+        padding: 3,
+        borderColor: greys(theme)[1300],
+        borderWidth: 0.2,
+      }}>
+      {transaction.isCancel ? (
+        <Icon name="mdi:cancel" color={greys(theme)[100]} size={10} />
+      ) : (
+        <Icon
+          name={isReceive ? 'fluent:arrow-download-16-filled' : 'fluent:arrow-upload-16-filled'}
+          color={greys(theme)[100]}
+          size={10}
+        />
+      )}
+    </View>
+  );
+
+  if (profilePicture) {
+    return (
+      <View className="relative h-7 w-7 bg-transparent">
+        <StatusIndicator />
+        <CachedImage
+          style={{
+            width: 28,
+            height: 28,
+            borderRadius: 1000,
+            borderColor: greys(theme)[1000],
+            borderWidth: 0.5,
+          }}
+          source={{ uri: profilePicture }}
+        />
+      </View>
+    );
+  }
+
+  if (isEsimRequest) {
+    return (
+      <View className="relative h-7 w-7 bg-transparent">
+        <StatusIndicator />
+        <Icon name="fluent:sim-24-filled" color={greys(theme)[100]} />
+      </View>
+    );
+  }
+
+  if (transaction.fromNIP05 && isReceive) {
+    return (
+      <View className="relative h-7 w-7 bg-transparent">
+        <Icon name="mdi:at" color={greys(theme)[100]} />
+      </View>
+    );
+  }
+
+  if (isReceive) {
+    return (
+      <View className="relative h-7 w-7 bg-transparent">
+        <Icon name="fluent:arrow-download-16-filled" color={greys(theme)[100]} />
+      </View>
+    );
+  }
+
+  if (transaction.isCancel) {
+    return (
+      <View className="relative h-7 w-7 bg-transparent">
+        <Icon name="mdi:cancel" color={greys(theme)[100]} />
+      </View>
+    );
+  }
+
+  return (
+    <View className="relative h-7 w-7 bg-transparent">
+      <Icon name="fluent:arrow-upload-16-filled" color={greys(theme)[100]} />
+    </View>
+  );
+}

--- a/components/layout/Transaction.tsx
+++ b/components/layout/Transaction.tsx
@@ -4,13 +4,11 @@ import { formatCurrency, formatCurrencyWrapper } from 'helper/currency';
 import Icon, { LightningUnit, BtcUnit } from 'assets/icons';
 import { convertTime } from 'helper/time';
 import { greens, greys, reds, shades } from 'helper/colors';
-import { useNostr } from 'helper/redux/nostr';
-import { useEsims } from 'helper/redux/esim';
 import { useSelector } from 'react-redux';
 import opacity from 'hex-color-opacity';
 import { TouchableOpacity } from 'components/common/TouchableOpacity';
 import { memoizedGetTheme, useSettings } from 'helper/redux/settings';
-import CachedImage from 'components/common/Image';
+import TransactionIcon, { TransactionData } from 'components/common/TransactionIcon';
 import { truncateMiddle } from 'helper/strings';
 import { useTransactions } from 'components/providers/TransactionsProvider';
 import { useTypedNavigation } from 'helper/navigation';
@@ -27,27 +25,6 @@ interface NostrData {
   [key: string]: any;
 }
 
-interface TransactionData {
-  id?: string;
-  txid?: string;
-  request?: string;
-  token?: string;
-  unit: string;
-  amount: number;
-  date?: string;
-  transactionType: 'send' | 'receive' | string;
-  type?: string;
-  isBuy?: string;
-  isSell?: boolean;
-  paid?: boolean;
-  isCancel?: boolean;
-  unifiedRequest?: string;
-  paymentRequest?: string;
-  from?: string;
-  to?: string;
-  status?: TransactionStatus;
-  nostr?: NostrData;
-}
 
 interface AccountData {
   accountIndex: number;
@@ -94,8 +71,7 @@ export function npubToPubkey(npub: string): string {
 export function Transaction({ tx, transactions, account }: TransactionProps): JSX.Element {
   const theme = useSelector(memoizedGetTheme);
   const navigation = useTypedNavigation();
-  const { profiles, search } = useNostr();
-  const { esims } = useEsims();
+
   const { settings } = useSettings();
   const { activeConnections } = useTransactions();
 
@@ -117,24 +93,6 @@ export function Transaction({ tx, transactions, account }: TransactionProps): JS
 
   const showLoading = isListening;
 
-  // Get profile picture from nostr data
-  const profilePicture =
-    search?.find(
-      (s: ProfileData) =>
-        s?.pubkey === npubToPubkey(tx?.nostr?.pubkey || tx?.fromNIP05?.split('@')[0])
-    )?.profile?.picture ||
-    profiles?.find(
-      (p: ProfileData) =>
-        p?.pubkey === npubToPubkey(tx?.nostr?.pubkey || tx?.fromNIP05?.split('@')[0])
-    )?.picture ||
-    search?.find(
-      (s: ProfileData) =>
-        s?.pubkey === npubToPubkey(tx?.nostr?.pubkey || tx?.fromNIP05?.split('@')[0])
-    )?.profile?.image ||
-    profiles?.find(
-      (p: ProfileData) =>
-        p?.pubkey === npubToPubkey(tx?.nostr?.pubkey || tx?.fromNIP05?.split('@')[0])
-    )?.image;
 
   /**
    * Handle navigation when transaction is pressed
@@ -218,115 +176,6 @@ export function Transaction({ tx, transactions, account }: TransactionProps): JS
     );
   };
 
-  /**
-   * Component to display transaction icon with status indicator
-   */
-  const IconContainer = ({ children }: { children: React.ReactNode }): JSX.Element => (
-    <View className="relative h-7 w-7 bg-transparent">{children}</View>
-  );
-
-  /**
-   * Status indicator for transaction icons
-   */
-  const StatusIndicator = ({
-    isCancel,
-    fromNIP05,
-  }: {
-    isCancel?: boolean;
-    fromNIP05?: boolean;
-  }): JSX.Element => (
-    <View
-      style={{
-        borderColor: greys(theme)[1000],
-        borderWidth: 0.2,
-        backgroundColor: greys(theme)[1800],
-      }}
-      className="absolute bottom-[-4] right-[-4] z-30 rounded-full p-0.5">
-      {isCancel ? (
-        <Icon name="mdi:cancel" color={greys(theme)[100]} size={10} />
-      ) : (
-        <Icon
-          name={isReceive ? 'fluent:arrow-download-16-filled' : 'fluent:arrow-upload-16-filled'}
-          color={greys(theme)[100]}
-          size={10}
-        />
-      )}
-    </View>
-  );
-
-  /**
-   * Profile image component for transaction
-   */
-  const ProfileImage = (): JSX.Element => (
-    <CachedImage
-      style={{
-        width: 28,
-        height: 28,
-        borderRadius: 1000,
-        borderColor: greys(theme)[1000],
-        borderWidth: 0.5,
-      }}
-      source={{ uri: profilePicture }}
-    />
-  );
-
-  /**
-   * Render transaction icon with appropriate indicators
-   */
-  const renderExchangeIcon = (): JSX.Element => {
-    // For receive transactions
-    if (isReceive) {
-      if (profilePicture) {
-        return (
-          <IconContainer>
-            <StatusIndicator />
-            <ProfileImage />
-          </IconContainer>
-        );
-      } else {
-        return (
-          <IconContainer>
-            <Icon name="fluent:arrow-download-16-filled" color={greys(theme)[100]} />
-          </IconContainer>
-        );
-      }
-    }
-    // For send transactions
-    else {
-      if (profilePicture) {
-        return (
-          <IconContainer>
-            <StatusIndicator isCancel={tx.isCancel} />
-            <ProfileImage />
-          </IconContainer>
-        );
-      } else if (
-        esims
-          .map((e: { request: string }) => e.request)
-          .filter(Boolean)
-          .includes(tx.request)
-      ) {
-        return (
-          <IconContainer>
-            <StatusIndicator isCancel={tx.isCancel} />
-            <Icon name="fluent:sim-24-filled" color={greys(theme)[100]} />
-          </IconContainer>
-        );
-      } else if (tx.isCancel) {
-        return (
-          <IconContainer>
-            <Icon name="mdi:cancel" color={greys(theme)[100]} />
-          </IconContainer>
-        );
-      } else {
-        return (
-          <IconContainer>
-            <Icon name="fluent:arrow-upload-16-filled" color={greys(theme)[100]} />
-          </IconContainer>
-        );
-      }
-    }
-  };
 
   /**
    * Render the amount display with appropriate formatting
@@ -452,7 +301,7 @@ export function Transaction({ tx, transactions, account }: TransactionProps): JS
     <View key={tx.txid} className="bg-transparent">
       <TouchableOpacity className="bg-transparent" onPress={handlePress}>
         <View className="flex flex-row items-center justify-between p-5 pl-4 pr-4">
-          {renderExchangeIcon()}
+          <TransactionIcon transaction={tx} />
 
           <View className="ml-3 flex-grow flex-col bg-transparent">
             <View className="flex flex-row items-end justify-between bg-transparent">


### PR DESCRIPTION
## Summary
- create `TransactionIcon` for send/receive icons
- use it in `Transaction` view
- refactor `BalanceUpdate` to use the shared component

## Testing
- `yarn test` *(fails: Error when performing the request to https://registry.yarnpkg.com/...)*

------
https://chatgpt.com/codex/tasks/task_b_68453e5d1734832589d1e8247752f2f8