### PR TITLE
Add npubcash WebSocket

### DIFF
--- a/app/(drawer)/(tabs)/index.tsx
+++ b/app/(drawer)/(tabs)/index.tsx
@@ -1,5 +1,5 @@
 import 'app/global';
-import React, { memo, useCallback, useState, useLayoutEffect, useEffect } from 'react';
+import React, { memo, useCallback, useState, useLayoutEffect, useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import 'react-native-get-random-values';
 import { RefreshControl, ScrollView, StyleSheet, Alert } from 'react-native';
@@ -34,6 +34,7 @@ import { memoizedGetCurrentProfile } from 'helper/redux/nostr';
 import { Text } from 'components/common/Themed';
 import { Card } from 'components/common/Card';
 import { SheetManager } from 'react-native-actions-sheet';
+import { openNpubxWebSocket } from 'helper/npubcash/websocket';
 
 async function getProfile(currentProfile: any, listenToTransaction: any) {
   const sk = nip19.decode(currentProfile?.nsec).data;
@@ -172,10 +173,22 @@ function TabOneScreen({
   ]);
   const [account, setAccount] = useState(accounts[0]);
 
+  const wsRef = useRef<WebSocket | null>(null);
+
+  const handleQuoteUpdate = useCallback(async () => {
+    await getProfile(currentProfile, listenToTransaction);
+  }, [currentProfile?.nsec]);
+
   const [refreshing, setRefreshing] = useState(false);
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
     await getProfile(currentProfile, listenToTransaction);
+    if (!wsRef.current && currentProfile?.nsec) {
+      wsRef.current = openNpubxWebSocket({
+        nsec: currentProfile.nsec,
+        onUpdate: handleQuoteUpdate,
+      });
+    }
     setRefreshing(false);
   }, [currentProfile?.pubkey]);
 
@@ -194,6 +207,15 @@ function TabOneScreen({
       ),
     });
   }, [navigation, account, accounts]);
+
+  useEffect(() => {
+    return () => {
+      if (wsRef.current) {
+        wsRef.current.close();
+        wsRef.current = null;
+      }
+    };
+  }, []);
 
   const { listenToTransaction } = useTransactions();
 

--- a/helper/npubcash/websocket.ts
+++ b/helper/npubcash/websocket.ts
@@ -1,0 +1,36 @@
+import { nip19 } from 'nostr-tools';
+import { NsecSigner } from '../third-party/cashu-address-sdk-rn/signer';
+import { createAuthTemplate } from '../third-party/cashu-address-sdk-rn/utils';
+import { isProduction } from '../version';
+
+export function openNpubxWebSocket({
+  nsec,
+  onUpdate,
+}: {
+  nsec: string;
+  onUpdate: (quoteId: string) => void;
+}): WebSocket {
+  const sk = nip19.decode(nsec).data as Uint8Array;
+  const signer = new NsecSigner(sk);
+  const protocol = isProduction ? 'wss' : 'ws';
+  const ws = new WebSocket(`${protocol}://npubx.cash/api/v2/ws/quote`);
+
+  ws.onmessage = async (event) => {
+    try {
+      const msg = JSON.parse(event.data);
+      if (msg.type === 'challenge') {
+        const auth = createAuthTemplate(msg.payload.url, msg.payload.method);
+        const signed = await signer.signEvent(auth);
+        ws.send(
+          JSON.stringify({ type: 'challenge-response', payload: signed })
+        );
+      } else if (msg.type === 'update') {
+        onUpdate?.(msg.payload.quoteId);
+      }
+    } catch (err) {
+      console.error('npubx ws error', err);
+    }
+  };
+
+  return ws;
+}

--- a/helper/npubcash/websocket.ts
+++ b/helper/npubcash/websocket.ts
@@ -2,30 +2,46 @@ import { nip19 } from 'nostr-tools';
 import { NsecSigner } from '../third-party/cashu-address-sdk-rn/signer';
 import { createAuthTemplate } from '../third-party/cashu-address-sdk-rn/utils';
 import { isProduction } from '../version';
+import { Alert } from 'react-native';
+import { nip98 } from 'nostr-tools';
 
-export function openNpubxWebSocket({
+export async function openNpubxWebSocket({
   nsec,
   onUpdate,
 }: {
   nsec: string;
   onUpdate: (quoteId: string) => void;
-}): WebSocket {
+}): Promise<WebSocket> {
   const sk = nip19.decode(nsec).data as Uint8Array;
   const signer = new NsecSigner(sk);
-  const protocol = isProduction ? 'wss' : 'ws';
+  const protocol = 'wss';
   const ws = new WebSocket(`${protocol}://npubx.cash/api/v2/ws/quote`);
+  console.log('npubx ws', ws);
 
   ws.onmessage = async (event) => {
+    console.log('npubx ws message', event);
     try {
       const msg = JSON.parse(event.data);
+      console.log('npubx ws message', msg);
+
       if (msg.type === 'challenge') {
-        const auth = createAuthTemplate(msg.payload.url, msg.payload.method);
-        const signed = await signer.signEvent(auth);
-        ws.send(
-          JSON.stringify({ type: 'challenge-response', payload: signed })
+        const token = await nip98.getToken(
+          msg.payload.url,
+          'GET',
+          (e) => signer.signEvent(e),
+          true
         );
+        console.log('npubx ws token', token);
+
+        // Send the raw token, not the unpacked event
+        ws.send(JSON.stringify({ type: 'challenge-response', payload: token }));
       } else if (msg.type === 'update') {
-        onUpdate?.(msg.payload.quoteId);
+        // {"payload": {"quoteId": "4W-NPWd1glZWs2UHrtXTndNvwgbhu7Dqcgl-17YO"}, "type": "update"}
+        Alert.alert('Update', msg.payload.quoteId);
+      } else if (msg.type === 'challenge-success') {
+        console.log('WebSocket authentication successful');
+      } else if (msg.type === 'error') {
+        console.error('WebSocket error:', msg.payload);
       }
     } catch (err) {
       console.error('npubx ws error', err);


### PR DESCRIPTION
## Summary
- implement `openNpubxWebSocket` helper for authenticating with npubx.cash
- connect to the WebSocket on refresh and refresh quotes on updates

## Testing
- `yarn test` *(fails: Error when performing the request to https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz; for troubleshooting help, see https://github.com/nodejs/corepack#troubleshooting)*

------
https://chatgpt.com/codex/tasks/task_b_68496500cc4c832594a6270d3b25af94