### PR TITLE
Fix websocket reconnection loop

### DIFF
--- a/helper/redux/pricelist/hooks.ts
+++ b/helper/redux/pricelist/hooks.ts
@@ -1,4 +1,5 @@
 import { useDispatch, useSelector } from 'react-redux';
+import { useCallback } from 'react';
 import { setPricelist } from './actions';
 import { memoizedPricelist } from './selectors';
 
@@ -6,8 +7,13 @@ export const usePricelist = () => {
   const dispatch = useDispatch();
   const pricelist = useSelector(memoizedPricelist);
 
+  const setPricelistCallback = useCallback(
+    (pricelistData) => dispatch(setPricelist(pricelistData)),
+    [dispatch]
+  );
+
   return {
     pricelist,
-    setPricelist: (pricelistData) => dispatch(setPricelist(pricelistData)),
+    setPricelist: setPricelistCallback,
   };
 };


### PR DESCRIPTION
## Summary
- memoize `setPricelist` in `usePricelist` to prevent the websocket in `PricelistProvider` from reconnecting on every render

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68554cbaa638832585e422b938fc63bb