### PR TITLE
Add camera permission handler hook

### DIFF
--- a/components/layout/AccountPagerView.tsx
+++ b/components/layout/AccountPagerView.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useRef } from 'react';
 import { useSelector } from 'react-redux';
-import { useCameraPermissions } from 'expo-camera';
+import { useHandleCameraPermission } from 'helper/hooks/useHandleCameraPermission';
 import 'react-native-get-random-values';
 import { Platform, StyleSheet } from 'react-native';
 import Swiper from 'react-native-web-infinite-swiper';
@@ -48,7 +48,7 @@ export function AccountPagerView({
   setAccount,
   account,
 }: AccountPagerViewProps): React.ReactElement {
-  const [hasPermission, requestPermission] = useCameraPermissions();
+  const { handlePermission } = useHandleCameraPermission();
   const theme = useSelector(memoizedGetTheme);
   const styles = createStyles(theme);
   const navigation = useTypedNavigation();
@@ -93,10 +93,9 @@ export function AccountPagerView({
       return;
     }
 
-    if (page === 'camera' && !hasPermission?.granted) {
-      const res = await requestPermission();
-      if (!res.granted) {
-        showMessage('camera_permission_denied', {}, { emoji: '🚨' });
+    if (page === 'camera') {
+      const granted = await handlePermission();
+      if (!granted) {
         return;
       }
     }

--- a/components/layout/sheets/popup/routes/index.tsx
+++ b/components/layout/sheets/popup/routes/index.tsx
@@ -16,6 +16,17 @@ declare module 'react-native-actions-sheet' {
       routes: {
         'route-a': RouteDefinition;
       };
+      payload: {
+        variant?: string;
+        emoji?: string;
+        message?: string;
+        submessage?: React.ReactNode;
+        buttons?: {
+          text: string;
+          page?: string;
+          onPress?: () => void;
+        }[];
+      };
     }>;
   }
 }

--- a/components/layout/sheets/popup/routes/routeA.tsx
+++ b/components/layout/sheets/popup/routes/routeA.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { View, StyleSheet, Animated } from 'react-native';
-import { RouteScreenProps } from 'react-native-actions-sheet';
+import { RouteScreenProps, useSheetPayload } from 'react-native-actions-sheet';
 import { Text } from 'components/common/Text';
 import { useSelector } from 'react-redux';
 import { memoizedGetTheme } from 'helper/redux/settings';
@@ -8,26 +8,12 @@ import { greys } from 'helper/colors';
 import { Button } from 'components/common/Button';
 import { useTypedNavigation } from 'helper/navigation';
 
-const RouteA = ({
-  router,
-  payload,
-}: RouteScreenProps<'popup-sheet', 'route-a'> & {
-  payload: {
-    variant?: string;
-    emoji?: string;
-    message?: string;
-    submessage?: React.ReactNode;
-    buttons?: {
-      text: string;
-      page?: string;
-      onPress?: () => void;
-    }[];
-  };
-}) => {
+const RouteA = ({ router }: RouteScreenProps<'popup-sheet', 'route-a'>) => {
   const theme = useSelector(memoizedGetTheme);
   const styles = createStyles(theme);
   const [progress] = useState(new Animated.Value(0));
 
+  const payload = useSheetPayload('popup-sheet');
   const isModal = payload?.variant === 'modal';
   const navigation = useTypedNavigation();
 
@@ -79,7 +65,8 @@ const RouteA = ({
                 navigation.navigate(button.page);
               }
             }}
-            text={button.text}></Button>
+            text={button.text}
+            variant={'primary'}></Button>
         );
       })}
       {!isModal && (

--- a/components/layout/sheets/popup/routes/routeA.tsx
+++ b/components/layout/sheets/popup/routes/routeA.tsx
@@ -17,7 +17,11 @@ const RouteA = ({
     emoji?: string;
     message?: string;
     submessage?: React.ReactNode;
-    buttons?: any;
+    buttons?: {
+      text: string;
+      page?: string;
+      onPress?: () => void;
+    }[];
   };
 }) => {
   const theme = useSelector(memoizedGetTheme);
@@ -69,7 +73,11 @@ const RouteA = ({
           <Button
             key={button.text}
             onPress={() => {
-              navigation.navigate(button.page);
+              if (button.onPress) {
+                button.onPress();
+              } else if (button.page) {
+                navigation.navigate(button.page);
+              }
             }}
             text={button.text}></Button>
         );

--- a/helper/hooks/useHandleCameraPermission.ts
+++ b/helper/hooks/useHandleCameraPermission.ts
@@ -28,21 +28,39 @@ export function useHandleCameraPermission() {
         return true;
       }
 
-      showMessage('camera_permission_denied', {}, { emoji: '🚨' });
+      showMessage(
+        'camera_permission_denied',
+        {},
+        {
+          emoji: '🚨',
+          buttons: [
+            {
+              text: 'Open Settings',
+              onPress: () => {
+                Linking.openURL('app-settings:');
+              },
+            },
+          ],
+        }
+      );
       return false;
     }
 
-    showMessage('camera_permission_blocked', {}, {
-      emoji: '🚨',
-      buttons: [
-        {
-          text: 'Open Settings',
-          onPress: () => {
-            Linking.openURL('app-settings:');
+    showMessage(
+      'camera_permission_blocked',
+      {},
+      {
+        emoji: '🚨',
+        buttons: [
+          {
+            text: 'Open Settings',
+            onPress: () => {
+              Linking.openURL('app-settings:');
+            },
           },
-        },
-      ],
-    });
+        ],
+      }
+    );
     return false;
   };
 

--- a/helper/hooks/useHandleCameraPermission.ts
+++ b/helper/hooks/useHandleCameraPermission.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useCameraPermissions } from 'expo-camera';
 import { showMessage } from 'helper/popup/popups';
-import * as Linking from 'expo-linking';
+import { Linking } from 'react-native';
 
 export function useHandleCameraPermission() {
   const [permission, requestPermission] = useCameraPermissions();
@@ -28,22 +28,14 @@ export function useHandleCameraPermission() {
         return true;
       }
 
-      showMessage('camera_permission_denied', {}, {
-        buttons: [
-          { text: 'Try Again', page: 'camera' },
-        ],
-        emoji: '🚨',
-      });
+      showMessage('camera_permission_denied', {}, { emoji: '🚨' });
       return false;
     }
 
     showMessage('camera_permission_blocked', {}, {
-      buttons: [
-        { text: 'Open Settings', page: 'settings' },
-      ],
       emoji: '🚨',
     });
-    Linking.openSettings();
+    Linking.openURL('app-settings:');
     return false;
   };
 

