### PR TITLE
Handle cashu deep links

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
     "slug": "sovran",
     "version": "0.0.24",
     "orientation": "portrait",
-    "scheme": "sovran",
+    "scheme": ["sovran", "cashu"],
     "userInterfaceStyle": "automatic",
     "splash": {
       "image": "./assets/images/bg_.png",

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -41,6 +41,7 @@ import { WalletsProvider } from 'components/providers/WalletsProviders';
 import { PricelistProvider } from 'components/providers/PricelistProvider';
 import { registerAllSheets } from 'components/layout/sheets/registerSheets';
 import PasscodeGate from 'components/passcode/PasscodeGate';
+import { useCashuDeeplink } from 'helper/hooks/useCashuDeeplink';
 
 registerAllSheets({ context: 'global' });
 
@@ -246,6 +247,8 @@ export default function RootLayout() {
   const { init: initializeNDK } = useNDK();
   const [appIsReady, setAppIsReady] = useState(false);
   const scaleRef = useRef(new Animated.Value(1));
+
+  useCashuDeeplink();
 
   // Load fonts
   const [fontsLoaded, fontsError] = useFonts(FONTS);

--- a/helper/hooks/useCashuDeeplink.ts
+++ b/helper/hooks/useCashuDeeplink.ts
@@ -1,0 +1,37 @@
+import { useEffect } from 'react';
+import { Linking } from 'react-native';
+import { useNavigation } from 'expo-router';
+import { URDecoder } from '@gandlaf21/bc-ur';
+import { useSelector } from 'react-redux';
+import { memoizedGetSelectedMint } from 'helper/redux/cashu';
+import { barcodeHandler } from 'helper/payment-handler/handlers';
+
+export const useCashuDeeplink = () => {
+  const navigation = useNavigation();
+  const selectedMint = useSelector(memoizedGetSelectedMint);
+
+  useEffect(() => {
+    const urDecoder = new URDecoder();
+
+    const handleUrl = async ({ url }: { url: string }) => {
+      if (!url || !url.startsWith('cashu://')) return;
+      const data = decodeURIComponent(url.replace('cashu://', ''));
+      await barcodeHandler({
+        scanning: { data },
+        navigation,
+        urDecoder,
+        unit: 'sat',
+        selectedMint,
+        setLoading: () => {},
+      });
+    };
+
+    const subscription = Linking.addEventListener('url', handleUrl);
+
+    Linking.getInitialURL().then((url) => {
+      if (url) handleUrl({ url });
+    });
+
+    return () => subscription.remove();
+  }, [navigation, selectedMint]);
+};


### PR DESCRIPTION
## Summary
- support cashu:// deep link scheme
- add useCashuDeeplink hook to pass deep links into barcodeHandler
- call the new hook from the root layout

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6869240ba2188325a7bcd59fafb9b791