### PR TITLE
Handle invalid mint on payment request

### DIFF
--- a/app/currency.tsx
+++ b/app/currency.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { Alert, StyleSheet } from 'react-native';
 import { useSelector, useDispatch } from 'react-redux';
 import Modal from 'components/layout/Modal';
@@ -50,6 +50,11 @@ function ModalScreen() {
 
   const selectedMint = useSelector(memoizedGetSelectedMint);
   const balance = useSelector(memoizedGetBalance(unit, selectedMint));
+  const isMintValid = useMemo(
+    () =>
+      params?.mints ? params.mints.includes(selectedMint) : true,
+    [params?.mints, selectedMint]
+  );
 
   // Validate the amount whenever it changes
   useEffect(() => {
@@ -208,12 +213,12 @@ function ModalScreen() {
   };
 
   useEffect(() => {
-    if (params?.paymentRequest && params?.amount) {
+    if (params?.paymentRequest && params?.amount && isMintValid) {
       setIsValidAmount(true);
       handleNext();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [isMintValid]);
 
   const handlePastePress = async () => {
     const text = await Clipboard.getStringAsync();
@@ -249,7 +254,7 @@ function ModalScreen() {
                   variant: 'primary',
                   onPress: handleNext,
                   loading: loading,
-                  disabled: !isValidAmount,
+                  disabled: !isValidAmount || !isMintValid,
                 },
               ]}
             />
@@ -277,7 +282,7 @@ function ModalScreen() {
                 variant: 'primary',
                 onPress: handleNext,
                 loading: loading,
-                disabled: !isValidAmount,
+                disabled: !isValidAmount || !isMintValid,
               },
               ...(isP2PK
                 ? []
@@ -310,7 +315,7 @@ function ModalScreen() {
               variant: 'primary',
               loading: loading,
               onPress: handleNext,
-              disabled: !isValidAmount, // Disable the button when amount is invalid
+              disabled: !isValidAmount || !isMintValid, // Disable the button when amount is invalid or mint is not valid
             },
           ]}
         />
@@ -346,6 +351,7 @@ function ModalScreen() {
         unit={unit}
         allowedMints={params?.mints}
         allowedUnits={params?.allowedUnits}
+        requireValidMint={!!params?.paymentRequest}
         requireBalance={
           params?.to === 'ecashSendConfirmation' || params?.to === 'lightningSendConfirmation'
         }

--- a/app/currency.tsx
+++ b/app/currency.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { Alert, StyleSheet } from 'react-native';
 import { useSelector, useDispatch } from 'react-redux';
 import Modal from 'components/layout/Modal';
@@ -55,6 +55,7 @@ function ModalScreen() {
       params?.mints ? params.mints.includes(selectedMint) : true,
     [params?.mints, selectedMint]
   );
+  const autoNextRef = useRef(false);
 
   // Validate the amount whenever it changes
   useEffect(() => {
@@ -213,7 +214,9 @@ function ModalScreen() {
   };
 
   useEffect(() => {
+    if (autoNextRef.current) return;
     if (params?.paymentRequest && params?.amount && isMintValid) {
+      autoNextRef.current = true;
       setIsValidAmount(true);
       handleNext();
     }

--- a/components/layout/MintBalanceDisplay.tsx
+++ b/components/layout/MintBalanceDisplay.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { StyleProp, ViewStyle } from 'react-native';
 import { useSelector } from 'react-redux';
 import { SheetManager } from 'react-native-actions-sheet';
@@ -31,6 +31,12 @@ interface Props {
   updateSelectedMint?: boolean;
   allowedMints?: string[];
   allowedUnits?: string[];
+  /**
+   * When true, the current selected mint will only be displayed if it is
+   * included in `allowedMints`. Otherwise a placeholder is shown.
+   * Defaults to false.
+   */
+  requireValidMint?: boolean;
   style?: StyleProp<ViewStyle>;
 }
 
@@ -41,6 +47,7 @@ const MintBalanceDisplay: React.FC<Props> = ({
   updateSelectedMint = true,
   allowedMints,
   allowedUnits,
+  requireValidMint = false,
   style,
 }) => {
   const theme = useSelector(memoizedGetTheme);
@@ -49,6 +56,13 @@ const MintBalanceDisplay: React.FC<Props> = ({
   const selectedMint = useSelector(memoizedGetSelectedMint);
   const mintInfo = useGetMintInfo({ mintUrl: selectedMint });
   const balance = useSelector(memoizedGetBalance(unit, selectedMint));
+
+  const isMintAllowed = useMemo(
+    () => (allowedMints ? allowedMints.includes(selectedMint) : true),
+    [allowedMints, selectedMint]
+  );
+
+  const showMintInfo = !(requireValidMint && !isMintAllowed);
 
   const handlePress = () => {
     SheetManager.show('mint-balance', {
@@ -83,14 +97,23 @@ const MintBalanceDisplay: React.FC<Props> = ({
           },
           style,
         ]}>
-        <View style={{ flexDirection: 'row' }}>
-          <MintIcon mintInfo={mintInfo} />
-          <View style={{ flexDirection: 'column', alignItems: 'flex-start', marginRight: 10 }}>
-            <Text style={styles.name}>
-              {mintInfo?.name || selectedMint?.replace('https://', '').split('/')[0]}
-            </Text>
-            <AmountFormatter size={12} weight="heavy" amount={balance} unit={unit} />
-          </View>
+        <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+          {showMintInfo ? (
+            <>
+              <MintIcon mintInfo={mintInfo} />
+              <View style={{ flexDirection: 'column', alignItems: 'flex-start', marginRight: 10 }}>
+                <Text style={styles.name}>
+                  {mintInfo?.name || selectedMint?.replace('https://', '').split('/')[0]}
+                </Text>
+                <AmountFormatter size={12} weight="heavy" amount={balance} unit={unit} />
+              </View>
+            </>
+          ) : (
+            <>
+              <Icon name="fluent:add-24-filled" size={20} color={greys(theme)[0]} />
+              <Text style={[styles.name, { marginLeft: 8 }]}>Selected mint</Text>
+            </>
+          )}
         </View>
         <View style={styles.chevronContainer}>
           <Icon name="fluent:chevron-down-12-filled" size={12} color={greys(theme)[0]} />


### PR DESCRIPTION
## Summary
- show placeholder on MintBalanceDisplay when the currently selected mint is not allowed
- disallow continuing in currency screen until an allowed mint is chosen

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_686d80d8c7948325ad2262aaf6310c51