--- a/helper/hooks/useHandleCameraPermission.ts
+++ b/helper/hooks/useHandleCameraPermission.ts
@@ -34,8 +34,15 @@ export function useHandleCameraPermission() {
 
     showMessage('camera_permission_blocked', {}, {
       emoji: '🚨',
+      buttons: [
+        {
+          text: 'Open Settings',
+          onPress: () => {
+            Linking.openURL('app-settings:');
+          },
+        },
+      ],
     });
-    Linking.openURL('app-settings:');
     return false;
   };
 

--- a/helper/hooks/useHandleCameraPermission.ts
+++ b/helper/hooks/useHandleCameraPermission.ts
@@ -1,0 +1,55 @@
+import { useState, useEffect } from 'react';
+import { useCameraPermissions } from 'expo-camera';
+import { showMessage } from 'helper/popup/popups';
+import * as Linking from 'expo-linking';
+
+export function useHandleCameraPermission() {
+  const [permission, requestPermission] = useCameraPermissions();
+  const [isChecking, setIsChecking] = useState(true);
+
+  useEffect(() => {
+    if (permission) {
+      setIsChecking(false);
+    }
+  }, [permission]);
+
+  const handlePermission = async (): Promise<boolean> => {
+    if (!permission) return false;
+
+    if (permission.granted) {
+      showMessage('camera_permission_granted');
+      return true;
+    }
+
+    if (permission.canAskAgain) {
+      const res = await requestPermission();
+      if (res.granted) {
+        showMessage('camera_permission_granted');
+        return true;
+      }
+
+      showMessage('camera_permission_denied', {}, {
+        buttons: [
+          { text: 'Try Again', page: 'camera' },
+        ],
+        emoji: '🚨',
+      });
+      return false;
+    }
+
+    showMessage('camera_permission_blocked', {}, {
+      buttons: [
+        { text: 'Open Settings', page: 'settings' },
+      ],
+      emoji: '🚨',
+    });
+    Linking.openSettings();
+    return false;
+  };
+
+  return {
+    permission,
+    isChecking,
+    handlePermission,
+  };
+}

