### PR TITLE
Add wireguard vpn controls

### DIFF
--- a/app/vpn.tsx
+++ b/app/vpn.tsx
@@ -1,4 +1,5 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, Alert } from 'react-native';
+import type { WireGuardStatus } from 'react-native-wireguard-vpn';
 
 import { greys } from 'helper/colors';
 import Modal from 'components/layout/Modal';
@@ -18,6 +19,13 @@ import { ButtonHandler } from 'components/common/ButtonHandler';
 import { Section } from 'components/common/Section';
 import { withSheetProvider } from 'components/hocs/withSheetProvider';
 import { activateVpn } from 'helper/api/sovran';
+import {
+  initializeVpn,
+  connectVpn,
+  disconnectVpn,
+  getVpnStatus,
+  parseWireGuardConfig,
+} from 'helper/vpn/wireguard';
 
 export function convertDataUsage(data) {
   const totalVolume = data.totalVolume; // in bytes
@@ -66,6 +74,7 @@ function ModalScreen() {
   const [query, setQuery] = useState();
   const [fetchingPackages, setFetchingPackages] = useState(false);
   const { vpn, updateVpn } = useVpn();
+  const [vpnStatus, setVpnStatus] = useState<WireGuardStatus | null>(null);
 
   console.log(129837, params);
   //
@@ -176,6 +185,31 @@ function ModalScreen() {
       setRemainingTime('Not activated');
     }
   }, [vpn, params.payment_request]);
+
+  const handleConnect = async () => {
+    const configLines = vpn
+      ?.find((v) => v.payment_request === params.payment_request)
+      ?.order?.WireguardConfig;
+    if (!configLines) {
+      Alert.alert('Configuration missing');
+      return;
+    }
+    await initializeVpn();
+    await connectVpn(parseWireGuardConfig(configLines));
+    const status = await getVpnStatus();
+    setVpnStatus(status);
+  };
+
+  const handleDisconnect = async () => {
+    await disconnectVpn();
+    const status = await getVpnStatus();
+    setVpnStatus(status);
+  };
+
+  const handleStatus = async () => {
+    const status = await getVpnStatus();
+    setVpnStatus(status);
+  };
 
   return (
     <Modal
@@ -313,6 +347,26 @@ function ModalScreen() {
                       text: 'Activate',
                       variant: 'primary',
                       onPress: activateVPN,
+                    },
+                  ]
+                : []),
+              ...(remainingTime !== 'Not activated'
+                ? [
+                    vpnStatus?.isConnected
+                      ? {
+                          text: 'Disconnect',
+                          variant: 'primary',
+                          onPress: handleDisconnect,
+                        }
+                      : {
+                          text: 'Connect',
+                          variant: 'primary',
+                          onPress: handleConnect,
+                        },
+                    {
+                      text: 'Status',
+                      variant: 'secondary',
+                      onPress: handleStatus,
                     },
                   ]
                 : []),

--- a/helper/vpn/wireguard.ts
+++ b/helper/vpn/wireguard.ts
@@ -1,0 +1,68 @@
+import { Alert } from 'react-native';
+import WireGuardVpnModule, { WireGuardConfig, WireGuardStatus } from 'react-native-wireguard-vpn';
+
+export const initializeVpn = async () => {
+  try {
+    await WireGuardVpnModule.initialize();
+    Alert.alert('VPN Initialized');
+  } catch (error) {
+    Alert.alert('Initialization Failed', JSON.stringify(error));
+  }
+};
+
+export const connectVpn = async (config: WireGuardConfig) => {
+  try {
+    await WireGuardVpnModule.connect(config);
+    Alert.alert('VPN Connected');
+  } catch (error) {
+    Alert.alert('Connection Failed', JSON.stringify(error));
+  }
+};
+
+export const disconnectVpn = async () => {
+  try {
+    await WireGuardVpnModule.disconnect();
+    Alert.alert('VPN Disconnected');
+  } catch (error) {
+    Alert.alert('Disconnection Failed', JSON.stringify(error));
+  }
+};
+
+export const getVpnStatus = async (): Promise<WireGuardStatus | null> => {
+  try {
+    const status = await WireGuardVpnModule.getStatus();
+    Alert.alert('VPN Status', JSON.stringify(status));
+    return status;
+  } catch (error) {
+    Alert.alert('Status Error', JSON.stringify(error));
+    return null;
+  }
+};
+
+export const parseWireGuardConfig = (lines: string[]): WireGuardConfig => {
+  const kv: Record<string, string> = {};
+  lines.forEach((line) => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#') || trimmed.startsWith('[')) {
+      return;
+    }
+    const [key, value] = trimmed.split('=');
+    if (key && value) {
+      kv[key.trim()] = value.trim();
+    }
+  });
+
+  const endpoint = kv['Endpoint'] || '';
+  const [serverAddress, serverPortStr] = endpoint.split(':');
+
+  return {
+    privateKey: kv['PrivateKey'],
+    publicKey: kv['PublicKey'],
+    serverAddress,
+    serverPort: parseInt(serverPortStr || '51820', 10),
+    allowedIPs: (kv['AllowedIPs'] || '').split(',').map((s) => s.trim()).filter(Boolean),
+    dns: kv['DNS'] ? [kv['DNS']] : undefined,
+    mtu: kv['MTU'] ? parseInt(kv['MTU'], 10) : undefined,
+    presharedKey: kv['PresharedKey'] || undefined,
+  } as WireGuardConfig;
+};

--- a/package.json
+++ b/package.json
@@ -161,7 +161,8 @@
     "usehooks-ts": "^3.1.0",
     "util": "^0.10.4",
     "vm-browserify": "^0.0.4",
-    "webln": "^0.3.2"
+    "webln": "^0.3.2",
+    "react-native-wireguard-vpn": "^1.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
## Summary
- add react-native-wireguard-vpn dependency
- expose helper functions for wireguard with alerts
- allow connecting/disconnecting VPN in vpn screen
- type vpn status state

## Testing
- `yarn pretty` *(fails: Error when performing the request to https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz)*
- `yarn test` *(fails: Error when performing the request to https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz)*

------
https://chatgpt.com/codex/tasks/task_b_685486ca29e08325bb6d054ca85f2305