### PR TITLE
Refactor payment request flow

### DIFF
--- a/app/currency.tsx
+++ b/app/currency.tsx
@@ -102,6 +102,7 @@ function ModalScreen() {
       amount: unit === 'sat' ? amount : amount * 100,
       unit: unit,
       memo: message,
+      paymentRequest: params.paymentRequest,
       ...(params?.profile?.pubkey || params?.profile?.npub
         ? {
             p2pk: {

--- a/app/currency.tsx
+++ b/app/currency.tsx
@@ -209,7 +209,7 @@ function ModalScreen() {
   };
 
   useEffect(() => {
-    if (params?.paymentRequest) {
+    if (params?.paymentRequest && params?.amount) {
       setIsValidAmount(true);
       handleNext();
     }
@@ -238,6 +238,26 @@ function ModalScreen() {
   const renderButtons = () => {
     const isP2PK = params?.profile && params.to === 'ecashSendConfirmation';
     if (params.to === 'ecashSendConfirmation') {
+      // When triggered by a payment request only show the Next button
+      if (params?.paymentRequest) {
+        return (
+          <View style={styles.buttonContainer}>
+            <ButtonHandler
+              buttons={[
+                {
+                  text: 'Next',
+                  icon: 'lucide:arrow-right',
+                  variant: 'primary',
+                  onPress: handleNext,
+                  loading: loading,
+                  disabled: !isValidAmount,
+                },
+              ]}
+            />
+          </View>
+        );
+      }
+
       return (
         <View style={styles.buttonContainer}>
           <ButtonHandler
@@ -258,7 +278,7 @@ function ModalScreen() {
                 variant: 'primary',
                 onPress: handleNext,
                 loading: loading,
-                disabled: !isValidAmount, // Disable the button when amount is invalid
+                disabled: !isValidAmount,
               },
               ...(isP2PK
                 ? []

--- a/app/currency.tsx
+++ b/app/currency.tsx
@@ -56,7 +56,6 @@ function ModalScreen() {
     setIsValidAmount(amount > 0);
   }, [amount]);
 
-
   const urDecoder = new URDecoder();
 
   const handleMintSelected = async (mint, balance) => {
@@ -346,6 +345,7 @@ function ModalScreen() {
         onMintSelected={handleMintSelected}
         unit={unit}
         allowedMints={params?.mints}
+        allowedUnits={params?.allowedUnits}
         requireBalance={
           params?.to === 'ecashSendConfirmation' || params?.to === 'lightningSendConfirmation'
         }

--- a/app/currency.tsx
+++ b/app/currency.tsx
@@ -43,7 +43,7 @@ function ModalScreen() {
   const { params } = useRoute();
   const navigation = useTypedNavigation();
 
-  const [amount, setAmount] = useState(0);
+  const [amount, setAmount] = useState(params?.amount || 0);
   const [loading, setLoading] = useState(false);
   const [unit, setUnit] = useState(params?.unit?.toLowerCase() || 'sat');
   const [isValidAmount, setIsValidAmount] = useState(false);
@@ -53,9 +53,9 @@ function ModalScreen() {
 
   // Validate the amount whenever it changes
   useEffect(() => {
-    // Amount must be greater than 0 to be valid
     setIsValidAmount(amount > 0);
   }, [amount]);
+
 
   const urDecoder = new URDecoder();
 
@@ -116,6 +116,7 @@ function ModalScreen() {
       ...params,
       token: transaction.token,
       amount: unit === 'sat' ? amount : amount * 100,
+      paymentRequest: params.paymentRequest,
     });
   };
 
@@ -205,6 +206,14 @@ function ModalScreen() {
     } finally {
     }
   };
+
+  useEffect(() => {
+    if (params?.paymentRequest) {
+      setIsValidAmount(true);
+      handleNext();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handlePastePress = async () => {
     const text = await Clipboard.getStringAsync();
@@ -296,7 +305,9 @@ function ModalScreen() {
       title="Select Amount"
       buttons={
         <>
-          <CustomKeyboard loading={loading} unit={unit} onKeyPress={setAmount} />
+          {!params?.amount && (
+            <CustomKeyboard loading={loading} unit={unit} onKeyPress={setAmount} />
+          )}
           {renderButtons()}
         </>
       }>
@@ -308,11 +319,12 @@ function ModalScreen() {
             ? 'send'
             : 'receive'
         }
-        onChange={setAmount}
+        onChange={params?.amount ? undefined : setAmount}
       />
       <MintBalanceDisplay
         onMintSelected={handleMintSelected}
         unit={unit}
+        allowedMints={params?.mints}
         requireBalance={
           params?.to === 'ecashSendConfirmation' || params?.to === 'lightningSendConfirmation'
         }

--- a/app/ecashSendConfirmation.tsx
+++ b/app/ecashSendConfirmation.tsx
@@ -10,7 +10,14 @@ import { PaymentInfo } from 'components/layout/PaymentInfo';
 import { greys } from 'helper/colors';
 import { useSelector } from 'react-redux';
 import { store } from 'helper/redux/store';
-import { getDecodedToken, getEncodedTokenV4 } from '@cashu/cashu-ts';
+import {
+  getDecodedToken,
+  getEncodedTokenV4,
+  decodePaymentRequest,
+  PaymentRequestTransportType,
+} from '@cashu/cashu-ts';
+import { nip19 } from 'nostr-tools';
+import { sendGiftWrappedEncryptedDirectMessage } from 'helper/nostrClient';
 import _, { capitalize } from 'lodash';
 import {
   memoizedGetTransactionByMatcher,
@@ -42,17 +49,20 @@ export function EcashSendConfirmation({
   unit,
   amount,
   token,
+  paymentRequest,
   extraButtons = [],
 }: {
   unit: string;
   amount: number;
   token: string;
+  paymentRequest?: string;
   extraButtons?: ButtonHandlerButton[];
 }) {
   const theme = useSelector(memoizedGetTheme);
   const navigation = useTypedNavigation();
   const [uri, setUri] = useState('');
   const [isCheckingStatus, setIsCheckingStatus] = useState(false);
+  const [sendingNostr, setSendingNostr] = useState(false);
 
   const currentProfile = useSelector(memoizedGetCurrentProfile);
 
@@ -84,6 +94,26 @@ export function EcashSendConfirmation({
       message: 'cashu://' + token,
     });
     onClose();
+  };
+
+  const handleSendNostr = async () => {
+    if (!paymentRequest) return;
+    try {
+      setSendingNostr(true);
+      const decoded = decodePaymentRequest(paymentRequest);
+      const receiverTarget = decoded.getTransport(
+        PaymentRequestTransportType.NOSTR
+      ).target;
+      const { data } = nip19.decode(receiverTarget);
+      const { pubkey } = data as { pubkey: string };
+      await sendGiftWrappedEncryptedDirectMessage({
+        message: token,
+        recipient: pubkey,
+        nsec: currentProfile.nsec,
+      });
+    } finally {
+      setSendingNostr(false);
+    }
   };
 
   const handleCancelSend = async (onClose) => {
@@ -243,6 +273,17 @@ export function EcashSendConfirmation({
                       variant: 'secondary',
                       onPress: handleNFCSend,
                     },
+                    ...(paymentRequest
+                      ? [
+                          {
+                            text: 'Send via Nostr',
+                            icon: 'mdi:send',
+                            variant: 'primary',
+                            loading: sendingNostr,
+                            onPress: handleSendNostr,
+                          },
+                        ]
+                      : []),
                     // {
                     //   text: 'Check Status',
                     //   icon: 'humbleicons:refresh',
@@ -356,8 +397,16 @@ export function EcashSendConfirmation({
 }
 
 function ModalScreen() {
-  const { unit, amount, token } = useTypedRoute<'ecashSendConfirmation'>();
-  return <EcashSendConfirmation unit={unit} amount={amount} token={token} />;
+  const { unit, amount, token, paymentRequest } =
+    useTypedRoute<'ecashSendConfirmation'>();
+  return (
+    <EcashSendConfirmation
+      unit={unit}
+      amount={amount}
+      token={token}
+      paymentRequest={paymentRequest}
+    />
+  );
 }
 
 export default withSheetProvider(ModalScreen);

--- a/app/ecashSendConfirmation.tsx
+++ b/app/ecashSendConfirmation.tsx
@@ -106,8 +106,16 @@ export function EcashSendConfirmation({
       ).target;
       const { data } = nip19.decode(receiverTarget);
       const { pubkey } = data as { pubkey: string };
+
+      const decodedToken = getDecodedToken(token);
+
       await sendGiftWrappedEncryptedDirectMessage({
-        message: token,
+        message: JSON.stringify({
+          mint: decodedToken.mint,
+          unit: decodedToken.unit,
+          proofs: decodedToken.proofs,
+          id: decoded.id,
+        }),
         recipient: pubkey,
         nsec: currentProfile.nsec,
       });

--- a/app/ecashSendConfirmation.tsx
+++ b/app/ecashSendConfirmation.tsx
@@ -112,10 +112,6 @@ export function EcashSendConfirmation({
       const { pubkey } = data as { pubkey: string };
 
       const decodedToken = getDecodedToken(token);
-      if (decodedToken.unit.toLowerCase() !== decoded.unit.toLowerCase()) {
-        showMessage('unit_mismatch', {}, { emoji: '🚨' });
-        return;
-      }
 
       await sendGiftWrappedEncryptedDirectMessage({
         message: JSON.stringify({

--- a/app/ecashSendConfirmation.tsx
+++ b/app/ecashSendConfirmation.tsx
@@ -79,6 +79,9 @@ export function EcashSendConfirmation({
     })
   );
 
+  const resolvedPaymentRequest =
+    paymentRequest || getCurrentTransaction[0]?.paymentRequest;
+
   const handleNFCSend = async () => {
     await write(token);
   };
@@ -97,10 +100,11 @@ export function EcashSendConfirmation({
   };
 
   const handleSendNostr = async () => {
-    if (!paymentRequest) return;
+    const request = resolvedPaymentRequest;
+    if (!request) return;
     try {
       setSendingNostr(true);
-      const decoded = decodePaymentRequest(paymentRequest);
+      const decoded = decodePaymentRequest(request);
       const receiverTarget = decoded.getTransport(
         PaymentRequestTransportType.NOSTR
       ).target;
@@ -281,7 +285,7 @@ export function EcashSendConfirmation({
                       variant: 'secondary',
                       onPress: handleNFCSend,
                     },
-                    ...(paymentRequest
+                    ...(resolvedPaymentRequest
                       ? [
                           {
                             text: 'Send via Nostr',

--- a/app/ecashSendConfirmation.tsx
+++ b/app/ecashSendConfirmation.tsx
@@ -112,6 +112,10 @@ export function EcashSendConfirmation({
       const { pubkey } = data as { pubkey: string };
 
       const decodedToken = getDecodedToken(token);
+      if (decodedToken.unit.toLowerCase() !== decoded.unit.toLowerCase()) {
+        showMessage('unit_mismatch', {}, { emoji: '🚨' });
+        return;
+      }
 
       await sendGiftWrappedEncryptedDirectMessage({
         message: JSON.stringify({

--- a/components/layout/MintBalanceDisplay.tsx
+++ b/components/layout/MintBalanceDisplay.tsx
@@ -29,6 +29,7 @@ interface Props {
    * Defaults to true.
    */
   updateSelectedMint?: boolean;
+  allowedMints?: string[];
   style?: StyleProp<ViewStyle>;
 }
 
@@ -37,6 +38,7 @@ const MintBalanceDisplay: React.FC<Props> = ({
   onMintSelected,
   requireBalance = true,
   updateSelectedMint = true,
+  allowedMints,
   style,
 }) => {
   const theme = useSelector(memoizedGetTheme);
@@ -52,6 +54,7 @@ const MintBalanceDisplay: React.FC<Props> = ({
         navigate: false,
         requireBalance,
         updateSelectedMint,
+        allowedMints,
         onMintPress: updateSelectedMint ? undefined : onMintSelected,
       },
       onClose: (mint?: { id: string; unit: string }) => {

--- a/components/layout/MintBalanceDisplay.tsx
+++ b/components/layout/MintBalanceDisplay.tsx
@@ -30,6 +30,7 @@ interface Props {
    */
   updateSelectedMint?: boolean;
   allowedMints?: string[];
+  allowedUnits?: string[];
   style?: StyleProp<ViewStyle>;
 }
 
@@ -39,6 +40,7 @@ const MintBalanceDisplay: React.FC<Props> = ({
   requireBalance = true,
   updateSelectedMint = true,
   allowedMints,
+  allowedUnits,
   style,
 }) => {
   const theme = useSelector(memoizedGetTheme);
@@ -55,6 +57,7 @@ const MintBalanceDisplay: React.FC<Props> = ({
         requireBalance,
         updateSelectedMint,
         allowedMints,
+        allowedUnits,
         onMintPress: updateSelectedMint ? undefined : onMintSelected,
       },
       onClose: (mint?: { id: string; unit: string }) => {

--- a/components/layout/Transaction.tsx
+++ b/components/layout/Transaction.tsx
@@ -72,6 +72,7 @@ const useTransaction = (tx: TransactionData) => {
             unit: tx.unit,
             token: tx.token,
             amount: tx.amount,
+            paymentRequest: tx.paymentRequest,
           });
           return;
         }

--- a/components/layout/sheets/mint-balance/routes/index.tsx
+++ b/components/layout/sheets/mint-balance/routes/index.tsx
@@ -22,6 +22,7 @@ declare module 'react-native-actions-sheet' {
         navigate?: boolean;
         requireBalance?: boolean;
         updateSelectedMint?: boolean;
+        allowedMints?: string[];
         onMintPress?: (
           mint: { id: string; unit: string; name: string; iconUrl: string | null }
         ) => void | Promise<void>;

--- a/components/layout/sheets/mint-balance/routes/index.tsx
+++ b/components/layout/sheets/mint-balance/routes/index.tsx
@@ -23,9 +23,13 @@ declare module 'react-native-actions-sheet' {
         requireBalance?: boolean;
         updateSelectedMint?: boolean;
         allowedMints?: string[];
-        onMintPress?: (
-          mint: { id: string; unit: string; name: string; iconUrl: string | null }
-        ) => void | Promise<void>;
+        allowedUnits?: string[];
+        onMintPress?: (mint: {
+          id: string;
+          unit: string;
+          name: string;
+          iconUrl: string | null;
+        }) => void | Promise<void>;
       };
     }>;
   }

--- a/components/layout/sheets/mint-balance/routes/list.tsx
+++ b/components/layout/sheets/mint-balance/routes/list.tsx
@@ -73,13 +73,10 @@ const ListRoute = () => {
   const navigation = useTypedNavigation();
 
   const balances = useSelector(memoizedGetAllBalancesMultipleCurrencies);
-  const VALID_UNITS = ['sat', 'usd', 'eur', 'gbp'];
   const allowedBalances = useMemo(
     () =>
-      balances.filter(
-        (b) =>
-          VALID_UNITS.includes(String(b.unit).toLowerCase()) &&
-          (payload?.allowedMints ? payload.allowedMints.includes(b.mintUrl) : true)
+      balances.filter((b) =>
+        payload?.allowedMints ? payload.allowedMints.includes(b.mintUrl) : true
       ),
     [balances, payload?.allowedMints]
   );

--- a/components/layout/sheets/mint-balance/routes/list.tsx
+++ b/components/layout/sheets/mint-balance/routes/list.tsx
@@ -72,6 +72,8 @@ const ListRoute = () => {
   const payload = useSheetPayload('mint-balance');
   const navigation = useTypedNavigation();
 
+  console.log(payload);
+
   const balances = useSelector(memoizedGetAllBalancesMultipleCurrencies);
   const allowedBalances = useMemo(
     () =>
@@ -83,12 +85,13 @@ const ListRoute = () => {
   const dispatch = useDispatch();
   const profileId = useSelector(memoizedGetCurrentProfile).id;
 
-  const currencies: string[] = _.uniq(
-    allowedBalances.map((b) => b.unit?.toUpperCase())
-  )
+  const currencies: string[] = _.uniq(allowedBalances.map((b) => b.unit?.toUpperCase()))
     .filter(Boolean)
     .filter((unit) => {
       return ['SAT', 'USD', 'EUR', 'GBP'].includes(unit);
+    })
+    .filter((unit) => {
+      return payload?.allowedUnits ? payload?.allowedUnits?.includes(unit) : true;
     });
 
   const [selectedCurrency, setSelectedCurrency] = useState<string>(

--- a/components/layout/sheets/mint-balance/routes/list.tsx
+++ b/components/layout/sheets/mint-balance/routes/list.tsx
@@ -73,10 +73,13 @@ const ListRoute = () => {
   const navigation = useTypedNavigation();
 
   const balances = useSelector(memoizedGetAllBalancesMultipleCurrencies);
+  const VALID_UNITS = ['sat', 'usd', 'eur', 'gbp'];
   const allowedBalances = useMemo(
     () =>
-      balances.filter((b) =>
-        payload?.allowedMints ? payload.allowedMints.includes(b.mintUrl) : true
+      balances.filter(
+        (b) =>
+          VALID_UNITS.includes(String(b.unit).toLowerCase()) &&
+          (payload?.allowedMints ? payload.allowedMints.includes(b.mintUrl) : true)
       ),
     [balances, payload?.allowedMints]
   );

--- a/components/layout/sheets/mint-balance/routes/list.tsx
+++ b/components/layout/sheets/mint-balance/routes/list.tsx
@@ -73,10 +73,19 @@ const ListRoute = () => {
   const navigation = useTypedNavigation();
 
   const balances = useSelector(memoizedGetAllBalancesMultipleCurrencies);
+  const allowedBalances = useMemo(
+    () =>
+      balances.filter((b) =>
+        payload?.allowedMints ? payload.allowedMints.includes(b.mintUrl) : true
+      ),
+    [balances, payload?.allowedMints]
+  );
   const dispatch = useDispatch();
   const profileId = useSelector(memoizedGetCurrentProfile).id;
 
-  const currencies: string[] = _.uniq(balances.map((b) => b.unit?.toUpperCase()))
+  const currencies: string[] = _.uniq(
+    allowedBalances.map((b) => b.unit?.toUpperCase())
+  )
     .filter(Boolean)
     .filter((unit) => {
       return ['SAT', 'USD', 'EUR', 'GBP'].includes(unit);
@@ -88,10 +97,10 @@ const ListRoute = () => {
   const [loadingId, setLoadingId] = useState<string | null>(null);
 
   const filteredMints = useMemo(() => {
-    return balances
+    return allowedBalances
       .filter((b) => b.unit?.toUpperCase() === selectedCurrency)
       .sort((a, b) => b.amount - a.amount);
-  }, [balances, selectedCurrency]);
+  }, [allowedBalances, selectedCurrency]);
 
   const handleMintSelect = async (mintUrl: string) => {
     const mint = filteredMints.find((m) => m.mintUrl === mintUrl);

--- a/helper/cashu/pay.ts
+++ b/helper/cashu/pay.ts
@@ -385,6 +385,13 @@ export async function sendEcash({
   const selectedMint = memoizedGetSelectedMint(state);
   const profile = memoizedGetCurrentProfile(state);
 
+  if (paymentRequest) {
+    const decoded = decodePaymentRequest(paymentRequest);
+    if (decoded.unit.toLowerCase() !== unit.toLowerCase()) {
+      throw new AppError('unit_mismatch', 'unit_mismatch');
+    }
+  }
+
   // Retry logic for wallet operations
   const attemptSend = async (forceRefresh = false): Promise<EcashSendTransaction> => {
     const currentProofs = memoizedGetProofs(unit)(state);

--- a/helper/cashu/pay.ts
+++ b/helper/cashu/pay.ts
@@ -78,6 +78,7 @@ interface BaseEcashTransaction extends BaseTransaction {
 
 interface EcashSendTransaction extends BaseEcashTransaction {
   transactionType: 'send';
+  paymentRequest?: string;
   proofs: {
     keep: Proof[];
     send: Proof[];
@@ -371,12 +372,14 @@ export async function sendEcash({
   memo,
   to,
   p2pk,
+  paymentRequest,
 }: {
   amount: number;
   unit: string;
   memo?: string;
   to?: string;
   p2pk?: { pubkey?: string; privkey?: string };
+  paymentRequest?: string;
 }): Promise<EcashSendTransaction> {
   const state = store.getState();
   const selectedMint = memoizedGetSelectedMint(state);
@@ -463,6 +466,7 @@ export async function sendEcash({
       transactionType: 'send',
       unit,
       paid: false,
+      ...(paymentRequest ? { paymentRequest } : {}),
       nostr: {
         pubkey: to,
       },

--- a/helper/cashu/pay.ts
+++ b/helper/cashu/pay.ts
@@ -385,13 +385,6 @@ export async function sendEcash({
   const selectedMint = memoizedGetSelectedMint(state);
   const profile = memoizedGetCurrentProfile(state);
 
-  if (paymentRequest) {
-    const decoded = decodePaymentRequest(paymentRequest);
-    if (decoded.unit.toLowerCase() !== unit.toLowerCase()) {
-      throw new AppError('unit_mismatch', 'unit_mismatch');
-    }
-  }
-
   // Retry logic for wallet operations
   const attemptSend = async (forceRefresh = false): Promise<EcashSendTransaction> => {
     const currentProofs = memoizedGetProofs(unit)(state);

--- a/helper/navigation/hooks/useEncryptedDirectMessage.ts
+++ b/helper/navigation/hooks/useEncryptedDirectMessage.ts
@@ -45,6 +45,7 @@ export const useSendEncryptedDirectMessage = () => {
       unit: decodedRequest.unit as string,
       amount: decodedRequest.amount as number,
       to: pubkey,
+      paymentRequest: request,
     });
 
     const decodedToken = getDecodedToken(transaction.token);

--- a/helper/navigation/hooks/useEncryptedDirectMessage.ts
+++ b/helper/navigation/hooks/useEncryptedDirectMessage.ts
@@ -49,9 +49,6 @@ export const useSendEncryptedDirectMessage = () => {
     });
 
     const decodedToken = getDecodedToken(transaction.token);
-    if (decodedToken.unit.toLowerCase() !== decodedRequest.unit.toLowerCase()) {
-      throw new Error('unit_mismatch');
-    }
 
     sendGiftWrappedEncryptedDirectMessage({
       message: JSON.stringify({

--- a/helper/navigation/hooks/useEncryptedDirectMessage.ts
+++ b/helper/navigation/hooks/useEncryptedDirectMessage.ts
@@ -49,6 +49,9 @@ export const useSendEncryptedDirectMessage = () => {
     });
 
     const decodedToken = getDecodedToken(transaction.token);
+    if (decodedToken.unit.toLowerCase() !== decodedRequest.unit.toLowerCase()) {
+      throw new Error('unit_mismatch');
+    }
 
     sendGiftWrappedEncryptedDirectMessage({
       message: JSON.stringify({

--- a/helper/navigation/screens.tsx
+++ b/helper/navigation/screens.tsx
@@ -198,12 +198,6 @@ export const MODAL_SCREENS: ModalConfig[] = [
     },
   },
   {
-    name: 'paymentRequestSendConfirmation',
-    options: {
-      presentation: 'modal',
-    },
-  },
-  {
     name: 'lightningReceiveConfirmation',
     options: {
       presentation: 'modal',

--- a/helper/navigation/types/NavigationParams.ts
+++ b/helper/navigation/types/NavigationParams.ts
@@ -11,6 +11,7 @@ export type NavigationParams = {
     unit: string;
     amount: number;
     token: string;
+    paymentRequest?: string;
   };
   lightningReceiveConfirmation: {
     request: string;

--- a/helper/payment-handler/handlers.ts
+++ b/helper/payment-handler/handlers.ts
@@ -252,6 +252,7 @@ export const handleBarcode = async ({
           unit: decodedPaymentRequest.unit,
           amount: decodedPaymentRequest.amount,
           mints: decodedPaymentRequest.mints,
+          allowedUnits: [decodedPaymentRequest.unit?.toUpperCase()],
           paymentRequest: scanning.data,
           to: 'ecashSendConfirmation',
         },

--- a/helper/payment-handler/handlers.ts
+++ b/helper/payment-handler/handlers.ts
@@ -244,9 +244,18 @@ export const handleBarcode = async ({
     case 'ecash':
       return handleEcash({ data: scanning.data, unit });
     case 'paymentRequest':
-      return handlePaymentRequest({
-        request: scanning.data,
-      });
+      const decodedPaymentRequest = decodePaymentRequest(scanning.data);
+
+      return {
+        screen: 'currency',
+        params: {
+          unit: decodedPaymentRequest.unit,
+          amount: decodedPaymentRequest.amount,
+          mints: decodedPaymentRequest.mints,
+          paymentRequest: scanning.data,
+          to: 'ecashSendConfirmation',
+        },
+      };
     case 'lightning':
       return handleLightning({
         data: scanning.data,

--- a/helper/popup/popups.tsx
+++ b/helper/popup/popups.tsx
@@ -218,11 +218,6 @@ const MESSAGE_CONFIGS: Record<string, MessageConfig> = {
     text: 'The payment request does not specify a mint.',
     type: MESSAGE_TYPES.ERROR,
   },
-  unit_mismatch: {
-    title: 'Currency Mismatch',
-    text: 'The payment request currency does not match the token currency.',
-    type: MESSAGE_TYPES.ERROR,
-  },
 
   // eSIM Related
   esim_error: {

--- a/helper/popup/popups.tsx
+++ b/helper/popup/popups.tsx
@@ -218,6 +218,11 @@ const MESSAGE_CONFIGS: Record<string, MessageConfig> = {
     text: 'The payment request does not specify a mint.',
     type: MESSAGE_TYPES.ERROR,
   },
+  unit_mismatch: {
+    title: 'Currency Mismatch',
+    text: 'The payment request currency does not match the token currency.',
+    type: MESSAGE_TYPES.ERROR,
+  },
 
   // eSIM Related
   esim_error: {


### PR DESCRIPTION
## Summary
- update barcode paymentRequest handler to route to `currency`
- support allowed mints and fixed amounts in `MintBalanceDisplay` and sheet
- restrict mint picker by allowedMints
- handle paymentRequest in currency screen and navigate automatically
- add nostr send option on ecash confirmation
- remove unused payment request screen from navigation
- extend navigation types for `paymentRequest`

## Testing
- `yarn lint` *(fails: Error when performing the request to https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz)*
- `yarn test` *(fails: Error when performing the request to https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz)*

------
https://chatgpt.com/codex/tasks/task_b_686aefe672a08325b643984a873db65b