### PR TITLE
Add startup warning popup

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -40,6 +40,7 @@ import { TransactionProvider } from 'components/providers/TransactionsProvider';
 import { WalletsProvider } from 'components/providers/WalletsProviders';
 import { registerAllSheets } from 'components/layout/sheets/registerSheets';
 import PasscodeGate from 'components/passcode/PasscodeGate';
+import { showMessage } from 'helper/popup/popups';
 
 registerAllSheets({ context: 'global' });
 
@@ -277,6 +278,12 @@ export default function RootLayout() {
   // Hide splash screen when app is ready
   const onLayoutRootView = useCallback(async () => {
     if (appIsReady) await SplashScreen.hideAsync();
+  }, [appIsReady]);
+
+  useEffect(() => {
+    if (appIsReady) {
+      showMessage('startup_warning', {}, { variant: 'modal' });
+    }
   }, [appIsReady]);
 
   // Show splash screen while loading

--- a/helper/popup/popups.tsx
+++ b/helper/popup/popups.tsx
@@ -243,6 +243,13 @@ const MESSAGE_CONFIGS: Record<string, MessageConfig> = {
     type: MESSAGE_TYPES.INFO,
   },
 
+  startup_warning: {
+    title: 'Warning',
+    text:
+      'Do not use with large amounts of ecash. Sovran wallet is operated on a best-effort basis and without any guarantees',
+    type: MESSAGE_TYPES.WARNING,
+  },
+
   'outputs have already been signed before.': {
     title: 'Outputs have been signed before',
     text: 'Fix this in the debug settings',


### PR DESCRIPTION
## Summary
- add `startup_warning` config for popups
- show the warning modal when the app is ready

## Testing
- `yarn test` *(fails: Error when performing the request to https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz)*

------
https://chatgpt.com/codex/tasks/task_b_68470a0f677c83258a801cf8a1e2796a