### PR TITLE
Enable image-based theme

### DIFF
--- a/app/(drawer)/(tabs)/index.tsx
+++ b/app/(drawer)/(tabs)/index.tsx
@@ -172,7 +172,7 @@ function TabOneScreen() {
         width: '100%',
         height: '100%',
       }}>
-      <AnimatedSpriteBackground />
+      {theme === 'image' && <AnimatedSpriteBackground />}
 
       <SafeAreaView style={styles.safeAreaView}>
         <ScrollView
@@ -189,8 +189,21 @@ function TabOneScreen() {
           <View className="m-4">
             <Transactions days={1} account={account} />
           </View>
+          {theme === 'image' && (
+            <LinearGradient
+              colors={['#131213', '#131213', opacity('#131213', 0.5), 'transparent']}
+              start={{ x: 0.5, y: 1 }}
+              end={{ x: 0.5, y: 0 }}
+              style={[
+                StyleSheet.absoluteFill,
+                { transform: [{ scale: 1.1 }], paddingTop: '100%', zIndex: -1 },
+              ]}
+            />
+          )}
+        </ScrollView>
+        {theme === 'image' && (
           <LinearGradient
-            colors={['#131213', '#131213', opacity('#131213', 0.5), 'transparent']} // purple-dark to transparent
+            colors={['#131213', '#131213', opacity('#131213', 0.5), 'transparent']}
             start={{ x: 0.5, y: 1 }}
             end={{ x: 0.5, y: 0 }}
             style={[
@@ -198,16 +211,7 @@ function TabOneScreen() {
               { transform: [{ scale: 1.1 }], paddingTop: '100%', zIndex: -1 },
             ]}
           />
-        </ScrollView>
-        <LinearGradient
-          colors={['#131213', '#131213', opacity('#131213', 0.5), 'transparent']} // purple-dark to transparent
-          start={{ x: 0.5, y: 1 }}
-          end={{ x: 0.5, y: 0 }}
-          style={[
-            StyleSheet.absoluteFill,
-            { transform: [{ scale: 1.1 }], paddingTop: '100%', zIndex: -1 },
-          ]}
-        />
+        )}
       </SafeAreaView>
     </View>
   );
@@ -218,11 +222,11 @@ const createStyles = (theme: string) =>
     scrollView: {
       marginTop: 0,
       marginBottom: -24,
-      // backgroundColor: greys(theme)[2300],
+      backgroundColor: theme === 'image' ? 'transparent' : greys(theme)[2300],
     },
     safeAreaView: {
       flex: 1,
-      // backgroundColor: greys(theme)[2300],
+      backgroundColor: theme === 'image' ? 'transparent' : greys(theme)[2300],
     },
     accountPagerView: {
       display: 'flex',

--- a/app/themeSettings.tsx
+++ b/app/themeSettings.tsx
@@ -32,6 +32,7 @@ const themes = [
   'crimson-night',
   'twilight-amber',
   'velvet-emerald',
+  'image',
   // "volcanic-crimson",
   // "urban-concrete",
   // "celestial-aura",
@@ -60,6 +61,7 @@ const themeNameMap = {
   'crimson-night': 'Crimson Night',
   'twilight-amber': 'Twilight Amber',
   'velvet-emerald': 'Velvet Emerald',
+  image: 'Image',
 
   'volcanic-crimson': 'Volcanic Crimson',
   'urban-concrete': 'Urban Concrete',

--- a/components/layout/Account.tsx
+++ b/components/layout/Account.tsx
@@ -166,7 +166,7 @@ const PLATFORM_BOTTOM_OFFSET = Platform.OS === 'web' ? 28.8 : 64 + 28.8;
 const createStyles = (theme: string) =>
   StyleSheet.create({
     nonGestureView: {
-      // backgroundColor: greys(theme)[2300], // Using a default theme value
+      backgroundColor: theme === 'image' ? 'transparent' : greys(theme)[2300],
       overflow: 'hidden',
       zIndex: 1,
       height: 335,

--- a/components/layout/AccountPagerView.tsx
+++ b/components/layout/AccountPagerView.tsx
@@ -164,7 +164,7 @@ export function AccountPagerView({
                 flex: 1,
                 justifyContent: 'center',
                 alignItems: 'center',
-                // backgroundColor: greys(theme)[2300],
+                backgroundColor: theme === 'image' ? 'transparent' : greys(theme)[2300],
               }}>
               <Account accounts={loopedAccounts} account={acc} goToIndex={goToIndex} />
             </View>
@@ -215,7 +215,7 @@ export function AccountPagerView({
                       isSend && styles.sendIconView,
                     ]}
                     blurTint="prominent"
-                    blur={!isCamera}>
+                    blur={theme === 'image' && !isCamera}>
                     <View className="bg-transparent">{icon}</View>
                     {!isCamera && (
                       <Text weight="bold" size={14} style={{ color: greys(theme)[0] }}>
@@ -283,14 +283,14 @@ const createStyles = (theme: string) =>
       borderRadius: 1000,
     },
     receiveIconView: {
-      // backgroundColor: greys(theme)[1800],
+      backgroundColor: theme === 'image' ? 'transparent' : greys(theme)[1800],
       borderBottomLeftRadius: 1000,
       borderTopLeftRadius: 1000,
       borderWidth: 0.3,
       borderColor: greys(theme)[1500],
     },
     sendIconView: {
-      // backgroundColor: greys(theme)[1800],
+      backgroundColor: theme === 'image' ? 'transparent' : greys(theme)[1800],
       borderBottomRightRadius: 1000,
       borderTopRightRadius: 1000,
       borderWidth: 0.3,

--- a/components/layout/Transactions.tsx
+++ b/components/layout/Transactions.tsx
@@ -154,7 +154,10 @@ export const Transactions = React.memo(
                 <Text size={14} heavy color={greys(theme)[1000]} className="mb-1">
                   {section.title}
                 </Text>
-                <View className="rounded-lg" blur>
+                <View
+                  className="rounded-lg"
+                  blur={theme === 'image'}
+                  style={theme === 'image' ? undefined : { backgroundColor: greys(theme)[1800] }}>
                   {section.data.map((tx) => (
                     <Transaction
                       key={tx.request || tx.token || tx.txid || tx.id || Math.random().toString()}
@@ -179,10 +182,11 @@ export const Transactions = React.memo(
               })
             }
             className="mt-4 flex items-center rounded-full border p-3"
-            style={{
-              backgroundColor: greys(theme)[1800],
-              borderColor: greys(theme)[1500],
-            }}>
+            style={[
+              theme === 'image'
+                ? { borderColor: greys(theme)[1500] }
+                : { backgroundColor: greys(theme)[1800], borderColor: greys(theme)[1500] },
+            ]}>
             <Text size={14} bold>
               View all ({filteredTransactions.length})
             </Text>
@@ -232,7 +236,8 @@ export const Transactions = React.memo(
             <View
               style={[
                 {
-                  backgroundColor: greys(theme)[1800],
+                  backgroundColor:
+                    theme === 'image' ? 'transparent' : greys(theme)[1800],
                   borderRadius: 8,
                   borderTopLeftRadius: index === 0 ? 8 : 0,
                   borderTopRightRadius: index === 0 ? 8 : 0,

--- a/components/layout/sheets/mints/index.tsx
+++ b/components/layout/sheets/mints/index.tsx
@@ -108,7 +108,7 @@ const MintSelectorButton: React.FC<SelectedMintDisplayProps> = ({
             justifyContent: 'space-between',
           },
         ]}
-        blur>
+        blur={theme === 'image'}>
         <View
           style={{
             flexDirection: 'row',
@@ -166,7 +166,7 @@ const baseStyles = (theme: string) => ({
   // Base container styles
   container: {
     padding: 8,
-    // backgroundColor: greys(theme)[1800],
+    backgroundColor: theme === 'image' ? 'transparent' : greys(theme)[1800],
     borderColor: greys(theme)[1300],
     borderWidth: 0.2,
     borderRadius: 8,
@@ -387,11 +387,12 @@ const sovran = (theme: string) => ({
 
   // Background variations
   backgroundSubtle: {
-    backgroundColor: opacity(greys(theme)[1800], 0.75),
+    backgroundColor:
+      theme === 'image' ? opacity(greys(theme)[1800], 0.5) : opacity(greys(theme)[1800], 0.75),
   } as ViewStyle,
 
   backgroundSolid: {
-    backgroundColor: greys(theme)[1800],
+    backgroundColor: theme === 'image' ? 'transparent' : greys(theme)[1800],
   } as ViewStyle,
 });
 
@@ -484,7 +485,7 @@ export const createStyles = (theme: string) =>
       paddingVertical: 6,
       paddingHorizontal: 6,
       borderRadius: 100000,
-      backgroundColor: greys(theme)[1800],
+      backgroundColor: theme === 'image' ? 'transparent' : greys(theme)[1800],
       marginBottom: 8,
     },
     icon: {
@@ -525,7 +526,7 @@ export const createStyles = (theme: string) =>
     },
     actionSheetContainer: {
       height: '100%',
-      backgroundColor: greys(theme)[2300],
+      backgroundColor: theme === 'image' ? 'transparent' : greys(theme)[2300],
     },
     scrollContainer: {
       padding: 16,
@@ -533,7 +534,7 @@ export const createStyles = (theme: string) =>
     },
     buttonContainer: {
       padding: 16,
-      backgroundColor: greys(theme)[2300],
+      backgroundColor: theme === 'image' ? 'transparent' : greys(theme)[2300],
     },
     sectionHeader: {
       color: greys(theme)[0],
@@ -548,7 +549,7 @@ export const createStyles = (theme: string) =>
       marginRight: 12,
       padding: 12,
       borderRadius: 8,
-      backgroundColor: greys(theme)[1800],
+      backgroundColor: theme === 'image' ? 'transparent' : greys(theme)[1800],
       minWidth: 100,
     },
     currencyContent: {
@@ -573,7 +574,7 @@ export const createStyles = (theme: string) =>
       alignItems: 'center',
       padding: 12,
       borderRadius: 8,
-      backgroundColor: greys(theme)[1800],
+      backgroundColor: theme === 'image' ? 'transparent' : greys(theme)[1800],
       marginBottom: 8,
     },
     selectedMintItem: {
@@ -600,7 +601,7 @@ export const createStyles = (theme: string) =>
     },
     button: {
       padding: 16,
-      backgroundColor: greys(theme)[1800],
+      backgroundColor: theme === 'image' ? 'transparent' : greys(theme)[1800],
       borderRadius: 8,
       marginTop: 16,
       alignItems: 'center',

--- a/helper/colors.tsx
+++ b/helper/colors.tsx
@@ -672,6 +672,10 @@ export const greys = (t = 'dark') => {
       };
     }
 
+    case 'image': {
+      return greys('dark');
+    }
+
     case 'dark':
     default: {
       return {


### PR DESCRIPTION
## Summary
- add `image` theme
- allow theme selection via settings
- render animated sprite and background gradients only in image theme
- conditionally blur and remove background colors when `image` theme is active

## Testing
- `yarn lint` *(fails: cannot access registry)*
- `yarn test` *(fails: cannot access registry)*

------
https://chatgpt.com/codex/tasks/task_b_685e09e5576c8325a86ff5ef88c62137