### PR TITLE
fix redux store require cycle

### DIFF
--- a/components/layout/sheets/delete/routes/routeA.tsx
+++ b/components/layout/sheets/delete/routes/routeA.tsx
@@ -3,7 +3,7 @@ import { Card } from 'components/common/Card';
 import { View, Text } from 'components/common/Themed';
 import { greys } from 'helper/colors';
 import { memoizedGetTheme } from 'helper/redux/settings';
-import { resetApp } from 'helper/redux/store/reducer';
+import { resetApp } from 'helper/redux/store';
 import * as Updates from 'expo-updates';
 import React from 'react';
 import { RouteScreenProps } from 'react-native-actions-sheet';

--- a/helper/redux/store/index.ts
+++ b/helper/redux/store/index.ts
@@ -1,6 +1,6 @@
 import { applyMiddleware, createStore } from 'redux';
 import { createMigrate, persistStore, persistReducer, MigrationManifest } from 'redux-persist';
-import rootReducer, { RootState } from './reducer';
+import rootReducer, { RootState, AppThunk, RESET_APP } from './reducer';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import _ from 'lodash/fp';
 
@@ -395,3 +395,24 @@ store.subscribe(() => {
 });
 
 export const persistor = persistStore(store);
+
+// Typed reset app action creator moved here to avoid a require cycle
+export const resetApp = (): AppThunk => {
+  return async (dispatch): Promise<void> => {
+    try {
+      // Clear persisted redux data
+      await persistor.purge();
+
+      // Dispatch the reset action to clear the in-memory state
+      dispatch({ type: RESET_APP });
+
+      // Restart persistence after reset
+      persistor.persist();
+
+      return Promise.resolve();
+    } catch (error) {
+      console.error('Failed to reset app:', error);
+      return Promise.reject(error);
+    }
+  };
+};

--- a/helper/redux/store/reducer.ts
+++ b/helper/redux/store/reducer.ts
@@ -7,7 +7,6 @@ import { pricelistReducer } from '../pricelist/reducer';
 import { vpnReducer } from '../lnvpn/reducer';
 import { esimReducer } from '../esim/reducer';
 import { nostrReducer } from '../nostr/reducer';
-import { persistor } from '.';
 
 // Action type for reset
 export const RESET_APP = 'RESET_APP' as const;
@@ -50,25 +49,5 @@ const rootReducer = (state: RootState | undefined, action: AnyAction): RootState
   return appReducer(state, action);
 };
 
-// Typed reset app action creator
-export const resetApp = (): AppThunk => {
-  return async (dispatch): Promise<void> => {
-    try {
-      // Clear persisted redux data
-      await persistor.purge();
-
-      // Dispatch the reset action to clear the in-memory state
-      dispatch({ type: RESET_APP });
-
-      // Restart persistence after reset
-      persistor.persist();
-
-      return Promise.resolve();
-    } catch (error) {
-      console.error('Failed to reset app:', error);
-      return Promise.reject(error);
-    }
-  };
-};
 
 export default rootReducer;


### PR DESCRIPTION
## Summary
- move resetApp action into store index to avoid circular import
- update imports referencing resetApp

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_685741a676108325ab6e6698028b6275