### PR TITLE
Handle incoming deeplinks

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -40,6 +40,7 @@ import { PricelistProvider } from 'components/providers/PricelistProvider';
 import { registerAllSheets } from 'components/layout/sheets/registerSheets';
 import PasscodeGate from 'components/passcode/PasscodeGate';
 import { useFonts } from 'hooks/useFonts';
+import { useDeeplink } from 'hooks/useDeeplink';
 
 registerAllSheets({ context: 'global' });
 
@@ -206,6 +207,9 @@ export default function RootLayout() {
 
   // Load fonts
   const [fontsLoaded, fontsError] = useFonts();
+
+  // Set up deeplink handler
+  useDeeplink();
 
   // Handle font loading errors
   useEffect(() => {

--- a/hooks/useDeeplink.ts
+++ b/hooks/useDeeplink.ts
@@ -13,9 +13,13 @@ export const useDeeplink = () => {
   useEffect(() => {
     const urDecoder = new URDecoder();
 
+    const supportedSchemes = ['test://', 'sovran://', 'cashu://'];
+
     const handleUrl = async ({ url }: { url: string }) => {
-      if (!url || !url.startsWith('test://')) return;
-      const data = decodeURIComponent(url.replace('test://', ''));
+      if (!url) return;
+      const scheme = supportedSchemes.find((s) => url.startsWith(s));
+      if (!scheme) return;
+      const data = decodeURIComponent(url.replace(scheme, ''));
       await barcodeHandler({
         scanning: { data },
         navigation,


### PR DESCRIPTION
## Summary
- support sovran/cashu schemes when handling deep links
- initialize deeplink handler in the app layout

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_686a729f41948325887499efe1269962