### PR TITLE
Fix theme reference in CurrencyIcon

### DIFF
--- a/assets/icons/index.tsx
+++ b/assets/icons/index.tsx
@@ -11,6 +11,7 @@ import { Monicon as Icon } from '@monicon/native';
 import { Animated, StyleProp, ViewStyle } from 'react-native';
 import { Easing } from 'react-native-reanimated';
 import { View } from 'components/common/View';
+import { greys } from 'helper/colors';
 export { FlagIcon } from './flag';
 
 export const icons = [
@@ -499,14 +500,9 @@ export function ProfileIcon() {
   );
 }
 
-export function CurrencyIcon({
-  width = 36,
-  currency,
-  colors,
-}) {
+export function CurrencyIcon({ width = 36, currency, colors }) {
   const theme = useSelector(memoizedGetTheme);
-  const gradientColors =
-    colors ?? [theme.shades[100], theme.shades[300], theme.shades[500]];
+  const gradientColors = colors ?? [theme.shades[100], theme.shades[300], theme.shades[500]];
   if (currency === 'eur') {
     return (
       <View
@@ -1024,11 +1020,7 @@ export function ImportIcon({ style }) {
         fill={theme.greys[0]}
         d="m12 14l-.707.707l.707.707l.707-.707zm1-9a1 1 0 1 0-2 0zM6.293 9.707l5 5l1.414-1.414l-5-5zm6.414 5l5-5l-1.414-1.414l-5 5zM13 14V5h-2v9z"
       />
-      <Path
-        stroke={theme.greys[0]}
-        strokeWidth={2}
-        d="M5 16v1a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-1"
-      />
+      <Path stroke={theme.greys[0]} strokeWidth={2} d="M5 16v1a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-1" />
     </Svg>
   );
 }

--- a/assets/icons/index.tsx
+++ b/assets/icons/index.tsx
@@ -502,9 +502,11 @@ export function ProfileIcon() {
 export function CurrencyIcon({
   width = 36,
   currency,
-  colors = [theme.shades[100], theme.shades[300], theme.shades[500]],
+  colors,
 }) {
   const theme = useSelector(memoizedGetTheme);
+  const gradientColors =
+    colors ?? [theme.shades[100], theme.shades[300], theme.shades[500]];
   if (currency === 'eur') {
     return (
       <View
@@ -650,7 +652,7 @@ export function CurrencyIcon({
           }}>
           <Defs>
             <LinearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="0%">
-              {colors.map((color, index) => (
+              {gradientColors.map((color, index) => (
                 <Stop key={index} offset={`${index * 25}%`} stopColor={color} />
               ))}
               {/* <Stop offset="50%" stopColor={greys('dark')[0]} /> */}
@@ -861,6 +863,7 @@ export function FalseIcon() {
 }
 
 export function TrueIcon() {
+  const theme = useSelector(memoizedGetTheme);
   return (
     <Svg width="21" height="20" viewBox="0 0 21 20" fill="none">
       <Path

--- a/components/common/QRCode.tsx
+++ b/components/common/QRCode.tsx
@@ -5,7 +5,7 @@ import { UR, UREncoder } from '@gandlaf21/bc-ur';
 import { View } from 'components/common/View';
 import { CurrencyIcon, FlagIcon } from 'assets/icons';
 import { useWindowDimensions, StyleSheet, ViewStyle } from 'react-native';
-import { greys, shades } from 'helper/colors';
+import { greys } from 'helper/colors';
 import EQRCode from 'react-native-qrcode-svg';
 import { useSelector } from 'react-redux';
 import { memoizedGetTheme } from 'helper/redux/settings';
@@ -74,18 +74,20 @@ export const QRCode = memo(function QRCode({
   return (
     <View style={containerStyle}>
       <LinearGradient
-        colors={!animate ? [shades[200], shades[500]] : [greys(theme)[1500], greys(theme)[1500]]}
+        colors={
+          !animate ? [theme.shades[200], theme.shades[500]] : [theme.greys[1500], theme.greys[1500]]
+        }
         style={{
           ...(hasBackground
             ? {
-                backgroundColor: greys(theme)[2300],
+                backgroundColor: theme.greys[2300],
                 padding: 16,
                 borderRadius: 16,
               }
             : {}),
         }}>
         <EQRCode
-          color={animate ? greys(theme)[0] : greys(theme)[0]}
+          color={animate ? theme.greys[0] : theme.greys[0]}
           backgroundColor={'transparent'}
           value={props.data}
           size={width - 2 * padding}


### PR DESCRIPTION
## Summary
- fix undefined `theme` in `CurrencyIcon` by reading it via `useSelector`
- update gradient color logic
- ensure `TrueIcon` also reads theme before use

## Testing
- `yarn lint` *(fails: Error when performing the request to https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz)*
- `yarn test` *(fails: Error when performing the request to https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz)*

------
https://chatgpt.com/codex/tasks/task_b_685f247e2b848325a85fc20330cd5b24