### PR TITLE
Fix mint sheet closing clearing selected mint

### DIFF
--- a/app/(drawer)/(tabs)/index.tsx
+++ b/app/(drawer)/(tabs)/index.tsx
@@ -190,7 +190,7 @@ function TabOneScreen() {
             <Spacer size={12} />
             <Card
               message="Do not use with large amounts of ecash. Sovran is still in development and is operated on a best-effort basis and without any guarentees."
-              variant="info"
+              variant="warning"
             />
           </View>
           <View

--- a/app/(drawer)/(tabs)/index.tsx
+++ b/app/(drawer)/(tabs)/index.tsx
@@ -196,12 +196,12 @@ function TabOneScreen() {
           <View
             className="p-4"
             style={{
-              backgroundColor: theme.greys[950],
+              backgroundColor: opacity(theme.greys[950], 0.99),
             }}>
             {theme.shades && (
               <LinearGradient
                 colors={[
-                  theme.greys[950],
+                  opacity(theme.greys[950], 0.99),
                   opacity(theme.greys[950], 0.5),
                   opacity(theme.greys[950], 0),
                 ]}

--- a/app/MessagePage/TransactionComponent.tsx
+++ b/app/MessagePage/TransactionComponent.tsx
@@ -3,16 +3,16 @@ import { View, Text, StyleSheet } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { formatCurrency } from 'helper/currency';
 import { convertTime } from 'helper/time';
-import { greys, shades } from 'helper/colors';
+import { greys } from 'helper/colors';
 
 const TransactionComponent = ({ transaction, theme, isReceived }) => {
   const styles = createStyles(theme);
 
   const gradientColors = isReceived
     ? [greys(theme)[500], greys(theme)[500]]
-    : [shades[50], shades[300]];
+    : [theme.shades[200], theme.shades[300]];
 
-  const arrowBackgroundColor = isReceived ? greys(theme)[500] : shades[300];
+  const arrowBackgroundColor = isReceived ? greys(theme)[500] : theme.shades[300];
 
   const formattedAmount =
     transaction.unit &&

--- a/app/currency.tsx
+++ b/app/currency.tsx
@@ -299,7 +299,14 @@ function ModalScreen() {
         }
         onChange={setAmount}
       />
-      <MintBalanceDisplay onMintSelected={handleMintSelected} unit={unit} />
+      <MintBalanceDisplay
+        onMintSelected={handleMintSelected}
+        unit={unit}
+        requireBalance={
+          params?.to === 'ecashSendConfirmation' ||
+          params?.to === 'lightningSendConfirmation'
+        }
+      />
       {params.to === 'ecashSendConfirmation' && params?.profile && (
         <TouchableOpacity style={[sovran(theme).listItem, { alignSelf: 'center' }]}>
           <Icon

--- a/app/esim.tsx
+++ b/app/esim.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { StyleSheet, Linking } from 'react-native';
 import { useSelector } from 'react-redux';
 import { useNavigation, useRoute } from '@react-navigation/native';
@@ -6,17 +6,17 @@ import lookup from 'country-code-lookup';
 
 import { greys, reds } from 'helper/colors';
 import Modal from 'components/layout/Modal';
-import { View } from 'components/common/View';
+import { Spacer, View } from 'components/common/View';
 import { Text } from 'components/common/Text';
 import { FlagIcon, ShareIcon } from 'assets/icons';
 import { useEsims } from 'helper/redux/esim';
 import { memoizedGetTheme } from 'helper/redux/settings';
-import { DonutChartContainer } from 'components/layout/Donut';
 import { truncateMiddle } from 'helper/strings';
 import { ButtonHandler } from 'components/common/ButtonHandler';
 import { Section } from 'components/common/Section';
 import { withSheetProvider } from 'components/hocs/withSheetProvider';
 import { fetchOrderData, fetchEsimData } from 'helper/api/sovran';
+import { DonutChartContainer } from 'components/layout/Donut';
 
 // Move utility function outside of component
 export function convertDataUsage(data) {
@@ -68,35 +68,27 @@ function ModalScreen() {
     state.esim?.esims?.find((esim) => esim.request === params.request)
   );
 
-  const fetchAndUpdateEsims = useCallback(
-    () => async (esim) => {
-      try {
-        setLoadingEsim(true);
-        const orderData = await fetchOrderData({
-          request: esim.request,
-          packageCode: esim.package.packageCode,
-          slug: esim.package.slug,
-          iccid: esim.iccid,
-          type: esim.type === 'TOPUP' ? 'TOPUP' : undefined,
-        });
-        const orderNo = orderData?.obj?.orderNo || esim.order.orderNo;
-        if (orderNo) {
-          const esimData = await fetchEsimData(orderNo);
-          updateEsim(esim.request, esimData.obj.esimList[0]);
-        }
-      } catch {
-      } finally {
-        setLoadingEsim(false);
+  const fetchAndUpdateEsims = async (esim) => {
+    console.log(esim);
+    try {
+      setLoadingEsim(true);
+      const orderData = await fetchOrderData({
+        request: esim.request,
+        packageCode: esim.package.packageCode,
+        slug: esim.package.slug,
+        iccid: esim.iccid,
+        type: esim.type === 'TOPUP' ? 'TOPUP' : undefined,
+      });
+      const orderNo = orderData?.obj?.orderNo || esim.order.orderNo;
+      if (orderNo) {
+        const esimData = await fetchEsimData({ orderNo });
+        updateEsim(esim.request, esimData.obj.esimList[0]);
       }
-    },
-    [updateEsim]
-  );
-
-  useEffect(() => {
-    if (esim) {
-      fetchAndUpdateEsims(esim);
+    } catch {
+    } finally {
+      setLoadingEsim(false);
     }
-  }, [esim, fetchAndUpdateEsims]);
+  };
 
   const handleInstallEsim = () => {
     if (!esim?.order?.ac) return;
@@ -236,6 +228,7 @@ function ModalScreen() {
           },
         ]}
       />
+      <Spacer size={12} />
 
       {esim?.order?.iccid && (
         <Section
@@ -247,6 +240,7 @@ function ModalScreen() {
           ]}
         />
       )}
+      <Spacer size={12} />
 
       {esim?.request && (
         <Section
@@ -258,6 +252,7 @@ function ModalScreen() {
           ]}
         />
       )}
+      <Spacer size={12} />
 
       <View style={styles.warningContainer}>
         <Text style={styles.warningText}>

--- a/app/esimCheckout.tsx
+++ b/app/esimCheckout.tsx
@@ -8,7 +8,7 @@ import opacity from 'hex-color-opacity';
 
 import { shades } from 'helper/colors';
 import Modal from 'components/layout/Modal';
-import { View } from 'components/common/View';
+import { Spacer, View } from 'components/common/View';
 import { Text } from 'components/common/Text';
 import { FlagIcon } from 'assets/icons';
 import { getLightningAmount, getMeltQuote } from 'components/cashu';
@@ -191,6 +191,8 @@ function ModalScreen() {
         </>
       }>
       <Section camera={false} items={getSectionItems()} />
+      <Spacer size={12} />
+
       <Section
         camera={false}
         items={[
@@ -200,6 +202,7 @@ function ModalScreen() {
           },
         ]}
       />
+      <Spacer size={12} />
       <Text weight="bold" size={16} style={styles.sectionTitle}>
         Pay with
       </Text>

--- a/components/common/Card.tsx
+++ b/components/common/Card.tsx
@@ -5,6 +5,7 @@ import { TouchableOpacity } from './TouchableOpacity';
 import { useSelector } from 'react-redux';
 import { memoizedGetTheme } from 'helper/redux/settings';
 import { View } from 'components/common/View';
+import opacity from 'hex-color-opacity';
 
 type VariantType = 'warning' | 'info';
 
@@ -47,6 +48,7 @@ export const Card = ({ title, message, variant, icon, onPress }: CardProps) => {
     <TouchableOpacity onPress={onPress}>
       <View
         blur
+        colorBlur={opacity(currentStyle.backgroundColor, 0.2)}
         style={{
           backgroundColor: currentStyle.backgroundColor,
           borderLeftColor: currentStyle.borderLeftColor,

--- a/components/layout/Account.tsx
+++ b/components/layout/Account.tsx
@@ -9,7 +9,7 @@ import { BitcoinMaskIcon, DollarMaskIcon, EuroMaskIcon, PoundMaskIcon } from 'as
 import { PrimaryBalance } from 'components/layout/PrimaryBalance';
 
 import { greys } from 'helper/colors';
-import { memoizedGetTheme } from 'helper/redux/settings';
+import { memoizedGetBackgroundImage, memoizedGetTheme } from 'helper/redux/settings';
 import { NonGestureView } from './NonGestureView';
 
 // Define proper interfaces for our data types
@@ -113,6 +113,8 @@ export function Account({ accounts, account }: AccountProps): React.ReactElement
     });
   };
 
+  const image = useSelector(memoizedGetBackgroundImage);
+
   return (
     <NonGestureView key={account.key} index={0} style={styles.nonGestureView}>
       <View style={styles.transparentBackground}>
@@ -149,17 +151,15 @@ export function Account({ accounts, account }: AccountProps): React.ReactElement
         </View>
       </View>
 
-      {/* <View style={styles.absoluteBottomBorder} /> */}
-
-      {/* <View style={styles.absoluteRightBottomBorder}>
-        <View style={styles.bottomNegative}>{renderCurrencyIcon()}</View>
-      </View> */}
+      <View style={styles.absoluteRightBottomBorder}>
+        <View style={styles.bottomNegative}>{!image && renderCurrencyIcon()}</View>
+      </View>
     </NonGestureView>
   );
 }
 
 // Use a constant for platform-specific values
-const PLATFORM_BOTTOM_OFFSET = Platform.OS === 'web' ? 28.8 : 64 + 28.8;
+const PLATFORM_BOTTOM_OFFSET = 24;
 
 // Using function to create styles to respect the existing pattern
 // but with proper typing for theme
@@ -214,17 +214,20 @@ const createStyles = (theme: string) =>
     },
     absoluteRightBottomBorder: {
       position: 'absolute',
-      right: -8,
       bottom: PLATFORM_BOTTOM_OFFSET,
       borderBottomColor: greys(theme)[600], // Using a default theme value
       borderBottomWidth: 0.2,
       zIndex: -1,
-      height: 128,
+      height: 300,
       backgroundColor: 'transparent',
       overflow: 'hidden',
+      width: '100%',
     },
     bottomNegative: {
-      bottom: -16,
+      position: 'absolute',
+      bottom: 0,
       backgroundColor: 'transparent',
+      borderRadius: 10000,
+      right: 0,
     },
   });

--- a/components/layout/AccountPagerView.tsx
+++ b/components/layout/AccountPagerView.tsx
@@ -83,7 +83,12 @@ export function AccountPagerView({
 
     if (page === 'currency' && balance <= 0) {
       SheetManager.show('mint-balance', {
-        payload: { accountType: account.type, accountIndex: account.accountIndex, navigate: true },
+        payload: {
+          accountType: account.type,
+          accountIndex: account.accountIndex,
+          navigate: true,
+          requireBalance: true,
+        },
         onClose: (mint?: { id: string; unit: string }) => {
           if (mint?.id) {
             const idx = accounts.findIndex((a) => a.unit === mint.unit.toLowerCase());

--- a/components/layout/MintBalanceDisplay.tsx
+++ b/components/layout/MintBalanceDisplay.tsx
@@ -3,8 +3,7 @@ import { StyleProp, ViewStyle } from 'react-native';
 import { useSelector } from 'react-redux';
 import { SheetManager } from 'react-native-actions-sheet';
 import { memoizedGetTheme } from 'helper/redux/settings';
-import { memoizedGetSelectedMint, memoizedGetBalance } from 'helper/redux/cashu';
-import { useGetMintInfo } from 'helper/redux/cashu';
+import { memoizedGetSelectedMint, memoizedGetBalance, useGetMintInfo } from 'helper/redux/cashu';
 import { greys } from 'helper/colors';
 import { TouchableOpacity } from 'components/common/TouchableOpacity';
 import { View } from 'components/common/View';
@@ -59,10 +58,14 @@ const MintBalanceDisplay: React.FC<Props> = ({
         blur
         style={[
           sovran(theme).listItem,
-          { alignSelf: 'center', flexDirection: 'row', justifyContent: 'space-between', backgroundColor: greys(theme)[800] },
+          {
+            alignSelf: 'center',
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+            backgroundColor: greys(theme)[800],
+          },
           style,
-        ]}
-      >
+        ]}>
         <View style={{ flexDirection: 'row' }}>
           <MintIcon mintInfo={mintInfo} />
           <View style={{ flexDirection: 'column', alignItems: 'flex-start', marginRight: 10 }}>
@@ -73,7 +76,7 @@ const MintBalanceDisplay: React.FC<Props> = ({
           </View>
         </View>
         <View style={styles.chevronContainer}>
-          <Icon name="fluent:chevron-down-12-filled" size={12} color={greys(theme)[400]} />
+          <Icon name="fluent:chevron-down-12-filled" size={12} color={greys(theme)[0]} />
         </View>
       </View>
     </TouchableOpacity>

--- a/components/layout/MintBalanceDisplay.tsx
+++ b/components/layout/MintBalanceDisplay.tsx
@@ -20,10 +20,20 @@ interface Props {
     mint: { id: string; name: string; iconUrl: string | null; unit: string },
     balance: { amount: number; unit: string }
   ) => void | Promise<void>;
+  /**
+   * When true, prevent selecting mints that have no balance.
+   * Defaults to true.
+   */
+  requireBalance?: boolean;
   style?: StyleProp<ViewStyle>;
 }
 
-const MintBalanceDisplay: React.FC<Props> = ({ unit, onMintSelected, style }) => {
+const MintBalanceDisplay: React.FC<Props> = ({
+  unit,
+  onMintSelected,
+  requireBalance = true,
+  style,
+}) => {
   const theme = useSelector(memoizedGetTheme);
   const styles = createStyles(theme);
 
@@ -33,9 +43,9 @@ const MintBalanceDisplay: React.FC<Props> = ({ unit, onMintSelected, style }) =>
 
   const handlePress = () => {
     SheetManager.show('mint-balance', {
-      payload: { navigate: false },
+      payload: { navigate: false, requireBalance },
       onClose: (mint?: { id: string; unit: string }) => {
-        if (mint && onMintSelected) {
+        if (mint?.id && onMintSelected) {
           const amt = memoizedGetBalance(unit, mint.id)(store.getState());
           onMintSelected(mint, { amount: amt, unit });
         }

--- a/components/layout/sheets/mint-balance/routes/index.tsx
+++ b/components/layout/sheets/mint-balance/routes/index.tsx
@@ -20,6 +20,7 @@ declare module 'react-native-actions-sheet' {
         accountType?: string;
         accountIndex?: number;
         navigate?: boolean;
+        requireBalance?: boolean;
       };
     }>;
   }

--- a/components/layout/sheets/mint-balance/routes/list.tsx
+++ b/components/layout/sheets/mint-balance/routes/list.tsx
@@ -92,7 +92,7 @@ const ListRoute = () => {
       return;
     }
 
-    if (mint.amount === 0) {
+    if (payload?.requireBalance && mint.amount === 0) {
       showMessage('insufficient_balance', {
         amount: mint.amount,
         unit: mint.unit,

--- a/components/layout/sheets/mint-balance/routes/list.tsx
+++ b/components/layout/sheets/mint-balance/routes/list.tsx
@@ -28,6 +28,7 @@ interface MintItemProps {
   onPress: () => void;
   isLoading: boolean;
   globalLoading: boolean;
+  requireBalance?: boolean;
 }
 
 const MintItem: React.FC<MintItemProps> = ({
@@ -37,11 +38,18 @@ const MintItem: React.FC<MintItemProps> = ({
   onPress,
   isLoading,
   globalLoading,
+  requireBalance = true,
 }) => {
   const styles = createStyles(theme);
   return (
     <TouchableOpacity onPress={onPress} disabled={globalLoading}>
-      <View blur style={[styles.mintItem, balance.amount === 0 && styles.zeroBalance]}>
+      <View
+        blur
+        style={[
+          styles.mintItem,
+          balance.amount === 0 && requireBalance && styles.zeroBalance,
+        ]}
+      >
         {mint.iconUrl ? (
           <Image source={{ uri: mint.iconUrl }} style={styles.mintIcon} />
         ) : (
@@ -196,6 +204,7 @@ const ListRoute = () => {
               theme={theme}
               isLoading={loadingId === mint.mintUrl}
               globalLoading={loadingId !== null}
+              requireBalance={payload?.requireBalance}
               onPress={() => handleMintSelect(mint.mintUrl)}
             />
           ))}

--- a/components/layout/sheets/mints/index.tsx
+++ b/components/layout/sheets/mints/index.tsx
@@ -143,7 +143,7 @@ const MintSelectorButton: React.FC<SelectedMintDisplayProps> = ({
           </View>
         </View>
         <View style={styles.chevronContainer}>
-          <Icon name="fluent:chevron-down-12-filled" size={12} color={greys(theme)[400]} />
+          <Icon name="fluent:chevron-down-12-filled" size={12} color={greys(theme)[0]} />
         </View>
         {/* <Text style={styles.dot}>•</Text> */}
       </View>

--- a/helper/api/sovran.ts
+++ b/helper/api/sovran.ts
@@ -39,7 +39,7 @@ export interface SearchResult {
 }
 
 export const fetchProducts = async () => {
-  const res = await fetch(`${BASE_URL}/api/products`);
+  const res = await fetch(`${BASE_URL}/products`);
   return res.json() as Promise<{ success: boolean; obj?: { packageList: ProductPackage[] } }>;
 };
 

--- a/helper/backgroundImages.ts
+++ b/helper/backgroundImages.ts
@@ -154,7 +154,7 @@ export const BACKGROUND_IMAGE_ATTRIBUTES: Record<string, BackgroundImageAttribut
   'bg9.png': makeBackgroundAttributes({
     id: 'bg9.png',
     base: ['#0C051C', '#3F92B2', '#0D1240', '#2C2575', '#4C75B0'],
-    darkenAmount: 0.05,
+    darkenAmount: 0.025,
   }),
   'bg10.png': makeBackgroundAttributes({
     id: 'bg10.png',


### PR DESCRIPTION
## Summary
- fix check on mint-balance sheet close so it doesn't send invalid object and clear selected mint
- add flag to restrict mint selection to mints with balance
- enforce balance requirement on send screens

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68655dca33148325a01a3f241945973a