### PR TITLE
Add pending transactions counter

### DIFF
--- a/components/layout/Transactions.tsx
+++ b/components/layout/Transactions.tsx
@@ -118,6 +118,20 @@ export const Transactions = React.memo(
       [pendingSections, confirmedSections]
     );
 
+    const pendingDisplayedCount = useMemo(
+      () =>
+        pendingSections.reduce(
+          (total, section) => total + section.data.length,
+          0
+        ),
+      [pendingSections]
+    );
+
+    const morePendingCount = useMemo(
+      () => splitByStatus.pending.length - pendingDisplayedCount,
+      [splitByStatus.pending.length, pendingDisplayedCount]
+    );
+
     if (filteredTransactions.length === 0) {
       return (
         <View className="flex items-center">
@@ -169,6 +183,25 @@ export const Transactions = React.memo(
       return (
         <View className="w-full pb-24">
           {renderStatus('Pending transactions', pendingSections)}
+          {morePendingCount > 0 && (
+            <TouchableOpacity
+              onPress={() =>
+                navigation.navigate('transactions', { account, tab: 'Pending' })
+              }>
+              <View
+                blur
+                className="mt-4 flex items-center rounded-full border p-3"
+                style={{
+                  backgroundColor: theme.greys[800],
+                  borderColor: theme.greys[700],
+                }}>
+                <Text size={14} bold>
+                  {morePendingCount} more pending transaction
+                  {morePendingCount > 1 ? 's' : ''}
+                </Text>
+              </View>
+            </TouchableOpacity>
+          )}
           {renderStatus('Confirmed transactions', confirmedSections)}
           <TouchableOpacity
             onPress={() =>


### PR DESCRIPTION
## Summary
- show how many additional pending transactions exist on the overview page

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_686669151f1c8325867007dd3113f84e