### PR TITLE
Check invoice expiration before send

### DIFF
--- a/helper/cashu/pay.ts
+++ b/helper/cashu/pay.ts
@@ -1,5 +1,5 @@
 import { Alert } from 'react-native';
-import { AppError } from 'components/cashu';
+import { AppError, getRawExpiry } from 'components/cashu';
 import { getKeys, getWallet } from '.';
 import {
   appendProofsV2,
@@ -113,6 +113,16 @@ export async function sendLightning({
 }): Promise<LightningSendTransaction> {
   const state = store.getState();
   const profile = memoizedGetCurrentProfile(state);
+
+  let expiry: Date | null = null;
+  try {
+    expiry = getRawExpiry({ pr });
+  } catch {
+    throw new AppError('invalid_invoice', 'Invalid payment request');
+  }
+  if (expiry && new Date(Date.now() + 60_000) > expiry) {
+    throw new AppError('invoice_expired', 'Invoice expired');
+  }
 
   // Retry logic for wallet operations
   const attemptSend = async (forceRefresh = false): Promise<LightningSendTransaction> => {


### PR DESCRIPTION
## Summary
- avoid sending lightning payments on invoices that are already expired or expiring in less than one minute

## Testing
- `npm run pretty` *(fails: Cannot find module 'prettier-plugin-tailwindcss')*
- `npm test -- -w=1` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_686771072e4c8325bad31bb203edbe39