### PR TITLE
Add dynamic shades and greys for themes

### DIFF
--- a/app/(drawer)/(tabs)/index.tsx
+++ b/app/(drawer)/(tabs)/index.tsx
@@ -32,7 +32,6 @@ import _ from 'lodash';
 import { memoizedGetCurrentProfile } from 'helper/redux/nostr';
 import AnimatedSpriteBackground from 'components/common/SpriteView';
 import { LinearGradient } from 'expo-linear-gradient';
-import { BACKGROUND_IMAGE_ATTRIBUTES } from 'helper/backgroundImages';
 import opacity from 'hex-color-opacity';
 
 interface NPUBQuote {
@@ -172,6 +171,8 @@ function TabOneScreen() {
     return <Welcome />;
   }
 
+  console.log(23982737, theme.greys);
+
   return (
     <View
       style={{
@@ -196,13 +197,14 @@ function TabOneScreen() {
           <View className="m-4">
             <Transactions days={1} account={account} />
           </View>
-          {BACKGROUND_IMAGE_ATTRIBUTES[image]?.secondary && (
+          {theme.shades && (
             <LinearGradient
               colors={[
-                BACKGROUND_IMAGE_ATTRIBUTES[image]?.secondary,
-                BACKGROUND_IMAGE_ATTRIBUTES[image]?.secondary,
-                opacity(BACKGROUND_IMAGE_ATTRIBUTES[image]?.secondary, 0),
-                opacity(BACKGROUND_IMAGE_ATTRIBUTES[image]?.secondary, 0),
+                theme.greys[700],
+                theme.greys[700],
+                theme.greys[700],
+                opacity(theme.greys[700], 0),
+                opacity(theme.greys[700], 0),
               ]}
               start={{ x: 0.5, y: 1 }}
               end={{ x: 0.5, y: 0 }}
@@ -213,13 +215,14 @@ function TabOneScreen() {
             />
           )}
         </ScrollView>
-        {BACKGROUND_IMAGE_ATTRIBUTES[image]?.secondary && (
+        {theme.greys && (
           <LinearGradient
             colors={[
-              BACKGROUND_IMAGE_ATTRIBUTES[image]?.secondary,
-              BACKGROUND_IMAGE_ATTRIBUTES[image]?.secondary,
-              opacity(BACKGROUND_IMAGE_ATTRIBUTES[image]?.secondary, 0),
-              opacity(BACKGROUND_IMAGE_ATTRIBUTES[image]?.secondary, 0),
+              theme.greys[700],
+              theme.greys[700],
+              theme.greys[700],
+              opacity(theme.greys[700], 0),
+              opacity(theme.greys[700], 0),
             ]}
             start={{ x: 0.5, y: 1 }}
             end={{ x: 0.5, y: 0 }}

--- a/assets/icons/index.tsx
+++ b/assets/icons/index.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useRef } from 'react';
 import Svg, { Circle, Defs, G, Path, Rect, Stop, LinearGradient } from 'react-native-svg';
-import { greys, shades } from 'helper/colors';
+
 import { useSelector } from 'react-redux';
 import CachedImage from 'components/common/Image';
 import { memoizedGetTheme } from 'helper/redux/settings';
 import { Monicon as Icon } from '@monicon/native';
 
-// todo: remove all these icons and use <Icon name={name} size={size} color={color || greys(theme)[0]} /> instead.
+// todo: remove all these icons and use <Icon name={name} size={size} color={color || theme.greys[0]} /> instead.
 
 import { Animated, StyleProp, ViewStyle } from 'react-native';
 import { Easing } from 'react-native-reanimated';
@@ -131,7 +131,7 @@ export default ({
         transform: [{ rotate: spinAnimation }],
         ...style,
       }}>
-      <Icon name={name} size={size} color={color || greys(theme)[0]} />
+      <Icon name={name} size={size} color={color || theme.greys[0]} />
     </Animated.View>
   );
 };
@@ -235,7 +235,7 @@ export function InfoIcon({ color }) {
 export function ActivityIcon({ color }) {
   const theme = useSelector(memoizedGetTheme);
   return (
-    <Svg width="24" height="24" viewBox="0 0 48 48" stroke={color || greys(theme)[0]}>
+    <Svg width="24" height="24" viewBox="0 0 48 48" stroke={color || theme.greys[0]}>
       <Path
         fill="none"
         stroke={color}
@@ -254,12 +254,12 @@ export function UserIcon() {
   return (
     <View
       style={{
-        backgroundColor: greys(theme)[1800], // Set the background color to black
+        backgroundColor: theme.greys[1800], // Set the background color to black
         borderRadius: 50, // Adjust this value to get the roundness you desire
         padding: 4, // Adjust padding to control the size of the background relative to the SVG
         marginLeft: 8, // Adjust margin to control the distance between the icon and the edge of the screen
       }}>
-      <Svg fill={greys(theme)[200]} height="24" viewBox="0 -960 960 960" width="24">
+      <Svg fill={theme.greys[200]} height="24" viewBox="0 -960 960 960" width="24">
         <Path d="M480-480q-66 0-113-47t-47-113q0-66 47-113t113-47q66 0 113 47t47 113q0 66-47 113t-113 47ZM160-160v-112q0-34 17.5-62.5T224-378q62-31 126-46.5T480-440q66 0 130 15.5T736-378q29 15 46.5 43.5T800-272v112H160Zm80-80h480v-32q0-11-5.5-20T700-306q-54-27-109-40.5T480-360q-56 0-111 13.5T260-306q-9 5-14.5 14t-5.5 20v32Zm240-320q33 0 56.5-23.5T560-640q0-33-23.5-56.5T480-720q-33 0-56.5 23.5T400-640q0 33 23.5 56.5T480-560Zm0-80Zm0 400Z" />
       </Svg>
     </View>
@@ -314,7 +314,7 @@ export function FixedAmountIcon() {
   return (
     <Svg width="24" height="24" viewBox="0 0 24 24">
       <Path
-        fill={greys(theme)[0]}
+        fill={theme.greys[0]}
         d="m17.423 20.789l-.707-.689L18.79 18h-6.81v-1h6.81l-2.075-2.1l.707-.688l3.289 3.288zM4.25 12.827v-1.692h1.692v1.692zm5.825 0q-1.14 0-1.944-.805q-.804-.806-.804-1.945v-4q0-1.14.806-1.945t1.946-.805t1.944.805t.804 1.945v4q0 1.14-.806 1.945t-1.946.805m7.885 0q-1.14 0-1.944-.805q-.804-.806-.804-1.945v-4q0-1.14.806-1.945t1.946-.805t1.944.805t.803 1.945v4q0 1.14-.805 1.945q-.806.805-1.946.805m-7.883-1q.729 0 1.24-.51t.51-1.24v-4q0-.73-.51-1.24q-.511-.51-1.24-.51q-.73 0-1.24.51t-.51 1.24v4q0 .729.51 1.24q.51.51 1.24.51m7.884 0q.73 0 1.24-.51q.51-.511.51-1.24v-4q0-.73-.51-1.24t-1.24-.51t-1.239.51t-.51 1.24v4q0 .729.51 1.24t1.24.51"
       />
     </Svg>
@@ -327,7 +327,7 @@ export function QRCodeIcon() {
   return (
     <Svg width="24" height="24" viewBox="0 0 24 24">
       <Path
-        fill={greys(theme)[0]}
+        fill={theme.greys[0]}
         d="M3 7.039V3h4.039v1H4v3.039zM3 21v-4.038h1V20h3.039v1zm13.962 0v-1H20v-3.038h1V21zM20 7.039V4h-3.038V3H21v4.039zm-3.058 9.903h1.212v1.212h-1.212zm0-2.423h1.212v1.212h-1.212zm-1.211 1.212h1.211v1.211h-1.211zm-1.212 1.211h1.212v1.212h-1.212zm-1.211-1.211h1.211v1.211h-1.211zm2.423-2.423h1.211v1.211h-1.211zm-1.212 1.211h1.212v1.212h-1.212zm-1.211-1.211h1.211v1.211h-1.211zm4.846-7.462v4.846h-4.846V5.846zm-7.462 7.462v4.846H5.846v-4.846zm0-7.462v4.846H5.846V5.846zM9.808 17.27v-3.077H6.73v3.077zm0-7.461V6.73H6.73v3.077zm7.461 0V6.73h-3.077v3.077z"
       />
     </Svg>
@@ -341,8 +341,8 @@ export function BitcoinMaskIcon() {
     <Svg width="150" height="150" viewBox="0 0 158 158" fill="none">
       <Defs>
         <LinearGradient id="gradient2" x1="0%" y1="0%" x2="100%" y2="0%">
-          <Stop stopOpacity={0} offset="0%" stopColor={greys(theme)[1800]} />
-          <Stop stopOpacity={1} offset="100%" stopColor={greys(theme)[1500]} />
+          <Stop stopOpacity={0} offset="0%" stopColor={theme.greys[1800]} />
+          <Stop stopOpacity={1} offset="100%" stopColor={theme.greys[1500]} />
         </LinearGradient>
       </Defs>
       <Path
@@ -351,7 +351,7 @@ export function BitcoinMaskIcon() {
       />
       <Path
         d="M113.271 67.4181C114.836 56.9571 106.871 51.3335 95.9802 47.582L99.513 33.4113L90.8873 31.2616L87.4478 45.0589C85.1802 44.4938 82.8511 43.9607 80.5369 43.4325L84.0009 29.5443L75.3801 27.3946L71.8448 41.5604C69.9678 41.1329 68.1252 40.7104 66.3366 40.2657L66.3465 40.2215L54.4507 37.2512L52.1561 46.4641C52.1561 46.4641 58.556 47.9308 58.4209 48.0217C61.9144 48.8939 62.5458 51.2057 62.4402 53.0385L58.416 69.182C58.6567 69.2434 58.9688 69.3319 59.3127 69.4695C59.0253 69.3982 58.7182 69.3196 58.4012 69.2434L52.7605 91.8581C52.333 92.9195 51.2495 94.5115 48.8075 93.9071C48.8935 94.0324 42.5378 92.3421 42.5378 92.3421L38.2556 102.216L49.4807 105.014C51.5689 105.538 53.6154 106.085 55.63 106.601L52.0603 120.934L60.6762 123.084L64.2115 108.903C66.5651 109.542 68.8499 110.132 71.0856 110.687L67.5626 124.801L76.1884 126.951L79.7581 112.645C94.4668 115.429 105.527 114.306 110.183 101.002C113.934 90.2907 109.996 84.1119 102.257 80.0828C107.893 78.7831 112.138 75.0758 113.271 67.4181ZM93.5627 95.0544C90.8971 105.766 72.8619 99.9753 67.0147 98.5234L71.7514 79.5349C77.5985 80.9942 96.3487 83.8834 93.5627 95.0544ZM96.2308 67.2633C93.7986 77.0069 78.7876 72.0565 73.9183 70.8428L78.2127 53.6208C83.0821 54.8344 98.7637 57.0996 96.2308 67.2633Z"
-        fill={greys(theme)[2300]}
+        fill={theme.greys[2300]}
       />
     </Svg>
   );
@@ -364,8 +364,8 @@ export function DollarMaskIcon() {
     <Svg width="150" height="150" viewBox="0 0 158 158" fill="none">
       <Defs>
         <LinearGradient id="gradient2" x1="0%" y1="0%" x2="100%" y2="0%">
-          <Stop stopOpacity={0} offset="0%" stopColor={greys(theme)[1800]} />
-          <Stop stopOpacity={1} offset="100%" stopColor={greys(theme)[1500]} />
+          <Stop stopOpacity={0} offset="0%" stopColor={theme.greys[1800]} />
+          <Stop stopOpacity={1} offset="100%" stopColor={theme.greys[1500]} />
         </LinearGradient>
       </Defs>
       <Path
@@ -374,7 +374,7 @@ export function DollarMaskIcon() {
       />
       <Path
         d="M59.6088 123.539L61.9469 114.088C57.4053 111.529 53.9555 108.145 51.5975 103.936C49.2396 99.726 47.8184 94.9361 47.334 89.5659L62.4836 87.8751C63.1327 91.5107 64.4166 94.718 66.3354 97.4968C68.2541 100.276 70.6906 102.031 73.6449 102.762C76.4923 103.466 78.9464 103.318 81.0072 102.317C83.0767 101.28 84.4374 99.4449 85.0891 96.811C85.5734 94.8534 85.4046 93.093 84.5827 91.5298C83.7695 89.931 82.4896 88.3868 80.743 86.897C79.0319 85.416 77.0495 83.8868 74.7958 82.3093C72.524 80.6518 70.2877 78.9276 68.0868 77.1365C65.8859 75.3455 63.9602 73.3581 62.3097 71.1744C60.6948 68.9996 59.5726 66.5123 58.9433 63.7125C58.3584 60.8859 58.5151 57.6574 59.4134 54.0269C60.523 49.5421 62.9329 45.8323 66.6431 42.8975C70.362 39.9271 75.0097 38.5463 80.5861 38.7551L82.6865 30.2661L97.5289 33.9385L95.4021 42.5343C99.4539 44.7832 102.405 47.7419 104.254 51.4102C106.104 55.0785 107.123 59.0512 107.311 63.3283L92.5207 64.4847C92.1949 62.1378 91.3493 59.9833 89.9839 58.0212C88.6273 56.0236 86.5787 54.6857 83.838 54.0076C81.5244 53.4352 79.6036 53.4888 78.0757 54.1683C76.5566 54.8123 75.568 56.0597 75.1101 57.9106C74.7402 59.4055 74.9748 60.8234 75.814 62.1642C76.6532 63.505 77.8704 64.8449 79.4655 66.1838C81.105 67.496 82.9268 68.8344 84.9311 70.1991C87.0957 71.679 89.3096 73.341 91.5729 75.1853C93.8718 77.0384 95.8957 79.1633 97.6445 81.5602C99.4022 83.9215 100.614 86.6576 101.279 89.7685C101.981 92.8882 101.829 96.4769 100.825 100.535C99.8038 104.663 98.0779 108.051 95.6476 110.698C93.253 113.354 90.4075 115.313 87.1113 116.575C83.815 117.837 80.3348 118.393 76.6705 118.241L74.4512 127.211L59.6088 123.539Z"
-        fill={greys(theme)[2300]}
+        fill={theme.greys[2300]}
       />
     </Svg>
   );
@@ -387,8 +387,8 @@ export function EuroMaskIcon() {
     <Svg width="158" height="158" viewBox="0 0 158 158" fill="none">
       <Defs>
         <LinearGradient id="gradient3" x1="0%" y1="0%" x2="100%" y2="0%">
-          <Stop stopOpacity={0} offset="0%" stopColor={greys(theme)[1800]} />
-          <Stop stopOpacity={1} offset="100%" stopColor={greys(theme)[1500]} />
+          <Stop stopOpacity={0} offset="0%" stopColor={theme.greys[1800]} />
+          <Stop stopOpacity={1} offset="100%" stopColor={theme.greys[1500]} />
         </LinearGradient>
       </Defs>
       <Path
@@ -397,7 +397,7 @@ export function EuroMaskIcon() {
       />
       <Path
         d="M77.2594 119.067C71.9204 117.746 67.6911 115.604 64.5713 112.641C61.496 109.652 59.3662 106.047 58.1821 101.825C56.998 97.604 56.5955 92.9717 56.9745 87.9285L46.9906 85.4582L54.185 76.3032L58.0291 77.2543C58.1608 76.5692 58.275 75.9553 58.3715 75.4126C58.5036 74.8787 58.6092 74.4516 58.6885 74.1313C58.7678 73.8109 58.8558 73.455 58.9527 73.0635C59.0852 72.6807 59.2749 72.0667 59.5218 71.2212L50.9794 69.1076L58.1469 59.8326L63.5927 61.18C65.1584 57.7524 67.0406 54.6487 69.2394 51.8687C71.4381 49.0888 73.9314 46.7972 76.7195 44.994C79.5519 43.1641 82.6837 41.9559 86.115 41.3696C89.5819 40.792 93.3619 41.0096 97.4552 42.0224C100.659 42.815 103.828 44.2035 106.963 46.1879C110.107 48.1367 113.173 50.8594 116.16 54.356L107.705 66.0886C106.027 63.7094 104.137 61.6552 102.034 59.9262C99.9399 58.1616 97.2556 56.8742 93.981 56.064C91.881 55.5444 89.9246 55.5891 88.1119 56.1983C86.308 56.7718 84.652 57.8163 83.1439 59.3318C81.6446 60.8116 80.3061 62.6335 79.1286 64.7974L104.329 71.0324L97.3754 80.5871L74.738 74.986C74.5083 75.6091 74.3228 76.1298 74.1815 76.5481C74.0758 76.9752 73.9658 77.4202 73.8513 77.8829C73.7368 78.3456 73.6135 78.8439 73.4814 79.3778C73.3849 79.9205 73.3062 80.4676 73.2453 81.0191L93.5335 86.0389L86.7001 95.5665L72.5517 92.0659C72.504 94.396 72.7892 96.4496 73.4071 98.2267C74.0606 100.013 75.0024 101.473 76.2324 102.609C77.4624 103.744 78.9494 104.527 80.6935 104.959C83.185 105.575 85.5503 105.481 87.7894 104.675C90.0641 103.878 92.3551 102.48 94.6624 100.483L104.411 110.317C100.791 113.954 96.6314 116.646 91.9312 118.391C87.2755 120.11 82.3849 120.335 77.2594 119.067Z"
-        fill={greys(theme)[2300]}
+        fill={theme.greys[2300]}
       />
     </Svg>
   );
@@ -410,8 +410,8 @@ export function PoundMaskIcon() {
     <Svg width="158" height="158" viewBox="0 0 158 158" fill="none">
       <Defs>
         <LinearGradient id="gradient4" x1="0%" y1="0%" x2="100%" y2="0%">
-          <Stop stopOpacity={0} offset="0%" stopColor={greys(theme)[1800]} />
-          <Stop stopOpacity={1} offset="100%" stopColor={greys(theme)[1500]} />
+          <Stop stopOpacity={0} offset="0%" stopColor={theme.greys[1800]} />
+          <Stop stopOpacity={1} offset="100%" stopColor={theme.greys[1500]} />
         </LinearGradient>
       </Defs>
       <Path
@@ -420,7 +420,7 @@ export function PoundMaskIcon() {
       />
       <Path
         d="M45.5424 109.86L48.9638 96.0316C50.8216 95.6981 52.4652 95.0093 53.8944 93.9654C55.368 92.8947 56.6233 91.6377 57.6603 90.1945C58.6973 88.7513 59.5475 87.2997 60.2109 85.8396C60.3966 85.3945 60.5557 84.9806 60.6881 84.5979C60.8294 84.1796 60.9309 83.8459 60.9925 83.5967L52.1832 81.4171L55.5517 67.8026L60.9441 69.1368C60.9166 68.7901 60.8709 68.2877 60.807 67.6298C60.7876 66.9451 60.7593 66.2959 60.7223 65.6824C60.6566 64.2686 60.6531 62.8324 60.7118 61.3738C60.8149 59.8884 61.0514 58.3983 61.4213 56.9033C62.346 53.166 64.1209 49.8091 66.746 46.8324C69.3711 43.8558 72.8387 41.7486 77.1488 40.5109C81.4677 39.2376 86.5814 39.3319 92.4899 40.7938C97.6154 42.062 101.875 43.8525 105.269 46.1653C108.707 48.4514 111.92 51.3427 114.908 54.8393L105.787 67.4272C104.663 66.016 103.357 64.5029 101.868 62.888C100.388 61.2375 98.592 59.7167 96.481 58.3256C94.3787 56.8989 91.8683 55.8245 88.9497 55.1024C86.4225 54.4771 84.2968 54.3667 82.5726 54.771C80.8483 55.1754 79.4805 55.8946 78.4692 56.9286C77.4579 57.9627 76.7938 59.1204 76.4767 60.4018C76.283 61.1848 76.1652 62.1189 76.1234 63.2039C76.1171 64.2978 76.214 65.7382 76.414 67.5252C76.5582 68.3163 76.7026 69.183 76.8472 70.1254C76.9917 71.0677 77.1543 72.09 77.3348 73.1923L95.5408 77.6968L92.1723 91.3113L76.0485 87.3219C76.0133 87.4643 75.925 87.7446 75.7838 88.1629C75.6425 88.5813 75.4568 89.0264 75.2268 89.4982C74.4668 91.501 73.5109 93.3798 72.3591 95.1345C71.2073 96.8892 69.7841 98.5956 68.0896 100.254L101.832 108.603L98.2918 122.911L45.5424 109.86Z"
-        fill={greys(theme)[2300]}
+        fill={theme.greys[2300]}
       />
     </Svg>
   );
@@ -502,7 +502,7 @@ export function ProfileIcon() {
 export function CurrencyIcon({
   width = 36,
   currency,
-  colors = [shades[100], shades[300], shades[500]],
+  colors = [theme.shades[100], theme.shades[300], theme.shades[500]],
 }) {
   const theme = useSelector(memoizedGetTheme);
   if (currency === 'eur') {
@@ -619,9 +619,9 @@ export function CurrencyIcon({
           }}>
           <Defs>
             <LinearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="0%">
-              <Stop offset="0%" stopColor={shades[100]} />
-              <Stop offset="50%" stopColor={shades[300]} />
-              <Stop offset="100%" stopColor={shades[500]} />
+              <Stop offset="0%" stopColor={theme.shades[100]} />
+              <Stop offset="50%" stopColor={theme.shades[300]} />
+              <Stop offset="100%" stopColor={theme.shades[500]} />
             </LinearGradient>
           </Defs>
           <Path
@@ -821,7 +821,7 @@ export function VerifiedIcon({ style, fill }) {
         </LinearGradient>
       </Defs>
       <Path
-        stroke={greys(theme)[1800]}
+        stroke={theme.greys[1800]}
         strokeWidth={2.5}
         strokeOpacity={0.5}
         fill="url(#gradient)"
@@ -854,7 +854,7 @@ export function FalseIcon() {
     <Svg width="21" height="20" viewBox="0 0 21 20" fill="none">
       <Path
         d="M6.9 15L10.5 11.4L14.1 15L15.5 13.6L11.9 10L15.5 6.4L14.1 5L10.5 8.6L6.9 5L5.5 6.4L9.1 10L5.5 13.6L6.9 15ZM10.5 20C9.11667 20 7.81667 19.7375 6.6 19.2125C5.38333 18.6875 4.325 17.975 3.425 17.075C2.525 16.175 1.8125 15.1167 1.2875 13.9C0.7625 12.6833 0.5 11.3833 0.5 10C0.5 8.61667 0.7625 7.31667 1.2875 6.1C1.8125 4.88333 2.525 3.825 3.425 2.925C4.325 2.025 5.38333 1.3125 6.6 0.7875C7.81667 0.2625 9.11667 0 10.5 0C11.8833 0 13.1833 0.2625 14.4 0.7875C15.6167 1.3125 16.675 2.025 17.575 2.925C18.475 3.825 19.1875 4.88333 19.7125 6.1C20.2375 7.31667 20.5 8.61667 20.5 10C20.5 11.3833 20.2375 12.6833 19.7125 13.9C19.1875 15.1167 18.475 16.175 17.575 17.075C16.675 17.975 15.6167 18.6875 14.4 19.2125C13.1833 19.7375 11.8833 20 10.5 20ZM10.5 18C12.7333 18 14.625 17.225 16.175 15.675C17.725 14.125 18.5 12.2333 18.5 10C18.5 7.76667 17.725 5.875 16.175 4.325C14.625 2.775 12.7333 2 10.5 2C8.26667 2 6.375 2.775 4.825 4.325C3.275 5.875 2.5 7.76667 2.5 10C2.5 12.2333 3.275 14.125 4.825 15.675C6.375 17.225 8.26667 18 10.5 18Z"
-        fill={greys(theme)[700]}
+        fill={theme.greys[700]}
       />
     </Svg>
   );
@@ -865,7 +865,7 @@ export function TrueIcon() {
     <Svg width="21" height="20" viewBox="0 0 21 20" fill="none">
       <Path
         d="M9.1 14.6L16.15 7.55L14.75 6.15L9.1 11.8L6.25 8.95L4.85 10.35L9.1 14.6ZM10.5 20C9.11667 20 7.81667 19.7375 6.6 19.2125C5.38333 18.6875 4.325 17.975 3.425 17.075C2.525 16.175 1.8125 15.1167 1.2875 13.9C0.7625 12.6833 0.5 11.3833 0.5 10C0.5 8.61667 0.7625 7.31667 1.2875 6.1C1.8125 4.88333 2.525 3.825 3.425 2.925C4.325 2.025 5.38333 1.3125 6.6 0.7875C7.81667 0.2625 9.11667 0 10.5 0C11.8833 0 13.1833 0.2625 14.4 0.7875C15.6167 1.3125 16.675 2.025 17.575 2.925C18.475 3.825 19.1875 4.88333 19.7125 6.1C20.2375 7.31667 20.5 8.61667 20.5 10C20.5 11.3833 20.2375 12.6833 19.7125 13.9C19.1875 15.1167 18.475 16.175 17.575 17.075C16.675 17.975 15.6167 18.6875 14.4 19.2125C13.1833 19.7375 11.8833 20 10.5 20ZM10.5 18C12.7333 18 14.625 17.225 16.175 15.675C17.725 14.125 18.5 12.2333 18.5 10C18.5 7.76667 17.725 5.875 16.175 4.325C14.625 2.775 12.7333 2 10.5 2C8.26667 2 6.375 2.775 4.825 4.325C3.275 5.875 2.5 7.76667 2.5 10C2.5 12.2333 3.275 14.125 4.825 15.675C6.375 17.225 8.26667 18 10.5 18Z"
-        fill={shades[300]}
+        fill={theme.shades[300]}
       />
     </Svg>
   );
@@ -878,7 +878,7 @@ export function EcashIcon() {
     <Svg width="21" height="15" viewBox="0 0 21 15" fill="none">
       <Path
         d="M13.2197 0C14.6596 0 16.0672 0.439867 17.2644 1.26398C18.4616 2.08809 19.3948 3.25943 19.9458 4.62987C20.4968 6.00032 20.641 7.50832 20.3601 8.96317C20.0792 10.418 19.3858 11.7544 18.3676 12.8033C17.3495 13.8522 16.0522 14.5665 14.64 14.8559C13.2277 15.1453 11.7639 14.9968 10.4336 14.4291C9.1033 13.8614 7.96627 12.9001 7.1663 11.6668C6.36633 10.4334 5.93934 8.98336 5.93934 7.5C5.93934 5.51087 6.70637 3.60322 8.0717 2.1967C9.43703 0.790176 11.2888 0 13.2197 0ZM2.29918 7.5C2.30047 8.66212 2.65113 9.7953 3.30295 10.7438C3.95478 11.6923 4.87577 12.4095 5.93934 12.7969V14.7562C4.38136 14.3368 3.00234 13.397 2.01812 12.084C1.03389 10.771 0.5 9.15891 0.5 7.5C0.5 5.84109 1.03389 4.22899 2.01812 2.91601C3.00234 1.60302 4.38136 0.66324 5.93934 0.24375V2.20312C4.87577 2.5905 3.95478 3.30772 3.30295 4.25621C2.65113 5.20469 2.30047 6.33788 2.29918 7.5Z"
-        fill={greys(theme)[0]}
+        fill={theme.greys[0]}
       />
     </Svg>
   );
@@ -889,13 +889,13 @@ export function BtcIcon({ height = 34, width = 34, color, weight }) {
     weight === 'heavy'
       ? 'material-symbols:currency-bitcoin'
       : 'material-symbols-light:currency-bitcoin';
-  return <Icon name={iconName} color={color || greys(theme)[0]} size={width * 1.2} />;
+  return <Icon name={iconName} color={color || theme.greys[0]} size={width * 1.2} />;
 }
 
 export function BtcUnit({ color, width = '24', height = '24' }) {
   const theme = useSelector(memoizedGetTheme);
   return (
-    <Icon name="material-symbols:currency-bitcoin" color={color || greys(theme)[0]} size={width} />
+    <Icon name="material-symbols:currency-bitcoin" color={color || theme.greys[0]} size={width} />
   );
 }
 
@@ -904,8 +904,8 @@ export function ShareIcon() {
 
   return (
     <Svg width="21" height="21" viewBox="0 0 24 24">
-      <Path fill={greys(theme)[0]} d="M20 8h-5v2h3v11H6V10h3V8H4v15h16z" />
-      <Path fill={greys(theme)[0]} d="M11 16h2V5h3l-4-4l-4 4h3z" />
+      <Path fill={theme.greys[0]} d="M20 8h-5v2h3v11H6V10h3V8H4v15h16z" />
+      <Path fill={theme.greys[0]} d="M11 16h2V5h3l-4-4l-4 4h3z" />
     </Svg>
   );
 }
@@ -916,7 +916,7 @@ export function CopyIcon() {
   return (
     <Svg height="21" viewBox="0 -960 960 960" width="21">
       <Path
-        fill={greys(theme)[0]}
+        fill={theme.greys[0]}
         d="M360-240q-33 0-56.5-23.5T280-320v-480q0-33 23.5-56.5T360-880h360q33 0 56.5 23.5T800-800v480q0 33-23.5 56.5T720-240H360Zm0-80h360v-480H360v480ZM200-80q-33 0-56.5-23.5T120-160v-560h80v560h440v80H200Zm160-240v-480 480Z"
       />
     </Svg>
@@ -929,7 +929,7 @@ export function CancelSendIcon() {
   return (
     <Svg width="21" height="21" viewBox="0 0 24 24">
       <Path
-        fill={greys(theme)[0]}
+        fill={theme.greys[0]}
         d="m16 20l-.707.707l.707.707l.707-.707zM4 15a1 1 0 1 0 2 0zm6.293.707l5 5l1.414-1.414l-5-5zm6.414 5l5-5l-1.414-1.414l-5 5zM17 20V9.5h-2V20zM4 9.5V15h2V9.5zM10.5 3A6.5 6.5 0 0 0 4 9.5h2A4.5 4.5 0 0 1 10.5 5zM17 9.5A6.5 6.5 0 0 0 10.5 3v2A4.5 4.5 0 0 1 15 9.5z"
       />
     </Svg>
@@ -942,7 +942,7 @@ export function RetryIcon() {
   return (
     <Svg width="24" height="24" viewBox="0 0 24 24">
       <Path
-        fill={greys(theme)[0]}
+        fill={theme.greys[0]}
         d="M12 20q-3.35 0-5.675-2.325T4 12t2.325-5.675T12 4q1.725 0 3.3.712T18 6.75V4h2v7h-7V9h4.2q-.8-1.4-2.187-2.2T12 6Q9.5 6 7.75 7.75T6 12t1.75 4.25T12 18q1.925 0 3.475-1.1T17.65 14h2.1q-.7 2.65-2.85 4.325T12 20"
       />
     </Svg>
@@ -956,7 +956,7 @@ export function CarrotIcon() {
     <Svg width="8" height="6" viewBox="0 0 8 6" fill="none">
       <Path
         d="M4 5.15833L0.5 1.65833L1.31667 0.841667L4 3.525L6.68333 0.841667L7.5 1.65833L4 5.15833Z"
-        fill={greys(theme)[2300]}
+        fill={theme.greys[2300]}
       />
     </Svg>
   );
@@ -969,7 +969,7 @@ export function QRIcon({ style, color }) {
     <Svg style={style} viewBox="0 0 36 36" fill="none">
       <Path
         d="M3 10.5V3H10.5V6H6V10.5H3ZM3 33V25.5H6V30H10.5V33H3ZM25.5 33V30H30V25.5H33V33H25.5ZM30 10.5V6H25.5V3H33V10.5H30ZM26.25 26.25H28.5V28.5H26.25V26.25ZM26.25 21.75H28.5V24H26.25V21.75ZM24 24H26.25V26.25H24V24ZM21.75 26.25H24V28.5H21.75V26.25ZM19.5 24H21.75V26.25H19.5V24ZM24 19.5H26.25V21.75H24V19.5ZM21.75 21.75H24V24H21.75V21.75ZM19.5 19.5H21.75V21.75H19.5V19.5ZM28.5 7.5V16.5H19.5V7.5H28.5ZM16.5 19.5V28.5H7.5V19.5H16.5ZM16.5 7.5V16.5H7.5V7.5H16.5ZM14.25 26.25V21.75H9.75V26.25H14.25ZM14.25 14.25V9.75H9.75V14.25H14.25ZM26.25 14.25V9.75H21.75V14.25H26.25Z"
-        fill={color || greys(theme)[0]}
+        fill={color || theme.greys[0]}
       />
     </Svg>
   );
@@ -980,7 +980,7 @@ export function PlusIcon({ style }) {
 
   return (
     <Svg style={style} viewBox="0 0 24 24">
-      <Path fill={greys(theme)[0]} d="M19 12.998h-6v6h-2v-6H5v-2h6v-6h2v6h6z" />
+      <Path fill={theme.greys[0]} d="M19 12.998h-6v6h-2v-6H5v-2h6v-6h2v6h6z" />
     </Svg>
   );
 }
@@ -990,7 +990,7 @@ export function DotsIcon({ style }) {
 
   return (
     <Svg style={style} viewBox="0 0 20 20">
-      <G fill={greys(theme)[0]}>
+      <G fill={theme.greys[0]}>
         <Circle cx="10" cy="15" r="2" />
         <Circle cx="10" cy="10" r="2" />
         <Circle cx="10" cy="5" r="2" />
@@ -1005,7 +1005,7 @@ export function CheckIcon({ color, style, size = 24 }) {
   return (
     <Svg style={style} width={size} height={size} viewBox="0 0 24 24">
       <Path
-        fill={color || greys(theme)[0]}
+        fill={color || theme.greys[0]}
         d="m10.6 13.8l-2.15-2.15q-.275-.275-.7-.275t-.7.275t-.275.7t.275.7L9.9 15.9q.3.3.7.3t.7-.3l5.65-5.65q.275-.275.275-.7t-.275-.7t-.7-.275t-.7.275zM12 22q-2.075 0-3.9-.788t-3.175-2.137T2.788 15.9T2 12t.788-3.9t2.137-3.175T8.1 2.788T12 2t3.9.788t3.175 2.137T21.213 8.1T22 12t-.788 3.9t-2.137 3.175t-3.175 2.138T12 22"
       />
     </Svg>
@@ -1018,11 +1018,11 @@ export function ImportIcon({ style }) {
   return (
     <Svg style={style} width="24" height="24" viewBox="0 0 24 24">
       <Path
-        fill={greys(theme)[0]}
+        fill={theme.greys[0]}
         d="m12 14l-.707.707l.707.707l.707-.707zm1-9a1 1 0 1 0-2 0zM6.293 9.707l5 5l1.414-1.414l-5-5zm6.414 5l5-5l-1.414-1.414l-5 5zM13 14V5h-2v9z"
       />
       <Path
-        stroke={greys(theme)[0]}
+        stroke={theme.greys[0]}
         strokeWidth={2}
         d="M5 16v1a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-1"
       />

--- a/components/common/Transaction/TransactionHeader.tsx
+++ b/components/common/Transaction/TransactionHeader.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Text } from 'components/common/Text';
 import { View } from 'components/common/View';
 import { useSelector } from 'react-redux';
-import { greens, greys, shades } from 'helper/colors';
+import { greens } from 'helper/colors';
 import { memoizedGetTheme } from 'helper/redux/settings';
 import { AmountFormatter } from 'components/common/AmountFormatter';
 import { formatCurrency, CurrencyCode, Denomination } from 'helper/currency';
@@ -22,7 +22,7 @@ export function TransactionHeader({ transaction }: TransactionHeaderProps) {
         <View className="flex-row items-center bg-transparent">
           <Text
             size={transaction.isSend ? 32 : 24}
-            color={transaction.isSend ? shades[300] : greens[300]}
+            color={transaction.isSend ? theme.shades[300] : greens[300]}
             className="ml-2 mr-2">
             {transaction.isSend ? '-' : '+'}
           </Text>
@@ -31,12 +31,12 @@ export function TransactionHeader({ transaction }: TransactionHeaderProps) {
             unit={transaction?.unit}
             size={28}
             weight="heavy"
-            color={transaction.isReceive ? greens[300] : shades[300]}
+            color={transaction.isReceive ? greens[300] : theme.shades[300]}
           />
         </View>
-        <Text size={18} color={greys(theme)[100]} bold className="ml-8">
+        <Text size={18} color={theme.greys[100]} bold className="ml-8">
           {transaction?.amount < 0 ? '-' : ''}
-          <Text size={18} color={greys(theme)[100]} className="ml-2">
+          <Text size={18} color={theme.greys[100]} className="ml-2">
             {transaction?.amount < 0 ? '-' : ''}
             {formatCurrency(
               {

--- a/components/layout/AccountPagerView.tsx
+++ b/components/layout/AccountPagerView.tsx
@@ -17,13 +17,12 @@ import {
   memoizedGetBalance,
   memoizedGetSelectedMint,
 } from 'helper/redux/cashu';
-import { greys, shades } from 'helper/colors';
-import { memoizedGetBackgroundImage, memoizedGetTheme } from 'helper/redux/settings';
+import { greys } from 'helper/colors';
+import { memoizedGetTheme } from 'helper/redux/settings';
 import { store } from 'helper/redux/store';
 import { showMessage } from 'helper/popup/popups';
 import { Account } from './Account';
 import { useTypedNavigation } from 'helper/navigation';
-import { BACKGROUND_IMAGE_ATTRIBUTES } from 'helper/backgroundImages';
 
 interface ActionButton {
   page: 'receive' | 'camera' | 'currency';
@@ -51,14 +50,8 @@ export function AccountPagerView({
 }: AccountPagerViewProps): React.ReactElement {
   const { handlePermission } = useHandleCameraPermission();
   const theme = useSelector(memoizedGetTheme);
-  const image = useSelector(memoizedGetBackgroundImage);
 
-  const styles = createStyles(
-    theme,
-    BACKGROUND_IMAGE_ATTRIBUTES[image]?.primary
-      ? BACKGROUND_IMAGE_ATTRIBUTES[image]?.primary
-      : shades[200]
-  );
+  const styles = createStyles(theme.greys, theme.shades);
   const navigation = useTypedNavigation();
 
   const selectedMintUrl = useSelector(memoizedGetSelectedMint);
@@ -215,12 +208,7 @@ export function AccountPagerView({
                 style={[isCamera && styles.cameraGradient]}
                 colors={
                   isCamera
-                    ? BACKGROUND_IMAGE_ATTRIBUTES[image]?.primary
-                      ? [
-                          BACKGROUND_IMAGE_ATTRIBUTES[image]?.primary,
-                          BACKGROUND_IMAGE_ATTRIBUTES[image]?.secondary,
-                        ]
-                      : [shades[200], shades[400]]
+                    ? [theme.shades[200], theme.shades[400]]
                     : ['rgba(0,0,0,0)', 'rgba(0,0,0,0)']
                 }>
                 <View style={styles.iconContainer}>
@@ -249,7 +237,7 @@ export function AccountPagerView({
   );
 }
 
-const createStyles = (theme: string, shadow = shades[200]) =>
+const createStyles = (greys: string, shades) =>
   StyleSheet.create({
     touchableOpacity: {
       flex: 1,
@@ -260,13 +248,13 @@ const createStyles = (theme: string, shadow = shades[200]) =>
     cameraButton: {
       maxWidth: 64,
       zIndex: 10000,
-      shadowColor: shadow,
+      shadowColor: shades[300],
       shadowOffset: { width: 0, height: 0 },
       shadowOpacity: 0.75,
       shadowRadius: 8,
       elevation: 5,
       borderRadius: 10000,
-      borderColor: shadow,
+      borderColor: shades[200],
       borderWidth: 0.5,
     },
     receiveButton: {
@@ -303,13 +291,13 @@ const createStyles = (theme: string, shadow = shades[200]) =>
       borderBottomLeftRadius: 1000,
       borderTopLeftRadius: 1000,
       // borderWidth: 0.3,
-      borderColor: greys(theme)[1500],
+      borderColor: greys[1500],
     },
     sendIconView: {
       // backgroundColor: greys(theme)[1800],
       borderBottomRightRadius: 1000,
       borderTopRightRadius: 1000,
       // borderWidth: 0.3,
-      borderColor: greys(theme)[1500],
+      borderColor: greys[1500],
     },
   });

--- a/components/layout/PrimaryBalance.tsx
+++ b/components/layout/PrimaryBalance.tsx
@@ -41,8 +41,11 @@ export function PrimaryBalance({ account }: PrimaryBalanceProps): React.ReactEle
       style={{ backgroundColor: 'transparent', flexDirection: 'column' }}>
       {btcPrice?.usd?.btc && (
         <View
+          blur
           style={{
             backgroundColor: opacity(greens[400], 0.1),
+            borderColor: opacity(greens[500], 0.5),
+            borderWidth: 0.2,
             padding: 8,
             borderRadius: 100,
             marginTop: -16,

--- a/components/layout/Transactions.tsx
+++ b/components/layout/Transactions.tsx
@@ -145,13 +145,13 @@ export const Transactions = React.memo(
         return (
           <View>
             <View className="flex-row items-start">
-              <Text heavy size={16} color={greys(theme)[1000]} className="mt-2">
+              <Text heavy size={16} color={greys(theme)[200]} className="mt-2">
                 {label}
               </Text>
             </View>
             {sections.map((section) => (
               <View key={section.title}>
-                <Text size={14} heavy color={greys(theme)[1000]} className="mb-1">
+                <Text size={14} heavy color={greys(theme)[200]} className="mb-1">
                   {section.title}
                 </Text>
                 <View className="rounded-lg" blur>

--- a/helper/backgroundImages.ts
+++ b/helper/backgroundImages.ts
@@ -1,26 +1,47 @@
 import { BlurTint } from 'expo-blur';
+import { computeGreys, computeShades } from './colors';
 
 export interface BackgroundImageAttributes {
-  primary: string;
-  secondary: string;
+  shades: Record<100 | 200 | 300 | 400 | 500, string>;
+  greys: Record<number, string>;
   text: string;
   tint: BlurTint;
 }
 
 export const BACKGROUND_IMAGE_ATTRIBUTES: Record<string, BackgroundImageAttributes> = {
-  'bg.png': { primary: '#A855F7', secondary: '#581C87', text: '#FFFFFF', tint: 'prominent' },
-  'bg2.png': { primary: '#F97316', secondary: '#7C2D12', text: '#FFFFFF', tint: 'prominent' },
-  'bg3.png': { primary: '#38BDF8', secondary: '#0C4A6E', text: '#FFFFFF', tint: 'prominent' },
-  'bg4.png': { primary: '#34D399', secondary: '#064E3B', text: '#FFFFFF', tint: 'prominent' },
+  'bg.png': {
+    shades: computeShades('#A855F7'),
+    greys: computeGreys('dark'),
+    text: '#FFFFFF',
+    tint: 'prominent',
+  },
+  'bg2.png': {
+    shades: computeShades('#F97316'),
+    greys: computeGreys('dark'),
+    text: '#FFFFFF',
+    tint: 'prominent',
+  },
+  'bg3.png': {
+    shades: computeShades('#38BDF8'),
+    greys: computeGreys('dark'),
+    text: '#FFFFFF',
+    tint: 'prominent',
+  },
+  'bg4.png': {
+    shades: computeShades('#34D399'),
+    greys: computeGreys('dark'),
+    text: '#FFFFFF',
+    tint: 'prominent',
+  },
   'bg5.png': {
-    primary: '#C8348A',
-    secondary: '#AB99E3',
+    shades: computeShades('#C8348A'),
+    greys: computeGreys('dark'),
     text: '#FFFFFF',
     tint: 'extraLight',
   },
   'bg6.png': {
-    primary: '#5E1B72',
-    secondary: '#6B4D9A',
+    shades: computeShades('#5E1B72'),
+    greys: computeGreys('dark'),
     text: '#FFFFFF',
     tint: 'extraLight',
   },

--- a/helper/backgroundImages.ts
+++ b/helper/backgroundImages.ts
@@ -41,8 +41,8 @@ export const BACKGROUND_IMAGE_ATTRIBUTES: Record<string, BackgroundImageAttribut
   },
   'bg6.png': {
     shades: computeShades('#5E1B72'),
-    greys: computeGreys('dark'),
+    greys: computeGreys('dark', '#5E1B72'),
     text: '#FFFFFF',
-    tint: 'extraLight',
+    tint: 'prominent',
   },
 };

--- a/helper/colors.tsx
+++ b/helper/colors.tsx
@@ -13,7 +13,15 @@ type ShadeKey = 100 | 200 | 300 | 400 | 500;
  */
 const hexToRgb = (hex: string) => {
   const clean = hex.replace('#', '');
-  const bigint = parseInt(clean.length === 3 ? clean.split('').map((c) => c + c).join('') : clean, 16);
+  const bigint = parseInt(
+    clean.length === 3
+      ? clean
+          .split('')
+          .map((c) => c + c)
+          .join('')
+      : clean,
+    16
+  );
   return {
     r: (bigint >> 16) & 255,
     g: (bigint >> 8) & 255,
@@ -110,7 +118,7 @@ export const computeShades = (base300: string) => {
   const baseHsl = rgbToHsl(...Object.values(hexToRgb(base300)));
   const result: Record<ShadeKey, string> = { 300: base300 } as Record<ShadeKey, string>;
 
-  (Object.keys(BASE_SHADE_DELTAS) as Array<Exclude<ShadeKey, 300>>).forEach((key) => {
+  (Object.keys(BASE_SHADE_DELTAS) as Exclude<ShadeKey, 300>[]).forEach((key) => {
     const delta = BASE_SHADE_DELTAS[key];
     const h = (baseHsl.h + delta.h + 360) % 360;
     const s = Math.max(0, Math.min(100, baseHsl.s + delta.s));
@@ -816,8 +824,22 @@ export const white = '#FFFFFF';
 
 export const black = '#181412'; // off black
 
-export const computeGreys = (theme = 'dark', zero?: string) => {
-  const g = greys(theme);
-  if (zero) g[0] = zero;
-  return g;
-};
+export function computeGreys(
+  theme: string,
+  primaryColor = '#FF0000',
+  saturation = 15,
+  minLightness = 12
+) {
+  const tinted: Record<string, string> = {};
+  const { h: primaryHue } = rgbToHsl(...Object.values(hexToRgb(primaryColor)));
+
+  for (const [key, hex] of Object.entries(greys(theme))) {
+    const { r, g, b } = hexToRgb(hex);
+    const { l } = rgbToHsl(r, g, b);
+    const adjustedL = Math.max(l, minLightness); // avoid fully black shades
+    const { r: newR, g: newG, b: newB } = hslToRgb(primaryHue, saturation, adjustedL);
+    tinted[key] = rgbToHex(newR, newG, newB);
+  }
+
+  return tinted;
+}

--- a/helper/colors.tsx
+++ b/helper/colors.tsx
@@ -6,6 +6,122 @@ export const shades = {
   500: '#BF004E',
 };
 
+type ShadeKey = 100 | 200 | 300 | 400 | 500;
+
+/**
+ * Convert a hex string to an RGB object.
+ */
+const hexToRgb = (hex: string) => {
+  const clean = hex.replace('#', '');
+  const bigint = parseInt(clean.length === 3 ? clean.split('').map((c) => c + c).join('') : clean, 16);
+  return {
+    r: (bigint >> 16) & 255,
+    g: (bigint >> 8) & 255,
+    b: bigint & 255,
+  };
+};
+
+/**
+ * Convert an RGB tuple to HSL.
+ */
+const rgbToHsl = (r: number, g: number, b: number) => {
+  r /= 255;
+  g /= 255;
+  b /= 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  let h = 0;
+  let s = 0;
+  const l = (max + min) / 2;
+
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      default:
+        h = (r - g) / d + 4;
+    }
+    h /= 6;
+  }
+
+  return { h: h * 360, s: s * 100, l: l * 100 };
+};
+
+/**
+ * Convert an HSL tuple to RGB.
+ */
+const hslToRgb = (h: number, s: number, l: number) => {
+  h /= 360;
+  s /= 100;
+  l /= 100;
+
+  if (s === 0) {
+    const val = Math.round(l * 255);
+    return { r: val, g: val, b: val };
+  }
+
+  const hue2rgb = (p: number, q: number, t: number) => {
+    if (t < 0) t += 1;
+    if (t > 1) t -= 1;
+    if (t < 1 / 6) return p + (q - p) * 6 * t;
+    if (t < 1 / 2) return q;
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+    return p;
+  };
+
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+
+  const r = hue2rgb(p, q, h + 1 / 3);
+  const g = hue2rgb(p, q, h);
+  const b = hue2rgb(p, q, h - 1 / 3);
+
+  return { r: Math.round(r * 255), g: Math.round(g * 255), b: Math.round(b * 255) };
+};
+
+const rgbToHex = (r: number, g: number, b: number) =>
+  `#${[r, g, b]
+    .map((x) => {
+      const hex = x.toString(16);
+      return hex.length === 1 ? `0${hex}` : hex;
+    })
+    .join('')}`;
+
+interface ShadeDelta {
+  h: number;
+  s: number;
+  l: number;
+}
+
+const BASE_SHADE_DELTAS: Record<Exclude<ShadeKey, 300>, ShadeDelta> = {
+  100: { h: -337.2701754385965, s: 9.638554216867476, l: 13.921568627450974 },
+  200: { h: 13.387458745874653, s: 9.638554216867476, l: 11.568627450980387 },
+  400: { h: -6.960517799352772, s: 8.677015755329023, l: -8.039215686274517 },
+  500: { h: -9.035951134380412, s: 9.638554216867476, l: -11.372549019607845 },
+};
+
+export const computeShades = (base300: string) => {
+  const baseHsl = rgbToHsl(...Object.values(hexToRgb(base300)));
+  const result: Record<ShadeKey, string> = { 300: base300 } as Record<ShadeKey, string>;
+
+  (Object.keys(BASE_SHADE_DELTAS) as Array<Exclude<ShadeKey, 300>>).forEach((key) => {
+    const delta = BASE_SHADE_DELTAS[key];
+    const h = (baseHsl.h + delta.h + 360) % 360;
+    const s = Math.max(0, Math.min(100, baseHsl.s + delta.s));
+    const l = Math.max(0, Math.min(100, baseHsl.l + delta.l));
+    const { r, g, b } = hslToRgb(h, s, l);
+    result[key] = rgbToHex(r, g, b);
+  });
+
+  return result;
+};
+
 export const reds = {
   300: shades[300],
 };
@@ -699,3 +815,9 @@ export const background = '#FFFFFF';
 export const white = '#FFFFFF';
 
 export const black = '#181412'; // off black
+
+export const computeGreys = (theme = 'dark', zero?: string) => {
+  const g = greys(theme);
+  if (zero) g[0] = zero;
+  return g;
+};

--- a/helper/redux/settings/hooks.ts
+++ b/helper/redux/settings/hooks.ts
@@ -7,19 +7,19 @@ import {
   setBackgroundImage,
 } from './actions';
 import {
-  selectTheme,
   selectLanguage,
   selectDisplayBitcoin,
   selectPasscode,
   selectBackgroundImage,
   selectBackgroundImageAttrs,
   memoizedGetSettings,
+  memoizedGetTheme,
 } from './selectors';
 
 export const useSettings = () => {
   const dispatch = useDispatch();
   const settings = useSelector(memoizedGetSettings);
-  const theme = useSelector(selectTheme);
+  const theme = useSelector(memoizedGetTheme);
   const lang = useSelector(selectLanguage);
   const displayBtc = useSelector(selectDisplayBitcoin);
   const passcode = useSelector(selectPasscode);

--- a/helper/redux/settings/selectors.ts
+++ b/helper/redux/settings/selectors.ts
@@ -1,5 +1,6 @@
 import { createSelector } from 'reselect';
 import { RootState } from '../store/reducer';
+import { computeGreys, shades as baseShades } from 'helper/colors';
 
 export const selectSettings = (state: RootState) => state.settings.settings;
 
@@ -37,12 +38,21 @@ export const memoizedGetSettings = createSelector(
 
 export const memoizedGetTheme = createSelector(
   [
-    (state: RootState) => {
-      return state.settings.settings.backgroundImage || state.settings.settings.theme;
-    },
+    (state: RootState) => state.settings.settings.theme,
+    (state: RootState) => state.settings.settings.backgroundImageAttrs,
   ],
-  (theme: string) => {
-    return theme;
+  (themeName: string, attrs) => {
+    if (attrs?.shades && attrs?.greys) {
+      return {
+        shades: attrs.shades,
+        greys: attrs.greys,
+      };
+    }
+
+    return {
+      shades: baseShades,
+      greys: computeGreys(themeName),
+    };
   }
 );
 

--- a/helper/redux/settings/selectors.ts
+++ b/helper/redux/settings/selectors.ts
@@ -1,6 +1,7 @@
 import { createSelector } from 'reselect';
 import { RootState } from '../store/reducer';
-import { computeGreys, shades as baseShades } from 'helper/colors';
+import { computeGreys, shades as baseShades, greys } from 'helper/colors';
+import { BACKGROUND_IMAGE_ATTRIBUTES } from 'helper/backgroundImages';
 
 export const selectSettings = (state: RootState) => state.settings.settings;
 
@@ -39,14 +40,17 @@ export const memoizedGetSettings = createSelector(
 export const memoizedGetTheme = createSelector(
   [
     (state: RootState) => state.settings.settings.theme,
-    (state: RootState) => state.settings.settings.backgroundImageAttrs,
+    (state: RootState) => state.settings.settings.backgroundImage,
   ],
-  (themeName: string, attrs) => {
-    if (attrs?.shades && attrs?.greys) {
-      return {
-        shades: attrs.shades,
-        greys: attrs.greys,
-      };
+  (themeName: string, image) => {
+    console.log(
+      22387474,
+      image,
+      BACKGROUND_IMAGE_ATTRIBUTES[image],
+      computeGreys(greys('dark'), ' #FF5733 ')
+    );
+    if (image) {
+      return BACKGROUND_IMAGE_ATTRIBUTES[image];
     }
 
     return {


### PR DESCRIPTION
## Summary
- generate color shades from a single base color with `computeShades`
- allow overriding grey colours with `computeGreys`
- expand background image attributes to use the new colour helpers
- expose new theme object via `memoizedGetTheme`
- update Redux hooks and a transaction component to use `theme.shades` and `theme.greys`
- update icon colours to use `theme` values

## Testing
- `yarn lint` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_685f11a04fe48325b570e46dce85ee5d