--- a/helper/popup/popups.tsx
+++ b/helper/popup/popups.tsx
@@ -20,11 +20,17 @@ const MESSAGE_EMOJIS = {
 
 type MessageText = string | React.ReactNode | ((params: any) => React.ReactNode);
 
+type MessageButton = {
+  text: string;
+  page?: string;
+  onPress?: () => void;
+};
+
 type MessageConfig = {
   title: string;
   text: MessageText;
   type: string;
-  buttons?: any; // Make button optional
+  buttons?: MessageButton[]; // Make button optional
 };
 
 const MESSAGE_CONFIGS: Record<string, MessageConfig> = {
@@ -340,7 +346,7 @@ const MESSAGE_CONFIGS: Record<string, MessageConfig> = {
 type MessageCode = keyof typeof MESSAGE_CONFIGS;
 
 type ShowMessageOptions = {
-  buttons?: any;
+  buttons?: MessageButton[];
   emoji?: string;
   dismissable?: boolean;
   variant?: string;

--- a/helper/popup/popups.tsx
+++ b/helper/popup/popups.tsx
@@ -90,6 +90,22 @@ const MESSAGE_CONFIGS: Record<string, MessageConfig> = {
     text: 'Please enable camera access in your device settings to use this feature.',
     type: MESSAGE_TYPES.ERROR,
   },
+  camera_permission_granted: {
+    title: 'Camera Permission Granted',
+    text: 'Camera access has been granted.',
+    type: MESSAGE_TYPES.SUCCESS,
+  },
+  camera_permission_blocked: {
+    title: 'Camera Permission Blocked',
+    text: 'Camera access is blocked. Please enable it in your device settings.',
+    buttons: [
+      {
+        text: 'Open Settings',
+        page: 'settings',
+      },
+    ],
+    type: MESSAGE_TYPES.ERROR,
+  },
   sharing_unavailable: {
     title: 'Sharing Unavailable',
     text: 'Sharing is not supported on your device.',

--- a/helper/popup/popups.tsx
+++ b/helper/popup/popups.tsx
@@ -92,14 +92,8 @@ const MESSAGE_CONFIGS: Record<string, MessageConfig> = {
     type: MESSAGE_TYPES.ERROR,
   },
   camera_permission_denied: {
-    title: 'Camera Access Required',
-    text: 'Please enable camera access in your device settings to use this feature.',
-    buttons: [
-      {
-        text: 'Try Again',
-        page: 'camera',
-      },
-    ],
+    title: 'Camera Permission Denied',
+    text: 'Camera access is denied. Please enable it in your device settings.',
     type: MESSAGE_TYPES.ERROR,
   },
   camera_permission_granted: {

--- a/helper/popup/popups.tsx
+++ b/helper/popup/popups.tsx
@@ -88,6 +88,12 @@ const MESSAGE_CONFIGS: Record<string, MessageConfig> = {
   camera_permission_denied: {
     title: 'Camera Access Required',
     text: 'Please enable camera access in your device settings to use this feature.',
+    buttons: [
+      {
+        text: 'Try Again',
+        page: 'camera',
+      },
+    ],
     type: MESSAGE_TYPES.ERROR,
   },
   camera_permission_granted: {


### PR DESCRIPTION
## Summary
- add `useHandleCameraPermission` hook for requesting camera permissions
- extend popup messages for camera permission states
- use the new hook when pressing the camera button on the home page

## Testing
- `yarn lint` *(fails: Request was cancelled due to no internet)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_685993ddc5488325ace66eb9f119a207