### PR TITLE
Improve insufficient balance text

### DIFF
--- a/components/common/AmountFormatter.tsx
+++ b/components/common/AmountFormatter.tsx
@@ -26,6 +26,7 @@ export function AmountFormatter({
   size = 37,
   weight = 'heavy',
   color,
+  style,
 }: AmountFormatterProps): React.ReactElement {
   const theme = useSelector(memoizedGetTheme);
   const { settings } = useSettings();
@@ -34,7 +35,7 @@ export function AmountFormatter({
 
   if (unit !== 'sat') {
     return (
-      <View className="flex-row items-center" style={{ backgroundColor: 'transparent' }}>
+      <View className="flex-row items-center" style={{ backgroundColor: 'transparent', ...style }}>
         <Text
           size={size}
           weight={weight}
@@ -50,9 +51,11 @@ export function AmountFormatter({
   }
 
   return (
-    <View className="flex-row items-center" style={{ backgroundColor: 'transparent' }}>
+    <View className="flex-row items-center" style={{ backgroundColor: 'transparent', ...style }}>
       {displayBtc === 0 && (
-        <>
+        <View
+          className="flex-row items-center"
+          style={{ backgroundColor: 'transparent', ...style }}>
           <View
             style={{ marginLeft: weight === 'heavy' ? -6 : -4, backgroundColor: 'transparent' }}>
             <BtcIcon weight={weight} height={size} width={size} color={currentColor} />
@@ -68,11 +71,13 @@ export function AmountFormatter({
             }}>
             {formatCurrencyWrapper(amount, unit, displayBtc)}
           </Text>
-        </>
+        </View>
       )}
 
       {displayBtc === 1 && (
-        <>
+        <View
+          className="flex-row items-center"
+          style={{ backgroundColor: 'transparent', ...style }}>
           <StyledText
             size={size}
             weight={weight}
@@ -86,24 +91,30 @@ export function AmountFormatter({
           <View style={{ marginBottom: 4, backgroundColor: 'transparent' }}>
             <LightningUnit height={size} width={size} color={currentColor} />
           </View>
-        </>
+        </View>
       )}
 
       {displayBtc === 2 && (
-        <Text
-          size={size}
-          weight={weight}
-          style={{
-            color: currentColor,
-            margin: 0,
-            zIndex: 2,
-          }}>
-          {formatCurrencyWrapper(amount, unit, displayBtc)}
-        </Text>
+        <View
+          className="flex-row items-center"
+          style={{ backgroundColor: 'transparent', ...style }}>
+          <Text
+            size={size}
+            weight={weight}
+            style={{
+              color: currentColor,
+              margin: 0,
+              zIndex: 2,
+            }}>
+            {formatCurrencyWrapper(amount, unit, displayBtc)}
+          </Text>
+        </View>
       )}
 
       {displayBtc === 3 && (
-        <>
+        <View
+          className="flex-row items-center"
+          style={{ backgroundColor: 'transparent', ...style }}>
           <View
             style={{ marginLeft: weight === 'heavy' ? -6 : -4, backgroundColor: 'transparent' }}>
             <BtcIcon weight={weight} height={size} width={size} color={currentColor} />
@@ -119,7 +130,7 @@ export function AmountFormatter({
             }}>
             {formatCurrencyWrapper(amount, unit, displayBtc)}
           </Text>
-        </>
+        </View>
       )}
     </View>
   );

--- a/components/layout/sheets/popup/routes/routeA.tsx
+++ b/components/layout/sheets/popup/routes/routeA.tsx
@@ -16,7 +16,7 @@ const RouteA = ({
     variant?: string;
     emoji?: string;
     message?: string;
-    submessage?: string;
+    submessage?: React.ReactNode;
     buttons?: any;
   };
 }) => {
@@ -57,7 +57,12 @@ const RouteA = ({
       <View style={styles.iconContainer}>
         <Text style={styles.icon}>{payload?.emoji || '🎉'}</Text>
         <Text style={styles.text}>{payload?.message || 'Error'}</Text>
-        {payload?.submessage && <Text style={styles.subText}>{payload?.submessage}</Text>}
+        {payload?.submessage &&
+          (typeof payload.submessage === 'string' ? (
+            <Text style={styles.subText}>{payload.submessage}</Text>
+          ) : (
+            payload.submessage
+          ))}
       </View>
       {payload?.buttons?.map((button) => {
         return (

--- a/helper/currency.ts
+++ b/helper/currency.ts
@@ -191,3 +191,11 @@ export const formatCurrencyWrapper = (amount: number, unit: string, display = 1)
     }
   );
 };
+
+/**
+ * Format an amount using the user's display preferences
+ */
+export const formatAmount = (amount: number, unit: string): string => {
+  const display_btc = store.getState().settings.settings.display_btc ?? 1;
+  return formatCurrencyWrapper(amount, unit, display_btc);
+};

--- a/helper/popup/popups.ts
+++ b/helper/popup/popups.ts
@@ -1,6 +1,8 @@
 import { SheetManager } from 'react-native-actions-sheet';
 import Constants from 'expo-constants';
 import { router } from 'expo-router';
+import React from 'react';
+import { formatAmount } from 'helper/currency';
 
 const MESSAGE_TYPES = {
   ERROR: 'error',
@@ -16,9 +18,11 @@ const MESSAGE_EMOJIS = {
   [MESSAGE_TYPES.SUCCESS]: '🎉',
 };
 
+type MessageText = string | React.ReactNode | ((params: any) => React.ReactNode);
+
 type MessageConfig = {
   title: string;
-  text: string | ((params: any) => string);
+  text: MessageText;
   type: string;
   buttons?: any; // Make button optional
 };
@@ -95,8 +99,12 @@ const MESSAGE_CONFIGS: Record<string, MessageConfig> = {
   // Balance & Transactions
   insufficient_balance: {
     title: 'Insufficient Balance',
-    text: ({ amount, unit, fee }: { amount: number; unit: string; fee: number }) =>
-      `Unable to send ${amount} ${unit.toUpperCase()} with fee of ${fee} ${unit.toUpperCase()}, you need to receive more funds or change mint.`,
+    text: ({ amount, unit, fee }: { amount: number; unit: string; fee: number }) => (
+      <>
+        Not enough funds to send {formatAmount(amount, unit)} with a fee of{' '}
+        {formatAmount(fee, unit)}. Add funds or switch mint.
+      </>
+    ),
     type: MESSAGE_TYPES.ERROR,
   },
   funds_received: {

--- a/helper/popup/popups.tsx
+++ b/helper/popup/popups.tsx
@@ -3,6 +3,8 @@ import Constants from 'expo-constants';
 import { router } from 'expo-router';
 import React from 'react';
 import { formatAmount } from 'helper/currency';
+import { Text } from 'components/common/Themed';
+import { AmountFormatter } from 'components/common/AmountFormatter';
 
 const MESSAGE_TYPES = {
   ERROR: 'error',
@@ -100,10 +102,32 @@ const MESSAGE_CONFIGS: Record<string, MessageConfig> = {
   insufficient_balance: {
     title: 'Insufficient Balance',
     text: ({ amount, unit, fee }: { amount: number; unit: string; fee: number }) => (
-      <>
-        Not enough funds to send {formatAmount(amount, unit)} with a fee of{' '}
-        {formatAmount(fee, unit)}. Add funds or switch mint.
-      </>
+      <Text
+        style={{
+          textAlign: 'center',
+        }}>
+        Not enough funds to send{' '}
+        <AmountFormatter
+          style={{
+            marginBottom: -4,
+            marginLeft: 3,
+          }}
+          size={14}
+          amount={amount}
+          unit={unit}
+        />{' '}
+        with a fee of{' '}
+        <AmountFormatter
+          style={{
+            marginBottom: -4,
+            marginLeft: 3,
+          }}
+          size={14}
+          amount={fee}
+          unit={unit}
+        />
+        .
+      </Text>
     ),
     type: MESSAGE_TYPES.ERROR,
   },


### PR DESCRIPTION
## Summary
- format amounts using user preferences
- support React nodes in popup messages
- show formatted amounts in insufficient balance error

## Testing
- `yarn test --watchAll=false` *(fails: Error when performing the request to yarn registry)*

------
https://chatgpt.com/codex/tasks/task_b_6846e2fb7ed08325bea9521cfdd82be5