### PR TITLE
Refactor cashu client to use neverthrow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,31 +39,33 @@ const createStyles = (theme: any) =>
 
 **Design:** Check `design.tsx` as it has some useful components.
 
-**Primary:** Use Tailwind CSS for styling whenever possible.
-
-**Colors:** When you need theme-aware colors, use inline styles:
-
-- Simple: `style={{backgroundColor: greys(theme)[950]}}`
-- Complex: Create a `createStyles` function as shown in the example above
-
 **Note:** Check `helper/colors` for the complete list of available theme colors.
 
-**Types:** For StyleSheet props use `style?: StyleProp<ViewStyle>`
+# Tailwind
+
+We are migrating away from `createStyles` but it has some differences from a full Tailwind conversion.
+
+- Our colors for `greys` goes from `50,100,200,300,400,500,600,700,800,900,950` and shades `goes` from `100-500`
+- Do not use Tailwind styles on `<Text />` components directly. Just use inline styles.
+- Use inline styles for everything except for color related styles so change `<View style={{color: greys(theme)[900], marginBottom: 8 }}>` -> `<View className="mb-1" style={{color: greys(theme)[900] }}>`
+
+# Error handling
+
+- Instead of using async/await we now use `neverthrow`
+- Example of typical pattern for neverthrow function calls:
 
 ```
-style={[
-  {
-    color: 'red',
-    ...style
-  },
-]}
-
-->
-
-style={[
-  {
-    color: 'red'
-  },
-  style,
-]}
+  const walletRes = await getWallet({ unit, mintUrl, profile: null });
+  if (walletRes.isErr()) return err(walletRes.error);
+  const wallet = walletRes.value;
 ```
+
+- You can also convert functions from other libraries using:
+
+```
+  const spentRes = await toResult(wallet.checkProofsStates(proofs));
+```
+
+# Text
+
+- use `size` and other props provided by Text to change size,font,weight rather than inline styles.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Sovran is an open-source Bitcoin wallet powered by ecash with Nostr capabilities
 
 ## Features
 
+- [x] Deeplinks, can receive ecash via airdrop, can send via airdrop.
 - [x] (optional) pin code to unlock app
 - [ ] Payment requests (needs more testing)
 

--- a/app/(drawer)/(tabs)/index.tsx
+++ b/app/(drawer)/(tabs)/index.tsx
@@ -34,8 +34,8 @@ import AnimatedSpriteBackground from 'components/common/SpriteView';
 import { LinearGradient } from 'expo-linear-gradient';
 import opacity from 'hex-color-opacity';
 import { AccountPagerView } from 'components/layout/AccountPagerView';
-import { Card } from 'components/common/Card';
 import { useDeeplink } from 'hooks/useDeeplink';
+import { Card } from 'components/common/Card';
 interface NPUBQuote {
   amount: number;
   createdAt: number;

--- a/app/(drawer)/(tabs)/lifestyle.tsx
+++ b/app/(drawer)/(tabs)/lifestyle.tsx
@@ -101,9 +101,9 @@ const ServicesSection = () => {
 
   const handleNavigation = (item: MenuItemData) => {
     if (item.params) {
-      navigation.navigate(item.navigateTo, item.params);
+      navigation.navigate(item.navigateTo, item.params, {});
     } else {
-      navigation.navigate(item.navigateTo);
+      navigation.navigate(item.navigateTo, {}, {});
     }
   };
 
@@ -126,7 +126,7 @@ const ServicesSection = () => {
       </Text>
       <View style={styles.gridContainer}>
         {SERVICE_MENU_ITEMS.filter((item) =>
-          ['giftcards', 'vpn', 'esims', 'donate'].includes(item.id) ? settings?.experimental : true
+          ['giftcards', 'donate'].includes(item.id) ? settings?.experimental : true
         ).map((item) => (
           <MenuItem
             key={item.id}

--- a/app/MessagePage/CashuTokenComponent.tsx
+++ b/app/MessagePage/CashuTokenComponent.tsx
@@ -40,11 +40,11 @@ const CashuTokenComponent = ({ token, theme, isReceived }: Props) => {
   };
 
   const handleRedeem = async () => {
-    try {
-      await receiveEcash({ token, unit });
+    const res = await receiveEcash({ token, unit });
+    if (res.isOk()) {
       showMessage('funds_received', { amount, unit }, { emoji: '🎉' });
-    } catch (error) {
-      showMessage(error.message, {}, { emoji: '🚨' });
+    } else {
+      showMessage(res.error.message, {}, { emoji: '🚨' });
     }
   };
 

--- a/app/VpnShare.tsx
+++ b/app/VpnShare.tsx
@@ -7,7 +7,7 @@ import { useTypedRoute } from 'helper/navigation';
 import { truncateMiddle } from 'helper/strings';
 import { showMessage } from 'helper/popup/popups';
 import { ButtonHandler } from 'components/common/ButtonHandler';
-import { View } from 'components/common/View';
+import { Spacer, View } from 'components/common/View';
 import { Section } from 'components/common/Section';
 import { withSheetProvider } from 'hocs/withSheetProvider';
 
@@ -67,6 +67,7 @@ function ModalScreen() {
         variant="secondary"
         unit={`location_${location}`}
       />
+      <Spacer size={12} />
       {config && (
         <Section
           items={[

--- a/app/bitrefill.tsx
+++ b/app/bitrefill.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { StyleSheet, Dimensions } from 'react-native';
 import { WebView } from 'react-native-webview';
 import { getMeltQuote } from 'helper/cashuClient';
+import { showMessage } from 'helper/popup/popups';
 import { useNavigation } from 'expo-router';
 import { useSelector } from 'react-redux';
 import { useBitrefill } from 'helper/redux/bitrefill';
@@ -79,19 +80,23 @@ function BitrefillWidget({ url = BITREFILL_URL }) {
       const { paymentAddress } = data;
       const mintUrl = memoizedGetSelectedMint(store.getState());
 
-      const meltQuote = await getMeltQuote({
+      const meltQuoteRes = await getMeltQuote({
         pr: paymentAddress,
         unit: 'sat',
         mintUrl,
       });
-
-      navigation.navigate('lightningSendConfirmation', {
-        pr: paymentAddress,
-        unit: 'sat',
-        meltQuote: JSON.stringify(meltQuote),
-        pubkey: BITREFILL_NOSTR_PUBKEY,
-        email: email,
-      });
+      if (meltQuoteRes.isOk()) {
+        const meltQuote = meltQuoteRes.value;
+        navigation.navigate('lightningSendConfirmation', {
+          pr: paymentAddress,
+          unit: 'sat',
+          meltQuote: JSON.stringify(meltQuote),
+          pubkey: BITREFILL_NOSTR_PUBKEY,
+          email: email,
+        });
+      } else {
+        showMessage(meltQuoteRes.error.message, {}, { emoji: '🚨' });
+      }
     }
   };
 

--- a/app/currency.tsx
+++ b/app/currency.tsx
@@ -85,25 +85,29 @@ function ModalScreen() {
         amount,
       })
     );
-    const response = await receiveLightning({
+    const res = await receiveLightning({
       amount: unit === 'sat' ? amount : amount * 100,
       unit: unit,
       memo,
     });
-
-    navigation?.goBack();
-    navigation.replace(params.to, {
-      ...params,
-      unifiedRequest: response.unifiedRequest,
-      paymentRequest: response.paymentRequest,
-      request: response.request,
-      amount: unit === 'sat' ? amount : amount * 100,
-      transaction: JSON.stringify(response),
-    });
+    if (res.isOk()) {
+      const response = res.value;
+      navigation?.goBack();
+      navigation.replace(params.to, {
+        ...params,
+        unifiedRequest: response.unifiedRequest,
+        paymentRequest: response.paymentRequest,
+        request: response.request,
+        amount: unit === 'sat' ? amount : amount * 100,
+        transaction: JSON.stringify(response),
+      });
+    } else {
+      showMessage(res.error.message, {}, { emoji: '🚨' });
+    }
   };
 
   const handleEcashSend = async ({ message }) => {
-    const transaction = await sendEcash({
+    const result = await sendEcash({
       to: npubToPublicKey(params?.profile?.npub),
       amount: unit === 'sat' ? amount : amount * 100,
       unit: unit,
@@ -119,12 +123,17 @@ function ModalScreen() {
         : {}),
     });
 
-    navigation.replace(params.to, {
-      ...params,
-      token: transaction.token,
-      amount: unit === 'sat' ? amount : amount * 100,
-      paymentRequest: params.paymentRequest,
-    });
+    if (result.isOk()) {
+      const transaction = result.value;
+      navigation.replace(params.to, {
+        ...params,
+        token: transaction.token,
+        amount: unit === 'sat' ? amount : amount * 100,
+        paymentRequest: params.paymentRequest,
+      });
+    } else {
+      showMessage(result.error.message, {}, { emoji: '🚨' });
+    }
   };
 
   const handleDefaultSend = async () => {
@@ -133,11 +142,16 @@ function ModalScreen() {
       tokens: utils.toSats(amount),
     });
 
-    const meltQuote = await getMeltQuote({
+    const meltQuoteRes = await getMeltQuote({
       pr: invoice,
       unit: unit,
       mintUrl: selectedMint,
     });
+    if (meltQuoteRes.isErr()) {
+      showMessage(meltQuoteRes.error.message, {}, { emoji: '🚨' });
+      return;
+    }
+    const meltQuote = meltQuoteRes.value;
 
     const totalAmount = Number(amount) + Number(meltQuote.fee_reserve);
 
@@ -166,8 +180,7 @@ function ModalScreen() {
 
     setLoading(true);
 
-    try {
-      switch (params.to) {
+    switch (params.to) {
         case 'lightningReceiveConfirmation':
           SheetManager.show('transaction-message', {
             onClose: async (data) => {
@@ -207,11 +220,6 @@ function ModalScreen() {
           setLoading(false);
           break;
       }
-    } catch (e) {
-      showMessage(e?.message, { ...e?.params }, { emoji: '🚨' });
-      setLoading(false);
-    } finally {
-    }
   };
 
   useEffect(() => {

--- a/app/currency.tsx
+++ b/app/currency.tsx
@@ -126,6 +126,14 @@ function ModalScreen() {
         paymentRequest: params.paymentRequest,
       });
     } else {
+      console.log(1298372, {
+        result,
+        error: result.error,
+        message: result.error.message,
+        cause: result.error.cause,
+        name: result.error.name,
+        stack: result.error.stack,
+      });
       showMessage(result.error.message, {}, { emoji: '🚨' });
     }
   };
@@ -175,45 +183,45 @@ function ModalScreen() {
     setLoading(true);
 
     switch (params.to) {
-        case 'lightningReceiveConfirmation':
-          SheetManager.show('transaction-message', {
-            onClose: async (data) => {
-              if (data?.action === 'confirm') {
-                await handleLightningReceive({ memo: data.message });
-              } else if (data?.action === 'skip') {
-                await handleLightningReceive({ memo: undefined });
-              }
-              setLoading(false);
-            },
-          });
-          break;
-        case 'ecashSendConfirmation':
-          // check balance
-          if (unit === 'sat' ? balance < amount : balance < amount * 100) {
-            showMessage(
-              'insufficient_balance',
-              { amount: unit === 'sat' ? amount : amount * 100, unit, fee: 0 },
-              { emoji: '🚨' }
-            );
+      case 'lightningReceiveConfirmation':
+        SheetManager.show('transaction-message', {
+          onClose: async (data) => {
+            if (data?.action === 'confirm') {
+              await handleLightningReceive({ memo: data.message });
+            } else if (data?.action === 'skip') {
+              await handleLightningReceive({ memo: undefined });
+            }
             setLoading(false);
-            return;
-          }
-          SheetManager.show('transaction-message', {
-            onClose: async (data) => {
-              if (data?.action === 'confirm') {
-                await handleEcashSend({ message: data.message });
-              } else if (data?.action === 'skip') {
-                await handleEcashSend({ message: undefined });
-              }
-              setLoading(false);
-            },
-          });
-          break;
-        default:
-          await handleDefaultSend();
+          },
+        });
+        break;
+      case 'ecashSendConfirmation':
+        // check balance
+        if (unit === 'sat' ? balance < amount : balance < amount * 100) {
+          showMessage(
+            'insufficient_balance',
+            { amount: unit === 'sat' ? amount : amount * 100, unit, fee: 0 },
+            { emoji: '🚨' }
+          );
           setLoading(false);
-          break;
-      }
+          return;
+        }
+        SheetManager.show('transaction-message', {
+          onClose: async (data) => {
+            if (data?.action === 'confirm') {
+              await handleEcashSend({ message: data.message });
+            } else if (data?.action === 'skip') {
+              await handleEcashSend({ message: undefined });
+            }
+            setLoading(false);
+          },
+        });
+        break;
+      default:
+        await handleDefaultSend();
+        setLoading(false);
+        break;
+    }
   };
 
   useEffect(() => {

--- a/app/currency.tsx
+++ b/app/currency.tsx
@@ -66,16 +66,10 @@ function ModalScreen() {
   const urDecoder = new URDecoder();
 
   const handleMintSelected = async (mint, balance) => {
-    try {
-      dispatch(setSelectedMint({ profileId, mintUrl: mint.id }));
-      const newUnit = mint.unit.toLowerCase();
-      setUnit(newUnit);
-      navigation.setParams({ ...params, unit: newUnit });
-    } catch (error) {
-      showMessage('general_error', {}, { emoji: '🚨' });
-
-      throw error;
-    }
+    dispatch(setSelectedMint({ profileId, mintUrl: mint.id }));
+    const newUnit = mint.unit.toLowerCase();
+    setUnit(newUnit);
+    navigation.setParams({ ...params, unit: newUnit });
   };
 
   const handleLightningReceive = async ({ memo }) => {

--- a/app/ecashReceiveConfirmation.tsx
+++ b/app/ecashReceiveConfirmation.tsx
@@ -129,21 +129,20 @@ export function EcashReceiveConfirmation({
   };
 
   const handleRedeem = async () => {
-    try {
-      setLoading(true);
-      await receiveEcash({
-        token: token as string,
-        unit: unit as string,
-      });
+    setLoading(true);
+    const res = await receiveEcash({
+      token: token as string,
+      unit: unit as string,
+    });
 
+    if (res.isOk()) {
       showMessage('funds_received', { amount, unit }, { emoji: '🎉' }, () => {
         navigation.navigate('index', {}, { closeParents: true });
       });
-
-      setLoading(false);
-    } catch (error) {
-      showMessage(error.message);
+    } else {
+      showMessage(res.error.message);
     }
+    setLoading(false);
   };
 
   const handleRedeemPress = async () => {

--- a/app/ecashSendConfirmation.tsx
+++ b/app/ecashSendConfirmation.tsx
@@ -26,6 +26,7 @@ import {
   useGetMintInfo,
 } from 'helper/redux/cashu';
 import { cancelEcashTransaction, getWallet } from 'helper/cashuClient';
+import { toResult } from 'helper/toResult';
 import { memoizedGetTheme } from 'helper/redux/settings';
 import { useTypedNavigation, useTypedRoute } from 'helper/navigation';
 import { showMessage, showSuccess } from 'helper/popup/popups';
@@ -133,10 +134,9 @@ export function EcashSendConfirmation({
       (t) => t.token === token && t.transactionType === 'send'
     );
 
-    try {
-      await cancelEcashTransaction(transaction, navigation);
-    } catch (error) {
-      showMessage(error.message, {}, {}, onClose);
+    const res = await cancelEcashTransaction(transaction, navigation);
+    if (res.isErr()) {
+      showMessage(res.error.message, {}, {}, onClose);
     }
   };
 
@@ -145,53 +145,47 @@ export function EcashSendConfirmation({
 
   const { isListening } = useAutoListenBatch(getCurrentTransaction);
 
-  const checkProofsSpent = async (token: string): Promise<boolean> => {
-    try {
-      const decodedToken = getDecodedToken(token);
-      const { unit, mint: mintUrl, proofs } = decodedToken;
+  const checkProofsSpent = async (token: string): Promise<Result<boolean, Error>> => {
+    const decodedToken = getDecodedToken(token);
+    const { unit, mint: mintUrl, proofs } = decodedToken;
 
-      const wallet = await getWallet({
-        unit,
-        mintUrl,
-        profile: null,
-      });
+    const walletRes = await getWallet({
+      unit,
+      mintUrl,
+      profile: null,
+    });
+    if (walletRes.isErr()) return err(walletRes.error);
+    const wallet = walletRes.value;
 
-      if (!wallet) {
-        throw new Error('Failed to initialize wallet');
-      }
+    const spentRes = await toResult(wallet.checkProofsStates(proofs));
+    if (spentRes.isErr()) return err(spentRes.error);
 
-      const spentProofs = await wallet.checkProofsStates(proofs);
-
-      if (spentProofs.some((p) => p.state === 'SPENT')) {
-        // Update transaction state
-        const profileId = store.getState().nostr?.currentProfile?.id;
-        await store.dispatch(
-          updateTransaction({
-            profileId,
-            matcher: (tx) => tx.token === token,
-            updateFn: (tx) => ({
-              ...tx,
-              paid: true,
-            }),
-          })
-        );
-
-        return true; // Proofs are spent
-      }
-
-      return false; // Proofs are not spent
-    } catch (error) {
-      throw error;
+    if (spentRes.value.some((p) => p.state === 'SPENT')) {
+      const profileId = store.getState().nostr?.currentProfile?.id;
+      await store.dispatch(
+        updateTransaction({
+          profileId,
+          matcher: (tx) => tx.token === token,
+          updateFn: (tx) => ({
+            ...tx,
+            paid: true,
+          }),
+        })
+      );
+      return ok(true);
     }
+
+    return ok(false);
   };
 
   const handleCheckStatus = async (onClose) => {
     if (isCheckingStatus) return;
 
-    try {
-      setIsCheckingStatus(true);
-      const proofsSpent = await checkProofsSpent(token);
+    setIsCheckingStatus(true);
+    const result = await checkProofsSpent(token);
 
+    if (result.isOk()) {
+      const proofsSpent = result.value;
       if (proofsSpent) {
         const decodedToken = getDecodedToken(token);
         const amount = _.sumBy(decodedToken.proofs, 'amount');
@@ -209,11 +203,10 @@ export function EcashSendConfirmation({
       } else {
         showMessage('ecash_transaction_pending', {}, { emoji: '❌' }, onClose);
       }
-    } catch (error) {
-      showMessage('error_checking_status', { error: error.message }, { emoji: '⚠️' }, onClose);
-    } finally {
-      setIsCheckingStatus(false);
+    } else {
+      showMessage('error_checking_status', { error: result.error.message }, { emoji: '⚠️' }, onClose);
     }
+    setIsCheckingStatus(false);
   };
 
   const handleCopyEmoji = async (onClose) => {

--- a/app/ecashSendConfirmation.tsx
+++ b/app/ecashSendConfirmation.tsx
@@ -45,6 +45,7 @@ import { memoizedGetCurrentProfile } from 'helper/redux/nostr';
 import { MintQuoteTimeline } from './lightningReceiveConfirmation';
 import { TransactionMintRefresh } from 'components/common/Transaction/TransactionMintRefresh';
 import { TransactionDebugCode } from 'components/common/Transaction/TransactionDebugCode';
+import { err, ok, Result } from 'neverthrow';
 
 export function EcashSendConfirmation({
   unit,
@@ -130,9 +131,7 @@ export function EcashSendConfirmation({
     const profileId = store.getState().nostr?.currentProfile?.id;
     const transactions = memoizedGetTransactions({ id: profileId })(store.getState());
 
-    const transaction = transactions.find(
-      (t) => t.token === token && t.transactionType === 'send'
-    );
+    const transaction = transactions.find((t) => t.token === token && t.transactionType === 'send');
 
     const res = await cancelEcashTransaction(transaction, navigation);
     if (res.isErr()) {
@@ -204,7 +203,12 @@ export function EcashSendConfirmation({
         showMessage('ecash_transaction_pending', {}, { emoji: '❌' }, onClose);
       }
     } else {
-      showMessage('error_checking_status', { error: result.error.message }, { emoji: '⚠️' }, onClose);
+      showMessage(
+        'error_checking_status',
+        { error: result.error.message },
+        { emoji: '⚠️' },
+        onClose
+      );
     }
     setIsCheckingStatus(false);
   };

--- a/app/ecashSendConfirmation.tsx
+++ b/app/ecashSendConfirmation.tsx
@@ -126,14 +126,14 @@ export function EcashSendConfirmation({
   };
 
   const handleCancelSend = async (onClose) => {
+    const profileId = store.getState().nostr?.currentProfile?.id;
+    const transactions = memoizedGetTransactions({ id: profileId })(store.getState());
+
+    const transaction = transactions.find(
+      (t) => t.token === token && t.transactionType === 'send'
+    );
+
     try {
-      const profileId = store.getState().nostr?.currentProfile?.id;
-      const transactions = memoizedGetTransactions({ id: profileId })(store.getState());
-
-      const transaction = transactions.find(
-        (t) => t.token === token && t.transactionType === 'send'
-      );
-
       await cancelEcashTransaction(transaction, navigation);
     } catch (error) {
       showMessage(error.message, {}, {}, onClose);

--- a/app/esimCheckout.tsx
+++ b/app/esimCheckout.tsx
@@ -48,45 +48,42 @@ function ModalScreen() {
   }, []);
 
   const handleMintSelected = async (mint, balance) => {
-    try {
-      dispatch(setSelectedMint({ profileId, mintUrl: mint.id }));
-      setUnit(mint.unit);
-    } catch (error) {
-      throw error;
-    }
+    dispatch(setSelectedMint({ profileId, mintUrl: mint.id }));
+    setUnit(mint.unit);
   };
 
   const handleBuy = async () => {
     setLoading(true);
-    try {
-      const meltQuote = await getMeltQuote({
-        pr: params.request,
-        unit: 'sat',
-        mintUrl: selectedMint,
-      });
-
-      const amount = getLightningAmount({ pr: params.request });
-      const totalAmount = amount + meltQuote.fee_reserve;
-
-      if (balance < totalAmount) {
-        showMessage(
-          'insufficient_balance',
-          { amount, unit, fee: meltQuote.fee_reserve },
-          { emoji: '🚨' }
-        );
-      } else {
-        navigation.navigate('lightningSendConfirmation', {
-          pr: params.request,
-          unit,
-          meltQuote: JSON.stringify(meltQuote),
-          pubkey: '1e53e900c3bbc5ead295215efe27b2c8d5fbd15fb3dd810da3063674cb7213b2',
-        });
-      }
-    } catch (error) {
+    const meltQuoteRes = await getMeltQuote({
+      pr: params.request,
+      unit: 'sat',
+      mintUrl: selectedMint,
+    });
+    if (meltQuoteRes.isErr()) {
       showMessage('general_error', {}, { emoji: '❌' });
-    } finally {
       setLoading(false);
+      return;
     }
+    const meltQuote = meltQuoteRes.value;
+
+    const amount = getLightningAmount({ pr: params.request });
+    const totalAmount = amount + meltQuote.fee_reserve;
+
+    if (balance < totalAmount) {
+      showMessage(
+        'insufficient_balance',
+        { amount, unit, fee: meltQuote.fee_reserve },
+        { emoji: '🚨' }
+      );
+    } else {
+      navigation.navigate('lightningSendConfirmation', {
+        pr: params.request,
+        unit,
+        meltQuote: JSON.stringify(meltQuote),
+        pubkey: '1e53e900c3bbc5ead295215efe27b2c8d5fbd15fb3dd810da3063674cb7213b2',
+      });
+    }
+    setLoading(false);
   };
 
   const getSectionItems = () => {

--- a/app/lightningReceiveConfirmation.tsx
+++ b/app/lightningReceiveConfirmation.tsx
@@ -41,6 +41,7 @@ import { TransactionMintRefresh } from 'components/common/Transaction/Transactio
 import Icon from 'assets/icons';
 import { TransactionDebugCode } from 'components/common/Transaction/TransactionDebugCode';
 import opacity from 'hex-color-opacity';
+import { err } from 'neverthrow';
 interface MintQuoteTimelineProps {
   mintQuotes?: (MintQuoteResponse & { addedAt?: number })[];
   meltQuotes?: {
@@ -432,72 +433,76 @@ export function LightningReceiveConfirmation({
     }
     const status = statusRes.value;
 
-      if (status.state === 'PAID') {
-        const profileId = store.getState().nostr?.currentProfile?.id;
+    if (status.state === 'PAID') {
+      const profileId = store.getState().nostr?.currentProfile?.id;
 
-        const counter = memoizedGetCounterV2({
+      const counter = memoizedGetCounterV2({
+        profileId: store.getState().nostr.currentProfile.id,
+        mintUrl: currentTx.mintUrl,
+        keysetId: wallet.keysetId,
+      })(store.getState());
+
+      // Mint proofs
+      const proofsResult = await toResult(
+        wallet.mintProofs(amount, currentTx.mintQuote.quote, {
+          counter,
+          keysetId: wallet.keysetId,
+        })
+      );
+      if (proofsResult.isErr()) return err(proofsResult.error);
+      const proofs = proofsResult.value;
+
+      // Increase counter
+      store.dispatch(
+        increaseCounterV2({
           profileId: store.getState().nostr.currentProfile.id,
           mintUrl: currentTx.mintUrl,
           keysetId: wallet.keysetId,
-        })(store.getState());
+          amount: proofs.length,
+        })
+      );
 
-        // Mint proofs
-        const proofs = await wallet.mintProofs(amount, currentTx.mintQuote.quote, {
-          counter,
-          keysetId: wallet.keysetId,
-        });
+      // Add proofs to redux
+      await store.dispatch(
+        appendProofsV2({
+          profileId: store.getState().nostr.currentProfile.id,
+          mintUrl: currentTx.mintUrl,
+          proofs: proofs,
+        })
+      );
 
-        // Increase counter
-        store.dispatch(
-          increaseCounterV2({
-            profileId: store.getState().nostr.currentProfile.id,
-            mintUrl: currentTx.mintUrl,
-            keysetId: wallet.keysetId,
-            amount: proofs.length,
-          })
-        );
+      // Publish wallet event, this basically just makes sure we can restore our account via nostr
+      const currentProfileId = store.getState().nostr.currentProfile.id;
+      const existingTxs = memoizedGetTransactions({ id: currentProfileId })(store.getState());
+      publishWalletEvent([...new Set([...existingTxs.map((t) => t.mintUrl), currentTx.mintUrl])]);
 
-        // Add proofs to redux
-        await store.dispatch(
-          appendProofsV2({
-            profileId: store.getState().nostr.currentProfile.id,
-            mintUrl: currentTx.mintUrl,
-            proofs: proofs,
-          })
-        );
+      // Update transaction status to paid
+      showMessage('funds_sent', {
+        amount: currentTx.amount,
+        unit: currentTx.unit,
+      });
 
-        // Publish wallet event, this basically just makes sure we can restore our account via nostr
-        const currentProfileId = store.getState().nostr.currentProfile.id;
-        const existingTxs = memoizedGetTransactions({ id: currentProfileId })(store.getState());
-        publishWalletEvent([...new Set([...existingTxs.map((t) => t.mintUrl), currentTx.mintUrl])]);
+      await store.dispatch(
+        updateTransaction({
+          profileId,
+          matcher: (tx) => tx.request === currentTx.request,
+          updateFn: (tx) => ({
+            ...tx,
+            paid: true,
+          }),
+        })
+      );
 
-        // Update transaction status to paid
-        showMessage('funds_sent', {
-          amount: currentTx.amount,
-          unit: currentTx.unit,
-        });
-
-        await store.dispatch(
-          updateTransaction({
-            profileId,
-            matcher: (tx) => tx.request === currentTx.request,
-            updateFn: (tx) => ({
-              ...tx,
-              paid: true,
-            }),
-          })
-        );
-
-        showMessage(
-          'funds_received',
-          { amount: currentTx.amount, unit: currentTx.unit },
-          { emoji: '🎉' },
-          onClose
-        );
-      } else if (status.state === 'ISSUED') {
-      } else {
-        showMessage('lightning_transaction_pending', {}, { emoji: '❌' }, onClose);
-      }
+      showMessage(
+        'funds_received',
+        { amount: currentTx.amount, unit: currentTx.unit },
+        { emoji: '🎉' },
+        onClose
+      );
+    } else if (status.state === 'ISSUED') {
+    } else {
+      showMessage('lightning_transaction_pending', {}, { emoji: '❌' }, onClose);
+    }
   };
 
   const mintInfo = useGetMintInfo({ mintUrl: getCurrentTransaction[0].mintUrl });

--- a/app/lightningReceiveConfirmation.tsx
+++ b/app/lightningReceiveConfirmation.tsx
@@ -20,6 +20,7 @@ import {
 } from 'helper/redux/cashu';
 import { useNavigation } from 'expo-router';
 import { getWallet, getRawExpiry } from 'helper/cashuClient';
+import { toResult } from 'helper/toResult';
 import { store } from 'helper/redux/store';
 import { Section } from 'components/common/Section';
 import { withSheetProvider } from 'hocs/withSheetProvider';
@@ -404,21 +405,32 @@ export function LightningReceiveConfirmation({
   // const { isListening } = useAutoListenBatch(getCurrentTransaction);
 
   const handleCheckStatus = async (onClose, forceRefresh) => {
-    try {
-      const currentTx = getCurrentTransaction[0];
-      const wallet = await getWallet({
-        unit: currentTx.unit,
-        mintUrl: currentTx.mintUrl,
-        profile: null,
-        forceRefresh,
-      });
-      const activeKeyset = wallet.getActiveKeyset(
-        wallet.keysets.filter((key) => key.unit === currentTx.unit)
-      );
-      const keysetId = activeKeyset.id;
-      wallet.keysetId = keysetId;
+    const currentTx = getCurrentTransaction[0];
+    const walletRes = await getWallet({
+      unit: currentTx.unit,
+      mintUrl: currentTx.mintUrl,
+      profile: null,
+      forceRefresh,
+    });
+    if (walletRes.isErr()) {
+      if (walletRes.error.message === 'keyset id inactive.') {
+        handleCheckStatus(onClose, true);
+      }
+      return;
+    }
+    const wallet = walletRes.value;
+    const activeKeyset = wallet.getActiveKeyset(
+      wallet.keysets.filter((key) => key.unit === currentTx.unit)
+    );
+    const keysetId = activeKeyset.id;
+    wallet.keysetId = keysetId;
 
-      const status = await wallet.checkMintQuote(currentTx.mintQuote?.quote);
+    const statusRes = await toResult(wallet.checkMintQuote(currentTx.mintQuote?.quote));
+    if (statusRes.isErr()) {
+      showMessage(statusRes.error.message);
+      return;
+    }
+    const status = statusRes.value;
 
       if (status.state === 'PAID') {
         const profileId = store.getState().nostr?.currentProfile?.id;
@@ -486,12 +498,6 @@ export function LightningReceiveConfirmation({
       } else {
         showMessage('lightning_transaction_pending', {}, { emoji: '❌' }, onClose);
       }
-    } catch (error) {
-      if (error.message === 'keyset id inactive.') {
-        handleCheckStatus(onClose, true);
-      } else {
-      }
-    }
   };
 
   const mintInfo = useGetMintInfo({ mintUrl: getCurrentTransaction[0].mintUrl });

--- a/app/lightningSendConfirmation.tsx
+++ b/app/lightningSendConfirmation.tsx
@@ -91,7 +91,7 @@ export function LightningSendConfirmation({
   const handleLightningSend = async () => {
     setLoading(true);
     try {
-      await sendLightning({
+      const result = await sendLightning({
         pr,
         unit,
         pubkey,
@@ -99,14 +99,17 @@ export function LightningSendConfirmation({
         email,
         lud16,
       });
-
-      showMessage('funds_sent', { amount, unit }, { emoji: '🎉' }, () => {
-        navigation.navigate(
-          redirect || (pubkey ? 'userMessages' : 'index'),
-          { pubkey },
-          { closeCurrentAndParents: true }
-        );
-      });
+      if (result.isOk()) {
+        showMessage('funds_sent', { amount, unit }, { emoji: '🎉' }, () => {
+          navigation.navigate(
+            redirect || (pubkey ? 'userMessages' : 'index'),
+            { pubkey },
+            { closeCurrentAndParents: true }
+          );
+        });
+      } else {
+        throw result.error;
+      }
     } catch (e) {
       const errorMessage = e instanceof Error ? e.message : 'Unknown error';
       showMessage(errorMessage, { error: errorMessage }, { emoji: '🚨' });

--- a/app/settings/proofs.tsx
+++ b/app/settings/proofs.tsx
@@ -8,6 +8,7 @@ import Container from 'components/layout/Container';
 import { memoizedGetTheme } from 'helper/redux/settings';
 import { greens, greys, reds } from 'helper/colors';
 import { getWallet } from 'helper/cashuClient';
+import { toResult } from 'helper/toResult';
 import { removeProofs } from 'helper/redux/cashu'; // Import the removeProofs action
 import { ScrollView } from 'react-native';
 import { memoizedGetCurrentProfile } from 'helper/redux/nostr';
@@ -60,31 +61,41 @@ export default function ModalScreen() {
       setCheckingSpent(true);
       setError(null);
 
-      try {
-        const wallet = await getWallet({ unit: 'sat', mintUrl, profile: currentProfile });
-
-        // Make sure proofs are in the correct format before checking
-        const validProofs = mintProofs.filter(
-          (proof) => proof && typeof proof === 'object' && proof.id && proof.C
-        );
-
-        if (validProofs.length === 0) {
-          throw new Error(`No valid proofs found for mint: ${mintUrl}`);
-        }
-
-        const states = await wallet.checkProofsStates(validProofs);
-
-        // Update proof states for this mint
-        setProofStates((prevStates) => ({
-          ...prevStates,
-          [mintUrl]: states,
-        }));
-      } catch (err) {
-        console.error(`Error checking spent status for ${mintUrl}:`, err);
-        setError(`Error for ${mintUrl}: ${err.message || JSON.stringify(err)}`);
-      } finally {
+      const walletResult = await getWallet({ unit: 'sat', mintUrl, profile: currentProfile });
+      if (walletResult.isErr()) {
+        console.error(`Error checking spent status for ${mintUrl}:`, walletResult.error);
+        setError(`Error for ${mintUrl}: ${walletResult.error.message}`);
         setCheckingSpent(false);
+        return;
       }
+
+      const wallet = walletResult.value;
+
+      const validProofs = mintProofs.filter(
+        (proof) => proof && typeof proof === 'object' && proof.id && proof.C
+      );
+
+      if (validProofs.length === 0) {
+        setError(`No valid proofs found for mint: ${mintUrl}`);
+        setCheckingSpent(false);
+        return;
+      }
+
+      const statesResult = await toResult(wallet.checkProofsStates(validProofs));
+      if (statesResult.isErr()) {
+        console.error(`Error checking spent status for ${mintUrl}:`, statesResult.error);
+        setError(`Error for ${mintUrl}: ${statesResult.error.message}`);
+        setCheckingSpent(false);
+        return;
+      }
+
+      const states = statesResult.value;
+
+      setProofStates((prevStates) => ({
+        ...prevStates,
+        [mintUrl]: states,
+      }));
+      setCheckingSpent(false);
     },
     [allProofs, currentProfile]
   );
@@ -95,12 +106,7 @@ export default function ModalScreen() {
     setError(null);
 
     for (const mintUrl of allMints) {
-      try {
-        await checkProofSpentStatus(mintUrl);
-      } catch (err) {
-        console.error(`Failed to check mint ${mintUrl}:`, err);
-        // Continue with other mints even if one fails
-      }
+      await checkProofSpentStatus(mintUrl);
     }
 
     setCheckingSpent(false);

--- a/app/vpn.tsx
+++ b/app/vpn.tsx
@@ -273,26 +273,26 @@ function ModalScreen() {
                     },
                   ]
                 : []),
-              ...(remainingTime !== 'Not activated'
-                ? [
-                    vpnStatus?.isConnected
-                      ? {
-                          text: 'Disconnect',
-                          variant: 'primary',
-                          onPress: handleDisconnect,
-                        }
-                      : {
-                          text: 'Connect',
-                          variant: 'primary',
-                          onPress: handleConnect,
-                        },
-                    {
-                      text: 'Status',
-                      variant: 'secondary',
-                      onPress: handleStatus,
-                    },
-                  ]
-                : []),
+              // ...(remainingTime !== 'Not activated'
+              //   ? [
+              //       vpnStatus?.isConnected
+              //         ? {
+              //             text: 'Disconnect',
+              //             variant: 'primary',
+              //             onPress: handleDisconnect,
+              //           }
+              //         : {
+              //             text: 'Connect',
+              //             variant: 'primary',
+              //             onPress: handleConnect,
+              //           },
+              //       {
+              //         text: 'Status',
+              //         variant: 'secondary',
+              //         onPress: handleStatus,
+              //       },
+              //     ]
+              //   : []),
             ]}
           />
         </View>

--- a/app/vpnCheckout.tsx
+++ b/app/vpnCheckout.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Platform } from 'react-native';
 import { shades } from 'helper/colors';
 import Modal from 'components/layout/Modal';
-import { View } from 'components/common/View';
+import { Spacer, View } from 'components/common/View';
 import { Text } from 'components/common/Text';
 import { useNavigation } from 'expo-router';
 import lookup from 'country-code-lookup';
@@ -189,6 +189,7 @@ function ModalScreen() {
           // },
         ]}
       />
+      <Spacer size={12} />
       <Section
         camera={false}
         items={[
@@ -198,6 +199,8 @@ function ModalScreen() {
           },
         ]}
       />
+      <Spacer size={12} />
+
       <Text
         weight="bold"
         size={16}

--- a/app/vpnCheckout.tsx
+++ b/app/vpnCheckout.tsx
@@ -35,39 +35,40 @@ function ModalScreen() {
   const balance = useSelector(memoizedGetBalance(unit));
   const selectedMint = useSelector(memoizedGetSelectedMint);
   async function buyEsim() {
-    try {
-      const meltQuote = await getMeltQuote({
-        pr: params.request,
-        unit: 'sat',
-        mintUrl: selectedMint,
-      });
+    setLoading(true);
+    const meltQuoteRes = await getMeltQuote({
+      pr: params.request,
+      unit: 'sat',
+      mintUrl: selectedMint,
+    });
 
-      const amount = getLightningAmount({ pr: params.request });
-      // Alert.alert(String(amount));
-
-      const totalAmount = amount + meltQuote.fee_reserve;
-      //
-      const isBalanceSufficient = balance >= totalAmount;
-
-      if (!isBalanceSufficient) {
-        showMessage(
-          'insufficient_balance',
-          { amount, unit, fee: meltQuote.fee_reserve },
-          { emoji: '🚨' }
-        );
-      } else {
-        navigation.navigate('lightningSendConfirmation', {
-          pr: params.request,
-          unit,
-          meltQuote: JSON.stringify(meltQuote),
-          pubkey: LNVPN_PUBKEY,
-        });
-      }
-    } catch {
+    if (meltQuoteRes.isErr()) {
       showMessage('general_error', {}, { emoji: '❌' });
-    } finally {
       setLoading(false);
+      return;
     }
+
+    const meltQuote = meltQuoteRes.value;
+
+    const amount = getLightningAmount({ pr: params.request });
+    const totalAmount = amount + meltQuote.fee_reserve;
+    const isBalanceSufficient = balance >= totalAmount;
+
+    if (!isBalanceSufficient) {
+      showMessage(
+        'insufficient_balance',
+        { amount, unit, fee: meltQuote.fee_reserve },
+        { emoji: '🚨' }
+      );
+    } else {
+      navigation.navigate('lightningSendConfirmation', {
+        pr: params.request,
+        unit,
+        meltQuote: JSON.stringify(meltQuote),
+        pubkey: LNVPN_PUBKEY,
+      });
+    }
+    setLoading(false);
   }
 
   useEffect(() => {
@@ -89,14 +90,8 @@ function ModalScreen() {
     iconUrl: string | null;
     unit: string;
   }) => {
-    try {
-      // Update selected mint in Redux
-      dispatch(setSelectedMint({ profileId, mintUrl: mint.id }));
-      setUnit(mint.unit);
-      // Update account unit
-    } catch (error) {
-      throw error;
-    }
+    dispatch(setSelectedMint({ profileId, mintUrl: mint.id }));
+    setUnit(mint.unit);
   };
 
   return (

--- a/app/vpnShare.tsx
+++ b/app/vpnShare.tsx
@@ -7,7 +7,7 @@ import { useTypedRoute } from 'helper/navigation';
 import { truncateMiddle } from 'helper/strings';
 import { showMessage } from 'helper/popup/popups';
 import { ButtonHandler } from 'components/common/ButtonHandler';
-import { View } from 'components/common/View';
+import { Spacer, View } from 'components/common/View';
 import { Section } from 'components/common/Section';
 import { withSheetProvider } from 'hocs/withSheetProvider';
 
@@ -67,6 +67,7 @@ function ModalScreen() {
         variant="secondary"
         unit={`location_${location}`}
       />
+      <Spacer size={12} />
       {config && (
         <Section
           items={[

--- a/components/layout/Camera.tsx
+++ b/components/layout/Camera.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import { Dimensions, StyleSheet, TouchableOpacity, View, ViewStyle } from 'react-native';
+import { Dimensions, StyleSheet, TouchableOpacity, ViewStyle } from 'react-native';
 import { CameraView, useCameraPermissions } from 'expo-camera';
 import { useNavigation } from 'expo-router';
 import { greys } from 'helper/colors';
@@ -11,10 +11,9 @@ import { memoizedGetTheme } from 'helper/redux/settings';
 import { useTypedRoute } from 'helper/navigation';
 import * as Clipboard from 'expo-clipboard';
 import { showMessage } from 'helper/popup/popups';
-import opacity from 'hex-color-opacity';
-import { BlurView } from 'expo-blur';
 import Icon from 'assets/icons';
 import { barcodeHandler } from 'helper/payment-handler/handlers';
+import { View } from 'components/common/View';
 
 // Screen dimensions
 const { width: screenWidth } = Dimensions.get('window');
@@ -49,14 +48,11 @@ const BlurredCircleButton: React.FC<BlurredCircleButtonProps> = ({
   const theme = useSelector(memoizedGetTheme);
 
   return (
-    <BlurView intensity={intensity} tint={tint} style={[styles.blurContainer, style]}>
-      <TouchableOpacity
-        className="m-auto items-center rounded-lg "
-        style={{ backgroundColor: opacity(greys(theme)[800], 0.1) }}
-        onPress={onPress}>
+    <View blur blurIntensity={intensity} blurTint={tint} style={[styles.blurContainer, style]}>
+      <TouchableOpacity className="m-auto items-center rounded-lg " onPress={onPress}>
         {children}
       </TouchableOpacity>
-    </BlurView>
+    </View>
   );
 };
 

--- a/components/layout/Donut/RenderItem.tsx
+++ b/components/layout/Donut/RenderItem.tsx
@@ -7,6 +7,8 @@ import { View } from 'components/common/View';
 import { memoizedGetTheme } from 'helper/redux/settings';
 import { getMint } from 'helper/cashuClient';
 import Image from 'components/common/Image';
+import { toResult } from 'helper/toResult';
+import { err } from 'neverthrow';
 
 interface RenderItemData {
   color: string;
@@ -30,10 +32,15 @@ const RenderItem = ({ item, index }: Props) => {
   useEffect(() => {
     const fetchMintInfo = async () => {
       try {
-        const mint = await getMint({ mintUrl: item.subtitle });
-        const info = await mint.getInfo();
+        const mintResult = await getMint({ mintUrl: item.subtitle });
+        if (mintResult.isErr()) return err(mintResult.error);
+        const mint = mintResult.value;
 
-        setIconUrl(info?.icon_url); // Set the icon URL from the mint info
+        const mintInfoResult = await toResult(mint.getInfo());
+        if (mintInfoResult.isErr()) return err(mintInfoResult.error);
+        const mintInfo = mintInfoResult.value;
+
+        setIconUrl(mintInfo?.icon_url); // Set the icon URL from the mint info
       } catch {}
     };
 

--- a/components/layout/EcashLightningReceiver.tsx
+++ b/components/layout/EcashLightningReceiver.tsx
@@ -1,14 +1,13 @@
 import React, { useCallback } from 'react';
 import { View } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
-import { isValidEcashToken } from 'helper/cashuClient';
+import { checkIfAlreadyRedeemed, isValidEcashToken } from 'helper/cashuClient';
 import Modal from 'components/layout/Modal';
 import { SimplePool } from 'nostr-tools';
 import { PaymentInfo } from '../layout/PaymentInfo';
 import { useNostr } from 'helper/redux/nostr';
 import { useCameraPermissions } from 'expo-camera';
 import { getGiveaway } from 'app/ecashReceiveConfirmation';
-import { checkIfAlreadyRedeemed } from 'helper/payment-handler/handlers';
 import { showMessage } from 'helper/popup/popups';
 import { ButtonHandler } from 'components/common/ButtonHandler';
 import { useTypedNavigation } from 'helper/navigation';

--- a/components/layout/sheets/mints/MintAddMore.tsx
+++ b/components/layout/sheets/mints/MintAddMore.tsx
@@ -1,597 +1,368 @@
-import React, { useState, useEffect, useMemo } from 'react';
-import { View, Image, StyleSheet, ActivityIndicator } from 'react-native';
+import React, { useState, useMemo, useEffect, useRef } from 'react';
+import { Image, ActivityIndicator, Dimensions, ScrollView as RNScrollView } from 'react-native';
 import { greens, greys, reds } from 'helper/colors';
 import { useSelector } from 'react-redux';
-import { memoizedGetMints } from 'helper/redux/cashu/selectors';
 import Icon, { CurrencyIcon, FlagIcon } from 'assets/icons';
 import { TouchableOpacity } from 'components/common/TouchableOpacity';
 import { useSheetRouter } from 'react-native-actions-sheet/dist/src/hooks/use-router';
 import { Text } from 'components/common/Text';
 import { useSubscribe } from '@nostr-dev-kit/ndk-mobile';
 import Wrapper from '../wrapper';
-import { sovran } from '.';
 import { ScrollView } from 'react-native-actions-sheet';
-import { getMint, getWallet } from 'helper/cashuClient';
 import { ButtonHandler } from 'components/common/ButtonHandler';
 import { memoizedGetTheme } from 'helper/redux/settings';
+import { getMint } from 'helper/cashuClient';
+import { toResult } from 'helper/toResult';
+import { Spacer, View } from 'components/common/View';
+import { memoizedGetAllBalancesMultipleCurrencies } from 'helper/redux/cashu';
 
-interface MintCount {
+interface CommentProps {
+  pubkey: string;
+  message: string;
+  theme: string;
+}
+
+interface Review {
+  pubkey: string;
+  message: string;
+}
+interface MintInfo {
+  name?: string;
+  icon_url?: string;
+  nuts?: Record<string, any>;
+}
+interface MintStats {
   mintUrl: string;
-  count: number;
+  averageRating: number;
+  reviewCount: number;
+  reviews: Review[];
+  info?: MintInfo;
+  error?: Error;
+  loading: boolean;
 }
 
-function useRecommendedMints(): { mintCounts: MintCount[] } {
-  // Same as original implementation
-  const filters = useMemo(() => ({ kinds: [38000], limit: 2000 }), []);
+export function Comment({ pubkey, message, theme }: CommentProps) {
+  const filters = useMemo(() => ({ kinds: [0], authors: [pubkey], limit: 1 }), [pubkey]);
+  const { events = [], loading } = useSubscribe({ filters });
+  const profile = events[0] ? safeJson(events[0].content) : undefined;
 
-  const { events } = useSubscribe({ filters });
-  const mintCounts = useMemo(() => {
-    if (!events || events.length === 0) return [];
-    const mintUrls: string[] = [];
+  const displayName = profile?.name?.trim() || pubkey;
+  const avatarSrc = profile?.picture;
 
-    events.forEach((event: { tags: string[][] }) => {
-      const tags = event.tags || [];
-      const kTag = tags.find((t) => t[0] === 'k' && t[1] === '38172');
-      const uTag = tags.find((t) => t[0] === 'u');
+  const g = greys(theme);
 
-      if (kTag && uTag && typeof uTag[1] === 'string' && uTag[1].startsWith('https://')) {
-        mintUrls.push(uTag[1]);
-      }
-    });
+  return (
+    <View
+      blur
+      className={`mb-2 flex-row items-start rounded-lg p-2.5`}
+      style={[{ backgroundColor: g[800], borderWidth: 0.5, borderColor: g[900] }]}>
+      <Image
+        source={{ uri: avatarSrc }}
+        className={`mr-2.5`}
+        style={[{ width: 32, height: 32, borderRadius: 22, backgroundColor: g[200] }]}
+      />
 
-    const uniqueUrls = Array.from(new Set([...mintUrls]));
-    const counts: MintCount[] = [
-      ...uniqueUrls.map((url) => ({
-        mintUrl: url,
-        count: mintUrls.filter((u) => u === url).length,
-      })),
-      ...[
-        {
-          mintUrl: 'https://mint.lnw.cash',
-          averageTimeTaken: 3448,
-          successRate: 0.6764705882352942,
-          successCount: 23,
-          totalCount: 34,
-          count: 0,
-        },
-        {
-          mintUrl: 'https://mint.mountainlake.io',
-          averageTimeTaken: 3924,
-          successRate: 0.9642857142857143,
-          successCount: 54,
-          totalCount: 56,
-          count: 0,
-        },
-        {
-          mintUrl: 'https://mint.mjex.me',
-          averageTimeTaken: 24937,
-          successRate: 0.2222222222222222,
-          successCount: 2,
-          totalCount: 9,
-          count: 0,
-        },
-        {
-          mintUrl: 'https://mint.utxo.one',
-          averageTimeTaken: 3088,
-          successRate: 0.38095238095238093,
-          successCount: 8,
-          totalCount: 21,
-          count: 0,
-        },
-        {
-          mintUrl: 'https://mint.103100.xyz',
-          averageTimeTaken: 5401,
-          successRate: 0.9117647058823529,
-          successCount: 31,
-          totalCount: 34,
-          count: 0,
-        },
-        {
-          mintUrl: 'https://antifiat.cash',
-          averageTimeTaken: 4522,
-          successRate: 0.5357142857142857,
-          successCount: 15,
-          totalCount: 28,
-          count: 0,
-        },
-        {
-          mintUrl: 'https://mint.lnpay.cz',
-          averageTimeTaken: 2608,
-          successRate: 0.8604651162790697,
-          successCount: 37,
-          totalCount: 43,
-          count: 0,
-        },
-        {
-          mintUrl: 'https://cashu.boats',
-          averageTimeTaken: 10364,
-          successRate: 0.9583333333333334,
-          successCount: 23,
-          totalCount: 24,
-          count: 0,
-        },
-        {
-          mintUrl: 'https://mint.coinos.io',
-          averageTimeTaken: 14770,
-          successRate: 0.972972972972973,
-          successCount: 36,
-          totalCount: 37,
-          count: 0,
-        },
-        {
-          mintUrl: 'https://mint.minibits.cash/Bitcoin',
-          averageTimeTaken: 3096,
-          successRate: 0.9545454545454546,
-          successCount: 42,
-          totalCount: 44,
-          count: 0,
-        },
-        {
-          mintUrl: 'https://server.githappens.space:3339',
-          averageTimeTaken: 0,
-          successRate: 0,
-          successCount: 0,
-          totalCount: 28,
-          count: 0,
-        },
-        {
-          mintUrl: 'https://mint.azzamo.net',
-          averageTimeTaken: 10722,
-          successRate: 0.7142857142857143,
-          successCount: 20,
-          totalCount: 28,
-          count: 0,
-        },
-        {
-          mintUrl: 'https://mint.westernbtc.com',
-          averageTimeTaken: 3716,
-          successRate: 0.9302325581395349,
-          successCount: 40,
-          totalCount: 43,
-          count: 0,
-        },
-        {
-          mintUrl: 'https://mint.belgianbitcoinembassy.org',
-          averageTimeTaken: 8317,
-          successRate: 0.7804878048780488,
-          successCount: 32,
-          totalCount: 41,
-          count: 0,
-        },
-        {
-          mintUrl: 'https://mint.nodenebula.com',
-          averageTimeTaken: 8167,
-          successRate: 0.9736842105263158,
-          successCount: 37,
-          totalCount: 38,
-          count: 0,
-        },
-        {
-          mintUrl: 'https://mint.gwoq.com',
-          averageTimeTaken: 3944,
-          successRate: 1,
-          successCount: 20,
-          totalCount: 20,
-          count: 0,
-        },
-        {
-          mintUrl: 'https://8333.space:3338',
-          averageTimeTaken: 3456,
-          successRate: 1,
-          successCount: 54,
-          totalCount: 54,
-          count: 0,
-        },
-        {
-          mintUrl: 'https://mint.data.haus',
-          averageTimeTaken: 3591,
-          successRate: 0.9285714285714286,
-          successCount: 39,
-          totalCount: 42,
-          count: 0,
-        },
-        {
-          mintUrl: 'https://stablenut.cashu.network',
-          averageTimeTaken: 2980,
-          successRate: 0.9183673469387755,
-          successCount: 45,
-          totalCount: 49,
-          count: 0,
-        },
-        {
-          mintUrl: 'https://21mint.me',
-          averageTimeTaken: 6408,
-          successRate: 0.92,
-          successCount: 23,
-          totalCount: 25,
-          count: 0,
-        },
-        {
-          mintUrl: 'https://mint.lnwasanee.com',
-          averageTimeTaken: 5805,
-          successRate: 0.8148148148148148,
-          successCount: 22,
-          totalCount: 27,
-          count: 0,
-        },
-        {
-          mintUrl: 'https://mint.lnwallet.app',
-          averageTimeTaken: 4801,
-          successRate: 1,
-          successCount: 13,
-          totalCount: 13,
-          count: 0,
-        },
-        {
-          mintUrl: 'http://lbutlh5lfggq5r7xpiwhrajdl7sxpupgagazxl65w4c5cg72wtofasad.onion:3338',
-          averageTimeTaken: 2941,
-          successRate: 0.8333333333333334,
-          successCount: 25,
-          totalCount: 30,
-          count: 0,
-        },
-        {
-          mintUrl: 'https://mint.agorist.space',
-          averageTimeTaken: 4579,
-          successRate: 0.9736842105263158,
-          successCount: 37,
-          totalCount: 38,
-          count: 0,
-        },
-        {
-          mintUrl: 'https://cashu.21m.lol',
-          averageTimeTaken: 3573,
-          successRate: 0.9591836734693877,
-          successCount: 47,
-          totalCount: 49,
-          count: 0,
-        },
-        {
-          mintUrl: 'https://mint.pailakapo.com',
-          averageTimeTaken: 3908,
-          successRate: 1,
-          successCount: 22,
-          totalCount: 22,
-          count: 0,
-        },
-        {
-          mintUrl: 'https://mint.lnvoltz.com',
-          averageTimeTaken: 6377,
-          successRate: 0.9230769230769231,
-          successCount: 36,
-          totalCount: 39,
-          count: 0,
-        },
-        {
-          mintUrl: 'https://mint.nimo.cash',
-          averageTimeTaken: 10116,
-          successRate: 0.88,
-          successCount: 22,
-          totalCount: 25,
-          count: 0,
-        },
-        {
-          mintUrl: 'https://mint2.nutmix.cash',
-          averageTimeTaken: 5077,
-          successRate: 0.9302325581395349,
-          successCount: 40,
-          totalCount: 43,
-          count: 0,
-        },
-        {
-          mintUrl: 'https://mint.mnt.cash',
-          averageTimeTaken: 8559,
-          successRate: 0.9375,
-          successCount: 15,
-          totalCount: 16,
-          count: 0,
-        },
-        // {
-        //   mintUrl: 'https://testnut.cashu.space',
-        //   count: 999,
-        // },
-        // {
-        //   mintUrl: 'https://nofees.testnut.cashu.space',
-        //   count: 998,
-        // },
-      ],
-    ].reduce((acc: MintCount[], curr) => {
-      const existing = acc.find((item) => item.mintUrl === curr.mintUrl);
-      if (!existing) {
-        acc.push(curr);
-      } else if (curr.count > existing.count) {
-        existing.count = curr.count;
-      }
-      return acc;
-    }, []);
+      <View className={`flex-1`}>
+        <Text weight="bold" style={[{ color: g[50], fontSize: 14 }]}>
+          {displayName}
+        </Text>
 
-    counts.sort((a, b) => b.count - a.count);
-    return counts;
-  }, [events]);
-  return { mintCounts };
+        {loading ? (
+          <ActivityIndicator size="small" />
+        ) : (
+          <Text
+            style={{
+              color: g[0],
+              fontSize: 13,
+              lineHeight: 18,
+              width: Dimensions.get('window').width - 120,
+            }}>
+            {message}
+          </Text>
+        )}
+      </View>
+    </View>
+  );
 }
 
-interface Mint {
+function safeJson(str?: string) {
+  try {
+    return str ? JSON.parse(str) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+export interface ProcessedMint {
   id: string;
   name: string;
   logo?: string;
   supportedUnits: string[];
+  averageRating: number;
+  reviewCount: number;
+  reviews: Review[];
+  loading: boolean;
+  error?: Error;
 }
 
-interface MintInfo {
-  icon_url: string;
-  nuts?: {
-    methods?: { unit: string }[];
-  }[];
+function extractSupportedUnits(info?: MintInfo): string[] {
+  if (!info?.nuts) return [];
+  const units = new Set<string>();
+  Object.values(info.nuts).forEach((value: any) => {
+    if (value && Array.isArray(value.methods)) {
+      value.methods.forEach((m: any) => m?.unit && units.add(m.unit.toUpperCase()));
+    }
+    if (Array.isArray(value?.supported)) {
+      value.supported.forEach((m: any) => m?.unit && units.add(m.unit.toUpperCase()));
+    }
+  });
+  return Array.from(units);
 }
 
-interface ProcessedMintData {
-  info: MintInfo;
-  supportedUnits: string[];
-  isLoading: boolean;
-  error?: string | null;
+function useRecommendedMints(): { mints: ProcessedMint[] } {
+  /* 0️⃣ Existing balances */
+  const balances = useSelector(memoizedGetAllBalancesMultipleCurrencies);
+  const balanceMintUrls = useMemo(() => new Set(balances.map((b) => b.mintUrl)), [balances]);
+
+  /* 1️⃣ Subscribe for reviews */
+  const filters = useMemo(() => ({ kinds: [38000], limit: 20000 }), []);
+  const { events } = useSubscribe({ filters });
+
+  /* 2️⃣ Stats per URL (skip already‑owned) */
+  const mintStats = useMemo<MintStats[]>(() => {
+    if (!events?.length) return [];
+
+    const urlEventsMap = events.reduce<Map<string, typeof events>>((map, event) => {
+      const tags = event.tags || [];
+      const kTag = tags.find((t) => t[0] === 'k' && t[1] === '38172');
+      const uTag = tags.find(
+        (t) => t[0] === 'u' && typeof t[1] === 'string' && t[1].startsWith('https://')
+      );
+      if (kTag && uTag) {
+        const url = uTag[1] as string;
+        if (balanceMintUrls.has(url)) return map; // already owned
+        if (!map.has(url)) map.set(url, []);
+        map.get(url)!.push(event);
+      }
+      return map;
+    }, new Map());
+
+    const stats = Array.from(urlEventsMap.entries()).map(([url, evts]) => {
+      const ratings = evts
+        .map((e) => {
+          const m = e.content.match(/^\[(\d+)\/\d+]/);
+          return m ? parseInt(m[1], 10) : null;
+        })
+        .filter((r): r is number => r !== null);
+
+      const reviewCount = evts.length;
+      const averageRating = ratings.length
+        ? ratings.reduce((s, r) => s + r, 0) / ratings.length
+        : 0;
+      const reviews: Review[] = evts.map((e) => ({
+        pubkey: e.pubkey,
+        message: e.content.replace(/^\[\d+\/\d+]\s*/, ''),
+      }));
+
+      return { mintUrl: url, averageRating, reviewCount, reviews, loading: true } as MintStats;
+    });
+
+    stats.sort((a, b) => b.averageRating - a.averageRating || b.reviewCount - a.reviewCount);
+    return stats;
+  }, [events, balanceMintUrls]);
+
+  /* 3️⃣ Fetch Mint info (only for unowned) */
+  const [infos, setInfos] = useState<Record<string, { info?: MintInfo; error?: Error }>>({});
+  const fetching = useRef(new Set<string>());
+
+  useEffect(() => {
+    const missing = mintStats
+      .map((s) => s.mintUrl)
+      .filter((url) => !infos[url] && !fetching.current.has(url));
+
+    if (!missing.length) return;
+
+    missing.forEach((url) => {
+      fetching.current.add(url);
+      (async () => {
+        try {
+          const mintRes = await getMint({ mintUrl: url, forceRefresh: true });
+          if (mintRes.isErr()) throw mintRes.error;
+          const mintInfoRes = await toResult(mintRes.value.getInfo());
+          if (mintInfoRes.isErr()) throw mintInfoRes.error;
+          setInfos((prev) => ({ ...prev, [url]: { info: mintInfoRes.value } }));
+        } catch (err) {
+          setInfos((prev) => ({ ...prev, [url]: { error: err as Error } }));
+        } finally {
+          fetching.current.delete(url);
+        }
+      })().catch(() => {});
+    });
+  }, [mintStats, infos]);
+
+  /* 4️⃣ Combine stats + info */
+  const mints = useMemo<ProcessedMint[]>(() => {
+    return mintStats.map((s) => {
+      const entry = infos[s.mintUrl] ?? {};
+      const info = entry.info;
+
+      return {
+        id: s.mintUrl,
+        name: info?.name ?? s.mintUrl.replace(/^https?:\/\//, ''),
+        logo: info?.icon_url,
+        supportedUnits: extractSupportedUnits(info),
+        averageRating: s.averageRating,
+        reviewCount: s.reviewCount,
+        reviews: s.reviews,
+        loading: !entry.info && !entry.error,
+        error: entry.error,
+      };
+    });
+  }, [mintStats, infos]);
+
+  return { mints };
 }
 
 function AddMintItem({
   index,
   mint,
-  mintData,
-  handleToggleMint,
-  selectedMints,
+  onToggle,
+  selected,
 }: {
-  mint: Mint;
-  mintData: ProcessedMintData;
-  handleToggleMint: (mintId: string) => void;
-  selectedMints: Set<string>;
+  index: number;
+  mint: ProcessedMint;
+  onToggle: (id: string) => void;
+  selected: boolean;
 }) {
   const theme = useSelector(memoizedGetTheme);
-  const styles = createStyles(theme);
+  const g = greys(theme);
 
-  if (!mintData || !mint) {
-    return null;
-  }
+  if (mint.error) return null;
+
+  const isDisabled = mint.loading;
+  const isHighlyRated = mint.averageRating >= 5 && mint.reviewCount >= 3;
+  const showReviews = isHighlyRated && mint.reviews.length > 0;
 
   return (
-    <TouchableOpacity
-      testID={`add-mint-item-${index}`}
-      onPress={() => handleToggleMint(mint.id)}
-      key={mint.id}
-      style={[
-        styles.mintItem,
-        {
-          flexDirection: 'row',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-        },
-      ]}>
-      <Image source={{ uri: mintData.info.icon_url }} style={styles.mintIcon} />
-      <View style={styles.mintDetails}>
-        <Text style={styles.mintName}>{mint.name}</Text>
-        <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
-          {mintData.supportedUnits.map((unit) => (
-            <View
-              key={unit}
-              style={{
-                backgroundColor: greys(theme)[700],
-                paddingHorizontal: 8,
-                paddingVertical: 4,
-                borderRadius: 4,
-                marginRight: 4,
-                marginBottom: 4,
-              }}>
-              <Text weight="bold" style={{ fontSize: 12, color: greys(theme)[0] }}>
-                {unit}
-              </Text>
+    <View className="mb-3 overflow-hidden rounded-lg" blur style={[{ backgroundColor: g[800] }]}>
+      <TouchableOpacity
+        testID={`add-mint-item-${index}`}
+        disabled={isDisabled}
+        onPress={() => !isDisabled && onToggle(mint.id)}>
+        <View className={`flex-row items-center p-3 ${isDisabled ? `opacity-50` : ''}`}>
+          <Image
+            source={{ uri: mint.logo || 'https://placehold.co/42x42' }}
+            style={[{ width: 42, height: 42, borderRadius: 21, backgroundColor: g[200] }]}
+          />
+
+          <View className={`ml-3 mr-3 flex-1`}>
+            <Text style={[{ color: g[0], fontSize: 16 }]}>{mint.name}</Text>
+
+            <View className={`flex-row flex-wrap`}>
+              {mint.supportedUnits.map((unit) => (
+                <View
+                  key={unit}
+                  className={`mb-1 mr-1 rounded`}
+                  style={[{ backgroundColor: g[700], paddingHorizontal: 8, paddingVertical: 4 }]}>
+                  <Text weight="bold" style={[{ color: g[0] }]}>
+                    {unit}
+                  </Text>
+                </View>
+              ))}
             </View>
-          ))}
+          </View>
+
+          {mint.loading ? (
+            <ActivityIndicator />
+          ) : selected ? (
+            <Icon name="gala:remove" color={reds[300]} />
+          ) : (
+            <Icon name="gala:add" color={greens[300]} />
+          )}
         </View>
-      </View>
-      {selectedMints.has(mint.id) ? (
-        <Icon name="gala:remove" color={reds[300]} />
-      ) : (
-        <Icon name="gala:add" color={greens[300]} />
-      )}
-    </TouchableOpacity>
+      </TouchableOpacity>
+
+      {/* {showReviews && (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={{ padding: 12, paddingTop: 0 }}>
+          {mint.reviews
+            .filter((r) => r.message)
+            .map((r) => (
+              <Comment
+                key={r.pubkey + r.message.slice(0, 10)}
+                pubkey={r.pubkey}
+                message={r.message}
+                theme={theme}
+              />
+            ))}
+        </ScrollView>
+      )} */}
+    </View>
   );
 }
 
 export function MintAddMore({ onClose, payload }) {
   const theme = useSelector(memoizedGetTheme);
-  const styles = createStyles(theme);
+  const g = greys(theme);
+  const router = useSheetRouter('mint');
+
+  /* State */
   const [selectedMints, setSelectedMints] = useState<Set<string>>(new Set());
-  // Set default selected currency based on allowed currencies
   const [selectedCurrency, setSelectedCurrency] = useState<string>(() => {
-    // If SAT is the only currency, select it by default
     if (payload?.currencies?.length === 1 && payload.currencies[0].toUpperCase() === 'SAT') {
       return 'SAT';
     }
     return 'All';
   });
-  const [mintsData, setMintsData] = useState<Map<string, ProcessedMintData>>(new Map());
-  const [, setLoading] = useState(true);
-  const [loadedMintIds, setLoadedMintIds] = useState<Set<string>>(new Set());
-  const router = useSheetRouter('mint');
-  const { mintCounts } = useRecommendedMints();
 
-  // Extract allowed currencies from payload
-  const allowedCurrencies = useMemo(
-    () =>
-      new Set(
-        payload?.currencies?.map((curr) => curr.toUpperCase()) ||
-          ['SAT', 'USD', 'EUR', 'GBP'].map((curr) => curr.toUpperCase())
-      ),
-    [payload]
-  );
+  const { mints } = useRecommendedMints();
 
-  const recommendedMints = useMemo(
-    () => [
-      // {
-      //   id: 'https://mint.sovran.cash',
-      //   name: 'mint.sovran.cash (1)',
-      //   supportedUnits: [],
-      // },
-      ...mintCounts.map((mint) => {
-        let hostname: string;
-        try {
-          const urlObj = new URL(mint.mintUrl);
-          hostname = urlObj.hostname;
-        } catch {
-          hostname = mint.mintUrl;
-        }
-        return {
-          id: mint.mintUrl,
-          name: `${hostname} (${mint.count})`,
-          supportedUnits: [],
-        };
-      }),
-    ],
-    [mintCounts]
-  );
-
-  // Fetch mint data progressively
-  useEffect(() => {
-    const fetchAllMintData = async () => {
-      setLoading(true);
-
-      // Process each mint one at a time
-      for (const mint of recommendedMints) {
-        try {
-          // Skip if we've already loaded this mint
-          if (loadedMintIds.has(mint.id)) continue;
-
-          const mintInfo = await (await getMint({ mintUrl: mint.id })).getInfo();
-          // {"contact": [{"info": "shyguy@nodenebula.com", "method": "email"}, {"info": "npub1shyguyyzs2e8jv0dcdqh8whwfd5k33999qy3vzvwxf6ql8c8xfpqqeearp", "method": "nostr"}], "description": "A community mint", "description_long": "Use this mint as you see fit but do so with caution. It is early days.", "motd": "Welcome", "name": "Nebula", "nuts": {"10": {"supported": true}, "11": {"supported": true}, "12": {"supported": true}, "14": {"supported": true}, "15": {"methods": [Array]}, "17": {"supported": [Array]}, "20": {"supported": true}, "4": {"disabled": false, "methods": [Array]}, "5": {"disabled": false, "methods": [Array]}, "7": {"supported": true}, "8": {"supported": true}, "9": {"supported": true}}, "pubkey": "02bf3ff52f21bd89be1992dc0fa42bf1d3a35ba4618364e7049c9861bd38a36dc4", "time": 1746411298, "version": "Nutshell/0.16.5"}
-          const supportedUnits: string[] = [];
-
-          if (mintInfo?.nuts?.[4]?.methods) {
-            mintInfo.nuts[4].methods.forEach((method) => {
-              const unit = method.unit.toUpperCase() === 'BTC' ? 'SAT' : method.unit.toUpperCase();
-              if (!supportedUnits.includes(unit)) {
-                supportedUnits.push(unit);
-              }
-            });
-          }
-
-          // Update the state for this individual mint
-          setMintsData((prev) => {
-            const newMap = new Map(prev);
-            newMap.set(mint.id, {
-              info: mintInfo,
-              supportedUnits,
-              isLoading: false,
-              error: null,
-            });
-            return newMap;
-          });
-
-          // Mark this mint as loaded
-          setLoadedMintIds((prev) => {
-            const newSet = new Set(prev);
-            newSet.add(mint.id);
-            return newSet;
-          });
-        } catch {
-          setMintsData((prev) => {
-            const newMap = new Map(prev);
-            newMap.set(mint.id, {
-              info: { icon_url: '' },
-              supportedUnits: [],
-              isLoading: false,
-              error: 'Failed to fetch mint details',
-            });
-            return newMap;
-          });
-
-          // Still mark this mint as loaded even if it failed
-          setLoadedMintIds((prev) => {
-            const newSet = new Set(prev);
-            newSet.add(mint.id);
-            return newSet;
-          });
-        }
-      }
-
-      // All mints have been processed
-      setLoading(false);
-    };
-
-    fetchAllMintData();
-  }, [recommendedMints, loadedMintIds]);
-
-  const handleToggleMint = (mintId: string) => {
+  /* Toggle */
+  const handleToggleMint = (id: string) => {
     setSelectedMints((prev) => {
-      const newSet = new Set(prev);
-      if (newSet.has(mintId)) {
-        newSet.delete(mintId);
-      } else {
-        newSet.add(mintId);
-      }
-      return newSet;
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
     });
   };
 
-  // Filter mints based on selected currency
-  const mints = useSelector(memoizedGetMints);
-
+  /* Currency filter */
   const filteredMints = useMemo(() => {
-    // Base filter function that excludes existing mints and checks allowed currencies
-    const baseFilter = (mint) => {
-      // Skip mints that are already added
-      if (mints.includes(mint.id)) return false;
+    if (selectedCurrency === 'All') return mints;
+    return mints.filter((m) => m.supportedUnits.includes(selectedCurrency));
+  }, [mints, selectedCurrency]);
 
-      const mintData = mintsData.get(mint.id);
-      if (!mintData) return false;
+  /* Save */
+  const handleSave = async () => {
+    await Promise.all(
+      Array.from(selectedMints).map(async (mintUrl) => {
+        await getMint({ mintUrl, forceRefresh: true });
+      })
+    );
+    await onClose({ mints: Array.from(selectedMints) });
+    router?.goBack();
+  };
 
-      // If mint has no supported units yet, keep it (still loading)
-      if (mintData.supportedUnits.length === 0) return true;
+  /* Allowed‑currency set (from payload or default) */
+  const allowedCurrencies = useMemo(
+    () =>
+      new Set((payload?.currencies ?? ['SAT', 'USD', 'EUR', 'GBP']).map((c) => c.toUpperCase())),
+    [payload]
+  );
 
-      // Only include mints that ONLY support currencies from the payload
-      // This means every supported unit must be in the allowed currencies
-      // return mintData.supportedUnits.every((unit) => allowedCurrencies.has(unit));
-      return true;
-    };
-
-    if (selectedCurrency === 'All') {
-      // Just apply the base filter for "All" selection
-      return recommendedMints.filter(baseFilter);
-    }
-
-    // For specific currency selection, filter by both the selected currency and the payload currencies
-    return recommendedMints.filter((mint) => {
-      if (!baseFilter(mint)) return false;
-
-      const mintData = mintsData.get(mint.id);
-      // Check if mint supports the selected currency
-      return mintData.supportedUnits.includes(selectedCurrency);
-    });
-  }, [recommendedMints, selectedCurrency, mintsData, mints]);
-
-  // Get loaded mints that match the currency filter
-  const loadedMints = useMemo(() => {
-    return filteredMints.filter((mint) => loadedMintIds.has(mint.id));
-  }, [filteredMints, loadedMintIds]);
-
-  // Determine if there are still mints to load
-  const hasMoreMintsToLoad = loadedMintIds.size < recommendedMints.length;
-
-  // Filter currency options to only show allowed currencies
+  /* Rendered selector options */
   const currencyOptions = useMemo(() => {
-    const options = [];
-
-    // Only include currency options that are in the allowed currencies
-    if (allowedCurrencies.has('SAT')) options.push('BTC');
-    if (allowedCurrencies.has('USD')) options.push('USD');
-    if (allowedCurrencies.has('EUR')) options.push('EUR');
-    if (allowedCurrencies.has('GBP')) options.push('GBP');
-
-    // Only add the 'All' option if we have more than one currency
-    if (options.length > 1) {
-      options.unshift('All');
-    }
-
-    return options;
+    const opts: string[] = [];
+    if (allowedCurrencies.has('SAT')) opts.push('BTC'); // show BTC but store SAT
+    if (allowedCurrencies.has('USD')) opts.push('USD');
+    if (allowedCurrencies.has('EUR')) opts.push('EUR');
+    if (allowedCurrencies.has('GBP')) opts.push('GBP');
+    if (opts.length > 1) opts.unshift('All');
+    return opts;
   }, [allowedCurrencies]);
 
+  /* Render */
   return (
     <Wrapper
       buttons={
@@ -601,20 +372,8 @@ export function MintAddMore({ onClose, payload }) {
               testID: 'save-mints',
               text: `Save (${selectedMints.size})`,
               variant: 'primary',
-              onPress: async () => {
-                await Promise.all(
-                  Array.from(selectedMints).map(async (mintUrl) => {
-                    await getWallet({
-                      mintUrl,
-                      forceRefresh: true,
-                    });
-                  })
-                );
-                await onClose({
-                  mints: Array.from(selectedMints),
-                });
-                router?.goBack();
-              },
+              onPress: handleSave,
+              disabled: selectedMints.size === 0,
             },
             {
               text: 'Cancel',
@@ -627,156 +386,93 @@ export function MintAddMore({ onClose, payload }) {
           ]}
         />
       }>
-      <View
-        style={{
-          flex: 1,
-          height: '100%',
-        }}>
-        <Text weight="bold" style={styles.sectionHeader}>
+      <View className={`flex-1`}>
+        <Text
+          weight="bold"
+          style={{
+            color: g[0],
+            fontSize: 18,
+            fontWeight: '600',
+          }}>
           Currency options
         </Text>
-        <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.currencyScroll}>
-          {currencyOptions.map((option) => (
-            <TouchableOpacity
-              key={option}
-              style={[
-                styles.currencyButton,
-                sovran(theme).borderSubtle,
-                ((option === 'BTC' && selectedCurrency === 'SAT') ||
-                  (option === 'All' && selectedCurrency === 'All') ||
-                  (option !== 'BTC' && option !== 'All' && selectedCurrency === option)) &&
-                  styles.selectedCurrencyButton,
-              ]}
-              onPress={() => {
-                setSelectedCurrency(option === 'BTC' ? 'SAT' : option);
-              }}>
-              <View style={styles.currencyContent}>
-                {option === 'USD' || option === 'EUR' || option === 'GBP' ? (
-                  <FlagIcon
-                    country={option === 'USD' ? 'US' : option === 'EUR' ? 'EU' : 'GB'}
-                    height={32}
-                    width={32}
-                  />
-                ) : option === 'BTC' ? (
-                  <CurrencyIcon currency="sat" />
-                ) : null}
-                <Text style={styles.currencyText}>{option}</Text>
-              </View>
-            </TouchableOpacity>
-          ))}
-        </ScrollView>
+        <Spacer size={4} />
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={{ paddingRight: 12 }}>
+          {currencyOptions.map((option) => {
+            const isSelected =
+              (option === 'BTC' && selectedCurrency === 'SAT') ||
+              (option === 'All' && selectedCurrency === 'All') ||
+              (option !== 'BTC' && option !== 'All' && selectedCurrency === option);
 
-        <Text weight="bold" style={[styles.sectionHeader, { marginTop: 24, marginBottom: 0 }]}>
+            return (
+              <TouchableOpacity
+                key={option}
+                onPress={() => setSelectedCurrency(option === 'BTC' ? 'SAT' : option)}>
+                <View
+                  blur
+                  className="mr-3 flex-row items-center rounded-lg"
+                  style={{
+                    padding: 12,
+                    minWidth: 100,
+                    backgroundColor: isSelected ? g[700] : g[800],
+                    borderWidth: 0.5,
+                    borderColor: g[900],
+                  }}>
+                  {option === 'USD' || option === 'EUR' || option === 'GBP' ? (
+                    <FlagIcon
+                      country={option === 'USD' ? 'US' : option === 'EUR' ? 'EU' : 'GB'}
+                      height={32}
+                      width={32}
+                    />
+                  ) : option === 'BTC' ? (
+                    <CurrencyIcon width={32} currency="sat" />
+                  ) : (
+                    <View className="h-[32px] "></View>
+                  )}
+                  <Text weight="bold" style={{ color: g[0], fontSize: 14, marginLeft: 8 }}>
+                    {option}
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            );
+          })}
+        </ScrollView>
+        <Spacer size={24} />
+
+        <Text
+          weight="bold"
+          style={[
+            {
+              color: g[0],
+              fontSize: 18,
+              fontWeight: '600',
+            },
+          ]}>
           Discovered mints
         </Text>
-        <Text style={[{ marginBottom: 12, color: greys(theme)[400] }]}>
-          Found {filteredMints.length} {filteredMints.length === 1 ? 'mint' : 'mints'}
-          {allowedCurrencies.size === 1 ? ' supporting only SAT' : ''}
-        </Text>
+        <Spacer size={4} />
 
-        <View>
-          {loadedMints.length > 0 ? (
-            loadedMints.map((mint, index) => {
-              const mintData = mintsData.get(mint.id);
-              // Skip mints with errors or that are still loading
-              if (!mintData || mintData.error) return null;
-
-              return (
-                <AddMintItem
-                  index={index}
-                  key={mint.id}
-                  mint={mint}
-                  mintData={mintData}
-                  handleToggleMint={handleToggleMint}
-                  selectedMints={selectedMints}
-                />
-              );
-            })
-          ) : !hasMoreMintsToLoad ? (
-            <Text style={[styles.noResults, { marginTop: 20, textAlign: 'center' }]}>
-              No mints found for the selected criteria
-            </Text>
-          ) : null}
-
-          {/* Show a loading indicator at the bottom while more mints are loading */}
-          {hasMoreMintsToLoad && (
-            <View style={styles.loadingContainer}>
-              <ActivityIndicator size="small" color={greens[300]} />
-              <Text style={styles.loadingText}>Loading more mints...</Text>
-            </View>
-          )}
-        </View>
+        {filteredMints.length === 0 ? (
+          <Text style={[{ color: g[400], textAlign: 'center', marginTop: 20 }]}>
+            No mints found
+          </Text>
+        ) : (
+          <RNScrollView className={`flex-1`}>
+            {filteredMints.map((mint, i) => (
+              <AddMintItem
+                key={mint.id}
+                index={i}
+                mint={mint}
+                onToggle={handleToggleMint}
+                selected={selectedMints.has(mint.id)}
+              />
+            ))}
+          </RNScrollView>
+        )}
       </View>
     </Wrapper>
   );
 }
-
-const createStyles = (theme: string) =>
-  StyleSheet.create({
-    noResults: {
-      color: greys(theme)[400],
-    },
-    sectionHeader: {
-      color: greys(theme)[0],
-      fontSize: 18,
-      fontWeight: '600',
-      marginBottom: 12,
-    },
-    currencyScroll: {
-      flexGrow: 1,
-    },
-    currencyButton: {
-      marginRight: 12,
-      padding: 12,
-      borderRadius: 8,
-      backgroundColor: greys(theme)[800],
-      minWidth: 100,
-    },
-    currencyContent: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      justifyContent: 'flex-start',
-      gap: 8,
-    },
-    selectedCurrencyButton: {
-      backgroundColor: greys(theme)[700],
-    },
-    currencyText: {
-      color: greys(theme)[0],
-      fontSize: 14,
-      fontFamily: 'OverpassBold',
-    },
-    mintItem: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      padding: 12,
-      borderRadius: 8,
-      backgroundColor: greys(theme)[800],
-      marginBottom: 8,
-    },
-    mintIcon: {
-      width: 42,
-      height: 42,
-      borderRadius: 21,
-      backgroundColor: greys(theme)[200],
-    },
-    mintDetails: {
-      flex: 1,
-      marginLeft: 12,
-      marginRight: 12,
-    },
-    mintName: {
-      color: greys(theme)[0],
-      fontSize: 16,
-    },
-    loadingContainer: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      justifyContent: 'center',
-      padding: 16,
-    },
-    loadingText: {
-      marginLeft: 8,
-      color: greys(theme)[200],
-    },
-  });

--- a/components/providers/TransactionsProvider.tsx
+++ b/components/providers/TransactionsProvider.tsx
@@ -19,7 +19,8 @@ import { showMessage } from 'helper/popup/popups';
 import { publishWalletEvent } from 'helper/nostr/cashu';
 import { getWallet } from 'helper/cashuClient';
 import _ from 'lodash';
-import { Alert } from 'react-native';
+import { err } from 'neverthrow';
+import { toResult } from 'helper/toResult';
 
 const TransactionContext = createContext(null);
 
@@ -184,14 +185,21 @@ export const TransactionProvider = ({ children }: TransactionProviderProps) => {
       // loop over mints
       for (const [mintUrl, txs] of Object.entries(groupedTransactions)) {
         // loop over txs
-        const w = await getWallet({
+        const walletResult = await getWallet({
           mintUrl,
           unit: 'sat',
           forceRefresh,
+          profile: null,
         });
-        const activeKeyset = w.getActiveKeyset(w.keysets.filter((key) => key.unit === 'sat'));
+
+        if (walletResult.isErr()) return err(walletResult.error);
+        const wallet = walletResult.value;
+
+        const activeKeyset = wallet.getActiveKeyset(
+          wallet.keysets.filter((key) => key.unit === 'sat')
+        );
         const keysetId = activeKeyset.id;
-        w.keysetId = keysetId;
+        wallet.keysetId = keysetId;
 
         for (const [type, txs_] of Object.entries(txs)) {
           try {
@@ -200,7 +208,7 @@ export const TransactionProvider = ({ children }: TransactionProviderProps) => {
 
             if (type === 'ecash') {
               const proofs = _.flatMap(txs_.map((tx: any) => getDecodedToken(tx.token).proofs));
-              unsub = await w.onProofStateUpdates(
+              unsub = await wallet.onProofStateUpdates(
                 // flat map the proofs
                 proofs,
                 (
@@ -270,7 +278,7 @@ export const TransactionProvider = ({ children }: TransactionProviderProps) => {
                 addConnection(id, unsub);
               }
             } else if (type === 'lightning') {
-              unsub = await w.onMintQuoteUpdates(
+              unsub = await wallet.onMintQuoteUpdates(
                 txs_.map((tx) => tx.mintQuote.quote),
                 async (update: MintQuoteResponse) => {
                   try {
@@ -281,7 +289,6 @@ export const TransactionProvider = ({ children }: TransactionProviderProps) => {
 
                     switch (update.state) {
                       case 'UNPAID':
-                        Alert.alert(update.state);
                         updateTransactionStatus(
                           {
                             request: transaction.request,
@@ -302,8 +309,6 @@ export const TransactionProvider = ({ children }: TransactionProviderProps) => {
                         );
                         break;
                       case 'ISSUED':
-                        Alert.alert(update.state);
-
                         updateTransactionStatus(
                           {
                             request: transaction.request,
@@ -331,30 +336,28 @@ export const TransactionProvider = ({ children }: TransactionProviderProps) => {
                         }
                         break;
                       case 'PAID':
-                        Alert.alert(update.state);
-
                         const counter = memoizedGetCounterV2({
                           profileId: store.getState().nostr.currentProfile.id,
                           mintUrl,
-                          keysetId: w.keysetId,
+                          keysetId: wallet.keysetId,
                         })(store.getState());
 
                         // Mint proofs
-                        const proofs = await w.mintProofs(
-                          transaction.amount,
-                          transaction.mintQuote.quote,
-                          {
+                        const proofsResult = await toResult(
+                          wallet.mintProofs(transaction.amount, transaction.mintQuote.quote, {
                             counter,
-                            keysetId: w.keysetId,
-                          }
+                            keysetId: wallet.keysetId,
+                          })
                         );
+                        if (proofsResult.isErr()) return err(proofsResult.error);
+                        const proofs = proofsResult.value;
 
                         // Increase counter
                         store.dispatch(
                           increaseCounterV2({
                             profileId: store.getState().nostr.currentProfile.id,
                             mintUrl,
-                            keysetId: w.keysetId,
+                            keysetId: wallet.keysetId,
                             amount: proofs.length,
                           })
                         );

--- a/helper/backgroundImages.ts
+++ b/helper/backgroundImages.ts
@@ -205,30 +205,30 @@ export const BACKGROUND_IMAGE_ATTRIBUTES: Record<string, BackgroundImageAttribut
 };
 
 export const BACKGROUND_IMAGES: Record<string, BackgroundImageMeta> = {
-  'bg.png': {
-    id: 'bg.png',
-    name: 'Eternal Pines',
-    category: 'Dynamic',
-    source: require('assets/images/backgrounds/bg.png'),
-  },
-  'bg2.png': {
-    id: 'bg2.png',
-    name: 'Eternal Jungle',
-    category: 'Dynamic',
-    source: require('assets/images/backgrounds/bg2.png'),
-  },
-  'bg3.png': {
-    id: 'bg3.png',
-    name: 'Cabin in the Light',
-    category: 'Dynamic',
-    source: require('assets/images/backgrounds/bg3.png'),
-  },
-  'bg4.png': {
-    id: 'bg4.png',
-    name: 'Ebb and Glow',
-    category: 'Dynamic',
-    source: require('assets/images/backgrounds/bg4.png'),
-  },
+  // 'bg.png': {
+  //   id: 'bg.png',
+  //   name: 'Eternal Pines',
+  //   category: 'Dynamic',
+  //   source: require('assets/images/backgrounds/bg.png'),
+  // },
+  // 'bg2.png': {
+  //   id: 'bg2.png',
+  //   name: 'Eternal Jungle',
+  //   category: 'Dynamic',
+  //   source: require('assets/images/backgrounds/bg2.png'),
+  // },
+  // 'bg3.png': {
+  //   id: 'bg3.png',
+  //   name: 'Cabin in the Light',
+  //   category: 'Dynamic',
+  //   source: require('assets/images/backgrounds/bg3.png'),
+  // },
+  // 'bg4.png': {
+  //   id: 'bg4.png',
+  //   name: 'Ebb and Glow',
+  //   category: 'Dynamic',
+  //   source: require('assets/images/backgrounds/bg4.png'),
+  // },
   'bg6.png': {
     id: 'bg6.png',
     name: 'Static 2',

--- a/helper/cashuClient.ts
+++ b/helper/cashuClient.ts
@@ -300,44 +300,48 @@ export async function sendLightning({
   meltQuote: MeltQuoteResponse;
   email?: string;
   lud16?: string;
-}): Promise<LightningSendTransaction> {
+}): Promise<Result<LightningSendTransaction, Error>> {
   const state = store.getState();
   const profile = memoizedGetCurrentProfile(state);
 
-  let expiry: Date | null = null;
-  try {
-    expiry = getRawExpiry({ pr });
-  } catch {
-    throw new AppError('invalid_invoice', 'Invalid payment request');
+  const expiryResult = toResultSync(() => getRawExpiry({ pr }));
+  if (expiryResult.isErr()) {
+    return err(new AppError('invalid_invoice', 'Invalid payment request'));
   }
+  const expiry = expiryResult.value;
   if (expiry && new Date(Date.now() + 60_000) > expiry) {
-    throw new AppError('invoice_expired', 'Invoice expired');
+    return err(new AppError('invoice_expired', 'Invoice expired'));
   }
 
   // Retry logic for wallet operations
-  const attemptSend = async (forceRefresh = false): Promise<LightningSendTransaction> => {
+  const attemptSend = async (
+    forceRefresh = false
+  ): Promise<Result<LightningSendTransaction, Error>> => {
     const currentProofs = memoizedGetProofs(unit)(state);
-
-    const wallet = await getWallet({
-      unit,
-      mintUrl,
-      profile: null,
-      ...(forceRefresh && { forceRefresh: true }),
-    });
+    const walletRes = await toResult(
+      getWallet({
+        unit,
+        mintUrl,
+        profile: null,
+        ...(forceRefresh && { forceRefresh: true }),
+      })
+    );
+    if (walletRes.isErr()) return err(walletRes.error);
+    const wallet = walletRes.value;
 
     const activeKeyset = wallet.getActiveKeyset(wallet.keysets.filter((key) => key.unit === unit));
     const keysetId = activeKeyset.id;
     wallet.keysetId = keysetId;
 
     if (!meltQuote.amount) {
-      throw new AppError('invalid_invoice', 'No amount specified in payment request');
+      return err(new AppError('invalid_invoice', 'No amount specified in payment request'));
     }
 
     const balance = currentProofs
       .map((p: { amount: number }) => p.amount)
       .reduce((a: number, b: number) => a + b, 0);
     if (meltQuote.amount + meltQuote.fee_reserve > balance) {
-      throw new AppError('insufficient_funds', 'Insufficient funds');
+      return err(new AppError('insufficient_funds', 'Insufficient funds'));
     }
 
     const profileId = store.getState().nostr?.currentProfile?.id;
@@ -376,10 +380,14 @@ export async function sendLightning({
       keysetId: wallet.keysetId,
     })(store.getState());
 
-    const { change } = await wallet.meltProofs(meltQuote, proofsToSend, {
-      counter: counter2, // it's going up forever, laura
-      keysetId,
-    });
+    const meltRes = await toResult(
+      wallet.meltProofs(meltQuote, proofsToSend, {
+        counter: counter2,
+        keysetId,
+      })
+    );
+    if (meltRes.isErr()) return err(meltRes.error);
+    const { change } = meltRes.value;
 
     store.dispatch(
       increaseCounterV2({
@@ -440,26 +448,16 @@ export async function sendLightning({
       })
     );
 
-    return transaction;
+    return ok(transaction);
   };
 
   // First attempt
-  try {
-    return await attemptSend(false);
-  } catch (error) {
-    // Check if it's the specific keyset inactive error
-    if (error.message === 'keyset id inactive.') {
-      Alert.alert('Updating keyset...');
-      try {
-        return await attemptSend(true);
-      } catch (retryError) {
-        throw retryError;
-      }
-    }
-
-    // Re-throw other errors
-    throw error;
+  const first = await attemptSend(false);
+  if (first.isErr() && first.error.message === 'keyset id inactive.') {
+    Alert.alert('Updating keyset...');
+    return attemptSend(true);
   }
+  return first;
 }
 
 export async function receiveLightning({
@@ -470,25 +468,30 @@ export async function receiveLightning({
   amount: number;
   unit: string;
   memo?: string;
-}): Promise<LightningReceiveTransaction> {
+}): Promise<Result<LightningReceiveTransaction, Error>> {
   const selectedMint = memoizedGetSelectedMint(store.getState());
   const profile = memoizedGetCurrentProfile(store.getState());
 
   Alert.alert('a', JSON.stringify(unit, selectedMint));
-  const wallet = await getWallet({
-    unit,
-    mintUrl: selectedMint,
-    profile: null,
-  });
+  const walletRes = await toResult(
+    getWallet({
+      unit,
+      mintUrl: selectedMint,
+      profile: null,
+    })
+  );
+  if (walletRes.isErr()) return err(walletRes.error);
+  const wallet = walletRes.value;
 
   const activeKeyset = wallet.getActiveKeyset(wallet.keysets.filter((key) => key.unit === unit));
   const keysetId = activeKeyset.id;
   wallet.keysetId = keysetId;
 
-  const mintQuote = await wallet.createMintQuote(amount, memo);
-
-  if (mintQuote.error) {
-    throw new AppError('quote_error', 'Error getting mint quote');
+  const mintQuoteResult = await toResult(wallet.createMintQuote(amount, memo));
+  if (mintQuoteResult.isErr()) return err(mintQuoteResult.error);
+  const mintQuote = mintQuoteResult.value;
+  if ((mintQuote as any).error) {
+    return err(new AppError('quote_error', 'Error getting mint quote'));
   }
 
   const paymentRequest = await getPaymentRequest({
@@ -522,7 +525,7 @@ export async function receiveLightning({
     })
   );
 
-  return transaction;
+  return ok(transaction);
 }
 
 export async function sendEcash({
@@ -539,29 +542,35 @@ export async function sendEcash({
   to?: string;
   p2pk?: { pubkey?: string; privkey?: string };
   paymentRequest?: string;
-}): Promise<EcashSendTransaction> {
+}): Promise<Result<EcashSendTransaction, Error>> {
   const state = store.getState();
   const selectedMint = memoizedGetSelectedMint(state);
   const profile = memoizedGetCurrentProfile(state);
 
   // Retry logic for wallet operations
-  const attemptSend = async (forceRefresh = false): Promise<EcashSendTransaction> => {
+  const attemptSend = async (
+    forceRefresh = false
+  ): Promise<Result<EcashSendTransaction, Error>> => {
     const currentProofs = memoizedGetProofs(unit)(state);
     const balance = memoizedGetBalance(unit)(state);
 
     if (amount > balance) {
-      throw new AppError('insufficient_funds', 'Insufficient funds');
+      return err(new AppError('insufficient_funds', 'Insufficient funds'));
     }
 
-    const wallet = await getWallet({
-      unit,
-      mintUrl: selectedMint,
-      profile: null,
-      ...(forceRefresh && { forceRefresh: true }),
-    });
+    const walletRes = await toResult(
+      getWallet({
+        unit,
+        mintUrl: selectedMint,
+        profile: null,
+        ...(forceRefresh && { forceRefresh: true }),
+      })
+    );
+    if (walletRes.isErr()) return err(walletRes.error);
+    const wallet = walletRes.value;
 
     if (!wallet) {
-      throw new AppError('wallet_not_found', 'Wallet not found');
+      return err(new AppError('wallet_not_found', 'Wallet not found'));
     }
 
     const activeKeyset = wallet.getActiveKeyset(wallet.keysets.filter((key) => key.unit === unit));
@@ -574,11 +583,15 @@ export async function sendEcash({
       keysetId: wallet.keysetId,
     })(state);
 
-    const { keep, send, used } = await wallet._send(Number(amount), currentProofs, {
-      ...(p2pk?.pubkey ? { pubkey: p2pk.pubkey } : {}),
-      counter,
-      keysetId,
-    });
+    const sendRes = await toResult(
+      wallet._send(Number(amount), currentProofs, {
+        ...(p2pk?.pubkey ? { pubkey: p2pk.pubkey } : {}),
+        counter,
+        keysetId,
+      })
+    );
+    if (sendRes.isErr()) return err(sendRes.error);
+    const { keep, send, used } = sendRes.value;
 
     store.dispatch(
       removeProofs({
@@ -645,27 +658,16 @@ export async function sendEcash({
       })
     );
 
-    return transaction;
+    return ok(transaction);
   };
 
   // First attempt
-  try {
-    return await attemptSend(false);
-  } catch (error) {
-    // Check if it's the specific keyset inactive error
-    if (error.message === 'keyset id inactive.') {
-      Alert.alert('Updating keyset...');
-      try {
-        return await attemptSend(true);
-      } catch (retryError) {
-        console.error('[sendEcash] Retry failed:', retryError);
-        throw retryError;
-      }
-    }
-
-    // Re-throw other errors
-    throw error;
+  const first = await attemptSend(false);
+  if (first.isErr() && first.error.message === 'keyset id inactive.') {
+    Alert.alert('Updating keyset...');
+    return attemptSend(true);
   }
+  return first;
 }
 
 export async function receiveEcash({
@@ -682,7 +684,7 @@ export async function receiveEcash({
   memo?: string;
   fromNIP05?: string;
   refund?: boolean;
-}): Promise<EcashReceiveTransaction> {
+}): Promise<Result<EcashReceiveTransaction, Error>> {
   const state = store.getState();
   const profile = memoizedGetCurrentProfile(state);
   const decodedToken = getDecodedToken(token);
@@ -690,15 +692,12 @@ export async function receiveEcash({
 
   const getPubkeyFromToken = (token: string) => {
     const decodedToken = getDecodedToken(token);
-
-    try {
-      return JSON.parse(decodedToken.proofs[0].secret)[0] === 'P2PK'
-        ? JSON.parse(decodedToken.proofs[0].secret)[1].data
-        : null;
-    } catch (error) {
-      console.error('Error parsing token secret:', error);
+    const res = toResultSync(() => JSON.parse(decodedToken.proofs[0].secret));
+    if (res.isErr()) {
+      console.error('Error parsing token secret:', res.error);
       return null;
     }
+    return res.value[0] === 'P2PK' ? res.value[1].data : null;
   };
 
   const key = (() => {
@@ -713,16 +712,22 @@ export async function receiveEcash({
   })();
 
   // Retry logic for wallet operations
-  const attemptReceive = async (forceRefresh = false): Promise<EcashReceiveTransaction> => {
-    const wallet = await getWallet({
-      unit,
-      mintUrl: receiveMintUrl,
-      profile: null,
-      ...(forceRefresh && { forceRefresh: true }),
-    });
+  const attemptReceive = async (
+    forceRefresh = false
+  ): Promise<Result<EcashReceiveTransaction, Error>> => {
+    const walletRes = await toResult(
+      getWallet({
+        unit,
+        mintUrl: receiveMintUrl,
+        profile: null,
+        ...(forceRefresh && { forceRefresh: true }),
+      })
+    );
+    if (walletRes.isErr()) return err(walletRes.error);
+    const wallet = walletRes.value;
 
     if (!wallet) {
-      throw new AppError('wallet_not_found', 'Wallet not found');
+      return err(new AppError('wallet_not_found', 'Wallet not found'));
     }
 
     const activeKeyset = wallet.getActiveKeyset(wallet.keysets.filter((key) => key.unit === unit));
@@ -735,14 +740,18 @@ export async function receiveEcash({
       keysetId: keysetId,
     })(state);
 
-    const response = await wallet.receive(token, {
-      counter,
-      keysetId,
-      ...(key?.privkey ? { privkey: key.privkey } : {}),
-    });
+    const responseRes = await toResult(
+      wallet.receive(token, {
+        counter,
+        keysetId,
+        ...(key?.privkey ? { privkey: key.privkey } : {}),
+      })
+    );
+    if (responseRes.isErr()) return err(responseRes.error);
+    const response = responseRes.value;
 
     if (!response) {
-      throw new AppError('invalid_token', 'Invalid token');
+      return err(new AppError('invalid_token', 'Invalid token'));
     }
 
     const newProofs = [...response];
@@ -800,30 +809,20 @@ export async function receiveEcash({
       ]),
     ]);
 
-    return transaction;
+    return ok(transaction);
   };
 
   // First attempt
-  try {
-    return await attemptReceive(false);
-  } catch (error) {
-    // Check if it's the specific keyset inactive error
-    if (
-      error.message === 'keyset id inactive.' ||
-      error?.message?.startsWith('Could not calculate fees. No keyset found with id:')
-    ) {
-      Alert.alert('Updating keyset...');
-      try {
-        return await attemptReceive(true);
-      } catch (retryError) {
-        console.error('[receiveEcash] Retry failed:', retryError);
-        throw retryError;
-      }
-    }
-
-    // Re-throw other errors
-    throw error;
+  const first = await attemptReceive(false);
+  if (
+    first.isErr() &&
+    (first.error.message === 'keyset id inactive.' ||
+      first.error.message.startsWith('Could not calculate fees. No keyset found with id:'))
+  ) {
+    Alert.alert('Updating keyset...');
+    return attemptReceive(true);
   }
+  return first;
 }
 
 export async function getPaymentRequest({
@@ -860,11 +859,14 @@ export async function cancelEcashTransaction(
   transaction: Transaction,
   navigation: any
 ): Promise<void> {
-  await receiveEcash({
+  const res = await receiveEcash({
     token: transaction.token as string,
     unit: transaction.unit,
     refund: true,
   });
+  if (res.isErr()) {
+    throw res.error;
+  }
 
   const profileId = store.getState().nostr?.currentProfile?.id;
   store.dispatch(
@@ -911,29 +913,26 @@ export function useWallet({ unit, mintUrl, profile, forceRefresh = false }) {
     let isMounted = true;
 
     const fetchWallet = async () => {
-      try {
-        setLoading(true);
-        setError(null);
+      setLoading(true);
+      setError(null);
 
-        const walletInstance = await getWallet({
+      const walletResult = await toResult(
+        getWallet({
           unit,
           mintUrl,
           profile,
           forceRefresh,
-        });
+        })
+      );
 
-        if (isMounted) {
-          setWallet(walletInstance);
+      if (isMounted) {
+        if (walletResult.isOk()) {
+          setWallet(walletResult.value);
+        } else {
+          setError(walletResult.error);
+          console.error('Failed to get wallet:', walletResult.error);
         }
-      } catch (err) {
-        if (isMounted) {
-          setError(err);
-          console.error('Failed to get wallet:', err);
-        }
-      } finally {
-        if (isMounted) {
-          setLoading(false);
-        }
+        setLoading(false);
       }
     };
 
@@ -954,15 +953,21 @@ export function useWallet({ unit, mintUrl, profile, forceRefresh = false }) {
       setError(null);
       setLoading(true);
 
-      getWallet({
-        unit,
-        mintUrl,
-        profile,
-        forceRefresh: true,
-      })
-        .then(setWallet)
-        .catch(setError)
-        .finally(() => setLoading(false));
+      toResult(
+        getWallet({
+          unit,
+          mintUrl,
+          profile,
+          forceRefresh: true,
+        })
+      ).then((result) => {
+        if (result.isOk()) {
+          setWallet(result.value);
+        } else {
+          setError(result.error);
+        }
+        setLoading(false);
+      });
     }
   };
 
@@ -1024,33 +1029,22 @@ export const giveaways = {
  * Validates if a string is a valid ecash token
  */
 export function isValidEcashToken(token: string): boolean {
-  try {
-    getDecodedToken(token);
-    return true;
-  } catch {
-    return false;
-  }
+  return toResultSync(() => getDecodedToken(token)).isOk();
 }
 
 /**
  * Validates if a string is a valid payment request
  */
 export function isValidPaymentRequest(paymentRequest: string): boolean {
-  try {
-    return !!decodePaymentRequest(paymentRequest);
-  } catch {
-    return false;
-  }
+  return toResultSync(() => decodePaymentRequest(paymentRequest)).isOk();
 }
 
 // Lightning invoice parsing utilities
 export function getLightningAmount({ pr }) {
-  try {
-    const decodedPR = decode(pr as string);
-    return decodedPR?.sections?.find((route) => route?.name === 'amount')?.value / 1000;
-  } catch {
-    return null;
-  }
+  const res = toResultSync(() => decode(pr as string));
+  if (res.isErr()) return null;
+  const decodedPR = res.value;
+  return decodedPR?.sections?.find((route) => route?.name === 'amount')?.value / 1000;
 }
 
 export function getTimestamp({ pr }) {
@@ -1082,12 +1076,7 @@ export function getDescription({ pr }) {
 }
 
 export function isValidLNURL(url: string): boolean {
-  try {
-    decode(url);
-    return true;
-  } catch {
-    return false;
-  }
+  return toResultSync(() => decode(url)).isOk();
 }
 
 export function npubToPublicKey(key: string) {
@@ -1132,8 +1121,7 @@ export async function* restoreMint({
   MAX_GAP?: number;
   allowedUnits?: string[];
 }) {
-  try {
-    let response = {};
+  let response = {};
     const mint = await getMint({ mintUrl });
 
     const keysets = (await mint.getKeySets()).keysets;
@@ -1283,9 +1271,6 @@ export async function* restoreMint({
     };
 
     return response;
-  } catch (err) {
-    return null;
-  }
 }
 
 export async function restoreCounter({

--- a/helper/cashuClient.ts
+++ b/helper/cashuClient.ts
@@ -46,6 +46,8 @@ import { getPublicKey, nip19 } from 'nostr-tools';
 import { v4 as uuidv4 } from 'uuid';
 import { SheetManager } from 'react-native-actions-sheet';
 import { bytesToHex } from '@noble/hashes/utils';
+import { toResult, toResultSync } from 'helper/toResult';
+import { ok, err, Result } from 'neverthrow';
 
 // TYPES
 
@@ -267,21 +269,29 @@ export async function getMeltQuote({
   unit: string;
   mintUrl: string;
   mppAmount?: number;
-}): Promise<MeltQuoteResponse> {
-  const wallet = await getWallet({ unit, mintUrl, profile: null });
+}): Promise<Result<MeltQuoteResponse, Error>> {
+  const walletRes = await toResult(
+    getWallet({ unit, mintUrl, profile: null })
+  );
+  if (walletRes.isErr()) return err(walletRes.error);
+  const wallet = walletRes.value;
   const activeKeyset = wallet.getActiveKeyset(wallet.keysets.filter((key) => key.unit === unit));
   const keysetId = activeKeyset.id;
   wallet.keysetId = keysetId;
 
   const options = mppAmount ? { options: { mpp: { amount: mppAmount } } } : {};
 
-  const meltQuote = await wallet.mint.createMeltQuote({
-    request: pr,
-    unit,
-    ...options,
-  });
+  const meltQuoteRes = await toResult(
+    wallet.mint.createMeltQuote({
+      request: pr,
+      unit,
+      ...options,
+    })
+  );
 
-  return meltQuote;
+  if (meltQuoteRes.isErr()) return err(meltQuoteRes.error);
+
+  return ok(meltQuoteRes.value);
 }
 
 export async function sendLightning({

--- a/helper/cashuClient.ts
+++ b/helper/cashuClient.ts
@@ -14,6 +14,7 @@ import {
   removeProofs,
   memoizedGetBalance,
   memoizedGetProofs,
+  TransactionData,
 } from 'helper/redux/cashu';
 import { store } from 'helper/redux/store';
 import { Alert, Platform } from 'react-native';
@@ -28,7 +29,6 @@ import { useState, useEffect } from 'react';
 import {
   MeltQuoteResponse,
   CashuWallet,
-  MintKeyset,
   CashuMint,
   decodePaymentRequest,
   getDecodedToken,
@@ -48,6 +48,7 @@ import { SheetManager } from 'react-native-actions-sheet';
 import { bytesToHex } from '@noble/hashes/utils';
 import { toResult, toResultSync } from 'helper/toResult';
 import { ok, err, Result } from 'neverthrow';
+import { getGiveaway } from 'app/ecashReceiveConfirmation';
 
 // TYPES
 
@@ -129,13 +130,17 @@ interface GetMintParams {
   forceRefresh?: boolean;
 }
 
-
 // wallet caches for all the mints
 let walletCache: { [key: string]: CashuWallet } = {};
 
 // MAIN UTILITIES
 
-export async function getWallet({ unit, mintUrl, profile, forceRefresh = false }: GetWalletParams): Promise<Result<CashuWallet, Error>> {
+export async function getWallet({
+  unit,
+  mintUrl,
+  profile,
+  forceRefresh = false,
+}: GetWalletParams): Promise<Result<CashuWallet, Error>> {
   if (walletCache?.[mintUrl]?.[unit] && !forceRefresh) {
     return ok(walletCache[mintUrl][unit]);
   }
@@ -201,7 +206,10 @@ export async function getWallet({ unit, mintUrl, profile, forceRefresh = false }
   return ok(wallet);
 }
 
-export async function getMint({ mintUrl, forceRefresh = false }: GetMintParams): Promise<Result<CashuMint, Error>> {
+export async function getMint({
+  mintUrl,
+  forceRefresh = false,
+}: GetMintParams): Promise<Result<CashuMint, Error>> {
   const mint = new CashuMint(mintUrl);
 
   if (forceRefresh) {
@@ -242,6 +250,7 @@ export async function getMeltQuote({
   const walletRes = await getWallet({ unit, mintUrl, profile: null });
   if (walletRes.isErr()) return err(walletRes.error);
   const wallet = walletRes.value;
+
   const activeKeyset = wallet.getActiveKeyset(wallet.keysets.filter((key) => key.unit === unit));
   const keysetId = activeKeyset.id;
   wallet.keysetId = keysetId;
@@ -285,6 +294,7 @@ export async function sendLightning({
   if (expiryResult.isErr()) {
     return err(new AppError('invalid_invoice', 'Invalid payment request'));
   }
+
   const expiry = expiryResult.value;
   if (expiry && new Date(Date.now() + 60_000) > expiry) {
     return err(new AppError('invoice_expired', 'Invoice expired'));
@@ -315,6 +325,7 @@ export async function sendLightning({
     const balance = currentProofs
       .map((p: { amount: number }) => p.amount)
       .reduce((a: number, b: number) => a + b, 0);
+
     if (meltQuote.amount + meltQuote.fee_reserve > balance) {
       return err(new AppError('insufficient_funds', 'Insufficient funds'));
     }
@@ -463,9 +474,6 @@ export async function receiveLightning({
   const mintQuoteResult = await toResult(wallet.createMintQuote(amount, memo));
   if (mintQuoteResult.isErr()) return err(mintQuoteResult.error);
   const mintQuote = mintQuoteResult.value;
-  if ((mintQuote as any).error) {
-    return err(new AppError('quote_error', 'Error getting mint quote'));
-  }
 
   const paymentRequest = await getPaymentRequest({
     amount: amount,
@@ -539,10 +547,6 @@ export async function sendEcash({
     });
     if (walletRes.isErr()) return err(walletRes.error);
     const wallet = walletRes.value;
-
-    if (!wallet) {
-      return err(new AppError('wallet_not_found', 'Wallet not found'));
-    }
 
     const activeKeyset = wallet.getActiveKeyset(wallet.keysets.filter((key) => key.unit === unit));
     const keysetId = activeKeyset.id;
@@ -694,10 +698,6 @@ export async function receiveEcash({
     });
     if (walletRes.isErr()) return err(walletRes.error);
     const wallet = walletRes.value;
-
-    if (!wallet) {
-      return err(new AppError('wallet_not_found', 'Wallet not found'));
-    }
 
     const activeKeyset = wallet.getActiveKeyset(wallet.keysets.filter((key) => key.unit === unit));
     const keysetId = activeKeyset.id;
@@ -1098,155 +1098,155 @@ export async function* restoreMint({
   allowedUnits?: string[];
 }) {
   let response = {};
-    const mint = await getMint({ mintUrl });
+  const mint = await getMint({ mintUrl });
 
-    const keysets = (await mint.getKeySets()).keysets;
+  const keysets = (await mint.getKeySets()).keysets;
 
-    const uniqueUnits = keysets
-      .filter((keyset, index, self) => index === self.findIndex((k) => k.unit === keyset.unit))
-      .filter((keyset) => allowedUnits.includes(keyset.unit));
+  const uniqueUnits = keysets
+    .filter((keyset, index, self) => index === self.findIndex((k) => k.unit === keyset.unit))
+    .filter((keyset) => allowedUnits.includes(keyset.unit));
+
+  yield {
+    label: 'INIT',
+    progress: 0,
+    totalUnits: uniqueUnits.length,
+    currentUnit: 0,
+    message: 'Starting restoration process',
+    mintUrl,
+    response,
+  };
+
+  for (let i = 0; i < uniqueUnits.length; i++) {
+    const keyset = uniqueUnits[i];
 
     yield {
-      label: 'INIT',
-      progress: 0,
+      label: 'RESTORING KEYSET',
+      unit: keyset.unit,
+      progress: i / uniqueUnits.length,
+      currentUnit: i + 1,
       totalUnits: uniqueUnits.length,
-      currentUnit: 0,
-      message: 'Starting restoration process',
+      message: `Restoring keyset for ${keyset.unit}`,
       mintUrl,
       response,
     };
 
-    for (let i = 0; i < uniqueUnits.length; i++) {
-      const keyset = uniqueUnits[i];
+    const wallet = await getWallet({ unit: keyset.unit, mintUrl, profile });
+    let start: number = 0;
+    let emptyBatchCount: number = 0;
+    let restoredProofs: Proof[] = [];
+    let totalProofsProcessed = 0;
+    let firstEmptyStart = 0; // Track the first position where proofs begin to be empty
 
+    while (emptyBatchCount < MAX_GAP) {
       yield {
-        label: 'RESTORING KEYSET',
+        label: 'RESTORING BATCH',
         unit: keyset.unit,
-        progress: i / uniqueUnits.length,
+        batchStart: start,
+        batchEnd: start + BATCH_SIZE,
         currentUnit: i + 1,
         totalUnits: uniqueUnits.length,
-        message: `Restoring keyset for ${keyset.unit}`,
+        message: `Fetching proofs ${start} to ${start + BATCH_SIZE}`,
         mintUrl,
         response,
       };
 
-      const wallet = await getWallet({ unit: keyset.unit, mintUrl, profile });
-      let start: number = 0;
-      let emptyBatchCount: number = 0;
-      let restoredProofs: Proof[] = [];
-      let totalProofsProcessed = 0;
-      let firstEmptyStart = 0; // Track the first position where proofs begin to be empty
+      // Fetch a batch of proofs
+      const uncheckedProofs: Proof[] = (
+        await wallet.restore(start, BATCH_SIZE, { keysetId: keyset.id })
+      ).proofs;
 
-      while (emptyBatchCount < MAX_GAP) {
-        yield {
-          label: 'RESTORING BATCH',
-          unit: keyset.unit,
-          batchStart: start,
-          batchEnd: start + BATCH_SIZE,
-          currentUnit: i + 1,
-          totalUnits: uniqueUnits.length,
-          message: `Fetching proofs ${start} to ${start + BATCH_SIZE}`,
-          mintUrl,
-          response,
-        };
-
-        // Fetch a batch of proofs
-        const uncheckedProofs: Proof[] = (
-          await wallet.restore(start, BATCH_SIZE, { keysetId: keyset.id })
-        ).proofs;
-
-        if (uncheckedProofs.length === 0) {
-          if (emptyBatchCount === 0) {
-            firstEmptyStart = start;
-          }
-          emptyBatchCount++;
-        } else {
-          emptyBatchCount = 0;
-          firstEmptyStart = 0; // Reset if we find proofs again
-          totalProofsProcessed += uncheckedProofs.length;
-
-          // Process this batch immediately instead of waiting
-          if (uncheckedProofs.length > 0) {
-            yield {
-              label: 'CHECKING BATCH',
-              unit: keyset.unit,
-              batchStart: start,
-              batchSize: uncheckedProofs.length,
-              currentUnit: i + 1,
-              totalUnits: uniqueUnits.length,
-              message: `Checking states for ${uncheckedProofs.length} proofs`,
-              mintUrl,
-              response,
-            };
-
-            // Check states of this batch
-            const proofStates: ProofState[] = await wallet.checkProofsStates(uncheckedProofs);
-
-            // Filter and keep only the unspent proofs
-            const unspentProofs = uncheckedProofs.filter(
-              (p, index) => proofStates[index].state === 'UNSPENT'
-            );
-
-            // Add unspent proofs to our collection
-            restoredProofs = restoredProofs.concat(unspentProofs);
-
-            yield {
-              label: 'BATCH_PROCESSED',
-              unit: keyset.unit,
-              batchStart: start,
-              unspentCount: unspentProofs.length,
-              totalUnspent: restoredProofs.length,
-              totalProcessed: totalProofsProcessed,
-              currentUnit: i + 1,
-              totalUnits: uniqueUnits.length,
-              message: `Found ${unspentProofs.length} unspent proofs in batch`,
-              mintUrl,
-              response,
-            };
-          }
+      if (uncheckedProofs.length === 0) {
+        if (emptyBatchCount === 0) {
+          firstEmptyStart = start;
         }
+        emptyBatchCount++;
+      } else {
+        emptyBatchCount = 0;
+        firstEmptyStart = 0; // Reset if we find proofs again
+        totalProofsProcessed += uncheckedProofs.length;
 
-        start += BATCH_SIZE;
+        // Process this batch immediately instead of waiting
+        if (uncheckedProofs.length > 0) {
+          yield {
+            label: 'CHECKING BATCH',
+            unit: keyset.unit,
+            batchStart: start,
+            batchSize: uncheckedProofs.length,
+            currentUnit: i + 1,
+            totalUnits: uniqueUnits.length,
+            message: `Checking states for ${uncheckedProofs.length} proofs`,
+            mintUrl,
+            response,
+          };
+
+          // Check states of this batch
+          const proofStates: ProofState[] = await wallet.checkProofsStates(uncheckedProofs);
+
+          // Filter and keep only the unspent proofs
+          const unspentProofs = uncheckedProofs.filter(
+            (p, index) => proofStates[index].state === 'UNSPENT'
+          );
+
+          // Add unspent proofs to our collection
+          restoredProofs = restoredProofs.concat(unspentProofs);
+
+          yield {
+            label: 'BATCH_PROCESSED',
+            unit: keyset.unit,
+            batchStart: start,
+            unspentCount: unspentProofs.length,
+            totalUnspent: restoredProofs.length,
+            totalProcessed: totalProofsProcessed,
+            currentUnit: i + 1,
+            totalUnits: uniqueUnits.length,
+            message: `Found ${unspentProofs.length} unspent proofs in batch`,
+            mintUrl,
+            response,
+          };
+        }
       }
 
-      // Calculate the final index after searching
-      const keysetIndex = firstEmptyStart !== 0 ? firstEmptyStart : start - MAX_GAP * BATCH_SIZE;
-
-      // Build the full response
-      response = {
-        ...response,
-        [keyset.unit]: {
-          proofs: restoredProofs,
-          keysets: {
-            ...response?.[keyset?.unit]?.keysets,
-            [keyset.id]: keysetIndex,
-          },
-        },
-      };
-
-      yield {
-        label: 'KEYSET_COMPLETE',
-        unit: keyset.unit,
-        progress: (i + 1) / uniqueUnits.length,
-        currentUnit: i + 1,
-        totalUnits: uniqueUnits.length,
-        proofCount: restoredProofs.length,
-        index: keysetIndex, // Add index to the yield data
-        message: `Completed keyset for ${keyset.unit} with ${restoredProofs.length} proofs, index: ${keysetIndex}`,
-        mintUrl,
-        response,
-      };
+      start += BATCH_SIZE;
     }
 
+    // Calculate the final index after searching
+    const keysetIndex = firstEmptyStart !== 0 ? firstEmptyStart : start - MAX_GAP * BATCH_SIZE;
+
+    // Build the full response
+    response = {
+      ...response,
+      [keyset.unit]: {
+        proofs: restoredProofs,
+        keysets: {
+          ...response?.[keyset?.unit]?.keysets,
+          [keyset.id]: keysetIndex,
+        },
+      },
+    };
+
     yield {
-      label: 'COMPLETE',
-      progress: 1,
-      message: 'Restoration complete',
+      label: 'KEYSET_COMPLETE',
+      unit: keyset.unit,
+      progress: (i + 1) / uniqueUnits.length,
+      currentUnit: i + 1,
+      totalUnits: uniqueUnits.length,
+      proofCount: restoredProofs.length,
+      index: keysetIndex, // Add index to the yield data
+      message: `Completed keyset for ${keyset.unit} with ${restoredProofs.length} proofs, index: ${keysetIndex}`,
       mintUrl,
       response,
     };
+  }
 
-    return response;
+  yield {
+    label: 'COMPLETE',
+    progress: 1,
+    message: 'Restoration complete',
+    mintUrl,
+    response,
+  };
+
+  return response;
 }
 
 export async function restoreCounter({
@@ -1291,14 +1291,27 @@ export async function restoreCounter({
   return firstEmptyStart;
 }
 
-// ERROR
+export const checkIfAlreadyRedeemed = (token: string): boolean => {
+  const profileId = store.getState().nostr?.currentProfile?.id;
+  const transactions = memoizedGetTransactions({ id: profileId })(store.getState());
+
+  const giveaway = getGiveaway({ token });
+  if (!giveaway) return false;
+
+  return transactions.some(
+    (tx: TransactionData) =>
+      tx.privkey === giveaway.private_key && tx.transactionType === 'receive' && !tx.isRefund
+  );
+};
 
 export class AppError extends Error {
-  static messageMap = {};
+  type: string;
+  code?: string;
 
-  constructor(name, message) {
-    const mappedError = AppError.messageMap[message];
-    super(mappedError?.message || message);
-    this.name = mappedError?.name || name;
+  constructor(message: string, type: string, code?: string) {
+    super(message);
+    this.name = 'AppError';
+    this.type = type;
+    this.code = code;
   }
 }

--- a/helper/cashuClient.ts
+++ b/helper/cashuClient.ts
@@ -129,20 +129,15 @@ interface GetMintParams {
   forceRefresh?: boolean;
 }
 
-interface GetKeysParams {
-  unit: string;
-  mintUrl: string;
-  forceRefresh?: boolean;
-}
 
 // wallet caches for all the mints
 let walletCache: { [key: string]: CashuWallet } = {};
 
 // MAIN UTILITIES
 
-export async function getWallet({ unit, mintUrl, profile, forceRefresh = false }: GetWalletParams) {
+export async function getWallet({ unit, mintUrl, profile, forceRefresh = false }: GetWalletParams): Promise<Result<CashuWallet, Error>> {
   if (walletCache?.[mintUrl]?.[unit] && !forceRefresh) {
-    return walletCache[mintUrl][unit];
+    return ok(walletCache[mintUrl][unit]);
   }
 
   const currentProfile = profile?.pubkey ? profile : memoizedGetCurrentProfile(store.getState());
@@ -154,10 +149,12 @@ export async function getWallet({ unit, mintUrl, profile, forceRefresh = false }
   const lastFetched = audits?.lastFetched ?? 0;
   const shouldRefresh = forceRefresh || !mintInfo || !keys || !keysets;
 
-  const mint = await getMint({
+  const mintRes = await getMint({
     mintUrl,
     forceRefresh: shouldRefresh,
   });
+  if (mintRes.isErr()) return err(mintRes.error);
+  const mint = mintRes.value;
 
   mintInfo = store.getState().cashu?.info?.[mintUrl];
   keys = store.getState().cashu?.keys?.[mintUrl];
@@ -201,61 +198,33 @@ export async function getWallet({ unit, mintUrl, profile, forceRefresh = false }
     ...walletCache,
   };
 
-  return wallet;
+  return ok(wallet);
 }
 
-export async function getMint({ mintUrl, forceRefresh = false }: GetMintParams) {
+export async function getMint({ mintUrl, forceRefresh = false }: GetMintParams): Promise<Result<CashuMint, Error>> {
   const mint = new CashuMint(mintUrl);
 
   if (forceRefresh) {
-    const mintInfo = await mint.getInfo();
+    const infoRes = await toResult(mint.getInfo());
+    if (infoRes.isErr()) return err(infoRes.error);
+
+    const keysetsRes = await toResult(mint.getKeySets());
+    if (keysetsRes.isErr()) return err(keysetsRes.error);
+
+    const keysRes = await toResult(mint.getKeys());
+    if (keysRes.isErr()) return err(keysRes.error);
 
     store.dispatch(
       setInfo({
         mintUrl,
-        mintInfo,
+        mintInfo: infoRes.value,
       })
     );
-    store.dispatch(setKeysets({ mintUrl, keysets: (await mint.getKeySets()).keysets }));
-    store.dispatch(setKeys({ mintUrl, keys: (await mint.getKeys()).keysets }));
+    store.dispatch(setKeysets({ mintUrl, keysets: keysetsRes.value.keysets }));
+    store.dispatch(setKeys({ mintUrl, keys: keysRes.value.keysets }));
   }
 
-  return mint;
-}
-
-export async function getKeys({
-  unit,
-  mintUrl,
-  forceRefresh = false,
-}: GetKeysParams): Promise<MintKeyset | undefined> {
-  const mint = getMint({ mintUrl });
-
-  // check if keysets and keys are already cached
-  if (store.getState().cashu.keysets[mintUrl] && !forceRefresh) {
-    return store.getState().cashu.keysets[mintUrl].find((k) => k.unit === unit);
-  }
-
-  const keysets = (await (await mint).getKeySets()).keysets;
-  const keys = (await (await mint).getKeys()).keysets;
-
-  const key = keysets.find((k) => k.unit === unit);
-
-  // Store the keyset in cache
-  store.dispatch(
-    setKeysets({
-      mintUrl,
-      keysets,
-    })
-  );
-
-  store.dispatch(
-    setKeys({
-      mintUrl,
-      keys,
-    })
-  );
-
-  return key;
+  return ok(mint);
 }
 
 // Melt quote and payment functions
@@ -270,9 +239,7 @@ export async function getMeltQuote({
   mintUrl: string;
   mppAmount?: number;
 }): Promise<Result<MeltQuoteResponse, Error>> {
-  const walletRes = await toResult(
-    getWallet({ unit, mintUrl, profile: null })
-  );
+  const walletRes = await getWallet({ unit, mintUrl, profile: null });
   if (walletRes.isErr()) return err(walletRes.error);
   const wallet = walletRes.value;
   const activeKeyset = wallet.getActiveKeyset(wallet.keysets.filter((key) => key.unit === unit));
@@ -328,14 +295,12 @@ export async function sendLightning({
     forceRefresh = false
   ): Promise<Result<LightningSendTransaction, Error>> => {
     const currentProofs = memoizedGetProofs(unit)(state);
-    const walletRes = await toResult(
-      getWallet({
-        unit,
-        mintUrl,
-        profile: null,
-        ...(forceRefresh && { forceRefresh: true }),
-      })
-    );
+    const walletRes = await getWallet({
+      unit,
+      mintUrl,
+      profile: null,
+      ...(forceRefresh && { forceRefresh: true }),
+    });
     if (walletRes.isErr()) return err(walletRes.error);
     const wallet = walletRes.value;
 
@@ -483,13 +448,11 @@ export async function receiveLightning({
   const profile = memoizedGetCurrentProfile(store.getState());
 
   Alert.alert('a', JSON.stringify(unit, selectedMint));
-  const walletRes = await toResult(
-    getWallet({
-      unit,
-      mintUrl: selectedMint,
-      profile: null,
-    })
-  );
+  const walletRes = await getWallet({
+    unit,
+    mintUrl: selectedMint,
+    profile: null,
+  });
   if (walletRes.isErr()) return err(walletRes.error);
   const wallet = walletRes.value;
 
@@ -568,14 +531,12 @@ export async function sendEcash({
       return err(new AppError('insufficient_funds', 'Insufficient funds'));
     }
 
-    const walletRes = await toResult(
-      getWallet({
-        unit,
-        mintUrl: selectedMint,
-        profile: null,
-        ...(forceRefresh && { forceRefresh: true }),
-      })
-    );
+    const walletRes = await getWallet({
+      unit,
+      mintUrl: selectedMint,
+      profile: null,
+      ...(forceRefresh && { forceRefresh: true }),
+    });
     if (walletRes.isErr()) return err(walletRes.error);
     const wallet = walletRes.value;
 
@@ -725,14 +686,12 @@ export async function receiveEcash({
   const attemptReceive = async (
     forceRefresh = false
   ): Promise<Result<EcashReceiveTransaction, Error>> => {
-    const walletRes = await toResult(
-      getWallet({
-        unit,
-        mintUrl: receiveMintUrl,
-        profile: null,
-        ...(forceRefresh && { forceRefresh: true }),
-      })
-    );
+    const walletRes = await getWallet({
+      unit,
+      mintUrl: receiveMintUrl,
+      profile: null,
+      ...(forceRefresh && { forceRefresh: true }),
+    });
     if (walletRes.isErr()) return err(walletRes.error);
     const wallet = walletRes.value;
 
@@ -868,14 +827,14 @@ export async function getPaymentRequest({
 export async function cancelEcashTransaction(
   transaction: Transaction,
   navigation: any
-): Promise<void> {
+): Promise<Result<void, Error>> {
   const res = await receiveEcash({
     token: transaction.token as string,
     unit: transaction.unit,
     refund: true,
   });
   if (res.isErr()) {
-    throw res.error;
+    return err(res.error);
   }
 
   const profileId = store.getState().nostr?.currentProfile?.id;
@@ -893,6 +852,7 @@ export async function cancelEcashTransaction(
 
   SheetManager.hide('button-handler');
   navigation.navigate('', {}, { closeParents: true });
+  return ok(undefined);
 }
 
 export function getUsedProofs(currentProofs, keepProofs) {
@@ -926,14 +886,12 @@ export function useWallet({ unit, mintUrl, profile, forceRefresh = false }) {
       setLoading(true);
       setError(null);
 
-      const walletResult = await toResult(
-        getWallet({
-          unit,
-          mintUrl,
-          profile,
-          forceRefresh,
-        })
-      );
+      const walletResult = await getWallet({
+        unit,
+        mintUrl,
+        profile,
+        forceRefresh,
+      });
 
       if (isMounted) {
         if (walletResult.isOk()) {
@@ -963,14 +921,12 @@ export function useWallet({ unit, mintUrl, profile, forceRefresh = false }) {
       setError(null);
       setLoading(true);
 
-      toResult(
-        getWallet({
-          unit,
-          mintUrl,
-          profile,
-          forceRefresh: true,
-        })
-      ).then((result) => {
+      getWallet({
+        unit,
+        mintUrl,
+        profile,
+        forceRefresh: true,
+      }).then((result) => {
         if (result.isOk()) {
           setWallet(result.value);
         } else {
@@ -996,8 +952,18 @@ export async function checkTokenSpent({ token }) {
   const decodedToken = getDecodedToken(token);
   const { unit, mint, proofs } = decodedToken;
 
-  const wallet = await getWallet({ unit, mintUrl: mint });
-  return (await wallet.checkProofsStates(proofs)).some((p) => p.state === 'SPENT');
+  const walletRes = await getWallet({ unit, mintUrl: mint, profile: null });
+  if (walletRes.isErr()) {
+    console.error('Error fetching wallet for checkTokenSpent:', walletRes.error);
+    return false;
+  }
+  const wallet = walletRes.value;
+  const statesRes = await toResult(wallet.checkProofsStates(proofs));
+  if (statesRes.isErr()) {
+    console.error('Error checking proof states:', statesRes.error);
+    return false;
+  }
+  return statesRes.value.some((p) => p.state === 'SPENT');
 }
 
 // HELPER FUNCTIONS

--- a/helper/navigation/hooks/useEncryptedDirectMessage.ts
+++ b/helper/navigation/hooks/useEncryptedDirectMessage.ts
@@ -41,13 +41,14 @@ export const useSendEncryptedDirectMessage = () => {
 
     const pubkey: string = (result.data as ProfilePointer).pubkey;
 
-    const transaction = await sendEcash({
+    const result = await sendEcash({
       unit: decodedRequest.unit as string,
       amount: decodedRequest.amount as number,
       to: pubkey,
       paymentRequest: request,
     });
-
+    if (result.isErr()) return;
+    const transaction = result.value;
     const decodedToken = getDecodedToken(transaction.token);
 
     sendGiftWrappedEncryptedDirectMessage({

--- a/helper/navigation/hooks/useEncryptedDirectMessage.ts
+++ b/helper/navigation/hooks/useEncryptedDirectMessage.ts
@@ -37,18 +37,18 @@ export const useSendEncryptedDirectMessage = () => {
   const sendPaymentRequest = async ({ request }: { request: string }) => {
     const decodedRequest = decodePaymentRequest(request);
 
-    const result = nip19.decode(decodedRequest.transport[0].target);
+    const decodedTarget = nip19.decode(decodedRequest.transport[0].target);
 
-    const pubkey: string = (result.data as ProfilePointer).pubkey;
+    const pubkey: string = (decodedTarget.data as ProfilePointer).pubkey;
 
-    const result = await sendEcash({
+    const sendResult = await sendEcash({
       unit: decodedRequest.unit as string,
       amount: decodedRequest.amount as number,
       to: pubkey,
       paymentRequest: request,
     });
-    if (result.isErr()) return;
-    const transaction = result.value;
+    if (sendResult.isErr()) return;
+    const transaction = sendResult.value;
     const decodedToken = getDecodedToken(transaction.token);
 
     sendGiftWrappedEncryptedDirectMessage({

--- a/helper/navigation/hooks/usePollingPaymentRequest.ts
+++ b/helper/navigation/hooks/usePollingPaymentRequest.ts
@@ -113,11 +113,16 @@ export const usePollingPaymentRequest = ({ paymentRequest }: UsePollingPaymentRe
     if (spent.length !== 0) {
       // throw new AppError("Token already spent.", "Token already spent.");
     } else {
-      received = await receiveEcash({
+      const res = await receiveEcash({
         token: encodedEcash,
         unit,
         from,
       });
+      if (res.isOk()) {
+        received = res.value;
+      } else {
+        return;
+      }
     }
 
     const profileId = memoizedGetCurrentProfile(store.getState()).id;

--- a/helper/navigation/hooks/usePollingPaymentRequest.ts
+++ b/helper/navigation/hooks/usePollingPaymentRequest.ts
@@ -110,7 +110,7 @@ export const usePollingPaymentRequest = ({ paymentRequest }: UsePollingPaymentRe
     });
 
     let received;
-    if (spent.length !== 0) {
+    if (spent) {
       // throw new AppError("Token already spent.", "Token already spent.");
     } else {
       const res = await receiveEcash({

--- a/helper/navigation/screens.tsx
+++ b/helper/navigation/screens.tsx
@@ -26,32 +26,24 @@ export const TAB_SCREENS = (settings: any): TabConfig[] => [
     title: 'Payments',
     icon: ({ color }) => <Icon name="fluent:arrow-swap-16-filled" color={color} size={32} />,
   },
-  ...(settings?.experimental
-    ? [
-        {
-          name: 'myEsims',
-          component: MyEsims,
-          title: '',
-          icon: ({ color }) => <Icon name="fluent:sim-24-filled" color={color} size={32} />,
-        },
-      ]
-    : []),
+  {
+    name: 'myEsims',
+    component: MyEsims,
+    title: '',
+    icon: ({ color }) => <Icon name="fluent:sim-24-filled" color={color} size={32} />,
+  },
   {
     name: 'index',
     component: HomeView,
     title: 'Wallet',
     icon: LightningIcon,
   },
-  ...(settings?.experimental
-    ? [
-        {
-          name: 'myVpns',
-          component: MyVpns,
-          title: '',
-          icon: ({ color }) => <Icon name="ic:baseline-vpn-lock" color={color} size={32} />,
-        },
-      ]
-    : []),
+  {
+    name: 'myVpns',
+    component: MyVpns,
+    title: '',
+    icon: ({ color }) => <Icon name="ic:baseline-vpn-lock" color={color} size={32} />,
+  },
   {
     name: 'lifestyle',
     component: LifestyleView,

--- a/helper/payment-handler/handlers.ts
+++ b/helper/payment-handler/handlers.ts
@@ -134,11 +134,15 @@ const handleLightning = async ({
   }
 
   if (amount) {
-    const meltQuote = await getMeltQuote({
+    const meltQuoteRes = await getMeltQuote({
       pr: lnurl,
       unit,
       mintUrl: selectedMint,
     });
+    if (meltQuoteRes.isErr()) {
+      return err('general_error');
+    }
+    const meltQuote = meltQuoteRes.value;
     const totalAmount = amount + meltQuote.fee_reserve;
     if (balance !== undefined && balance < totalAmount) {
       return err('insufficient_balance');

--- a/helper/payment-handler/handlers.ts
+++ b/helper/payment-handler/handlers.ts
@@ -1,34 +1,24 @@
-import { getLightningAmount, getMeltQuote, isValidEcashToken } from 'helper/cashuClient';
+import {
+  checkIfAlreadyRedeemed,
+  getLightningAmount,
+  getMeltQuote,
+  isValidEcashToken,
+  isValidPaymentRequest,
+} from 'helper/cashuClient';
 
 import { getGiveaway } from 'app/ecashReceiveConfirmation';
-import { store } from '../redux/store';
 import { decodePaymentRequest } from '@cashu/cashu-ts';
-import { memoizedGetTransactions, TransactionData } from '../redux/cashu';
 import { URDecoder } from '@gandlaf21/bc-ur';
 import Haptics from 'components/common/Haptics';
 import { isLightningAddress, isLightningInvoice, isLnurlp, lnTrim } from 'helper/third-party/lnurl';
-import { isValidPaymentRequest } from '../cashu/helper';
 import { ok, err, Result } from 'neverthrow';
-
-export const checkIfAlreadyRedeemed = (token: string): boolean => {
-  const profileId = store.getState().nostr?.currentProfile?.id;
-  const transactions = memoizedGetTransactions({ id: profileId })(store.getState());
-
-  const giveaway = getGiveaway({ token });
-  if (!giveaway) return false;
-
-  return transactions.some(
-    (tx: TransactionData) =>
-      tx.privkey === giveaway.private_key && tx.transactionType === 'receive' && !tx.isRefund
-  );
-};
 
 interface NavigationResult {
   screen: string;
   params: Record<string, any>;
 }
 
-type HandlerResult = Result<NavigationResult | null, string>;
+type HandlerResult = Result<NavigationResult | null, Error>;
 
 interface BarcodeHandlerProps {
   scanning: { data: string };
@@ -93,11 +83,11 @@ const handleEcash = async ({
   const giveaway = getGiveaway({ token: data });
   if (giveaway?.id) {
     if (checkIfAlreadyRedeemed(data)) {
-      return err('already_redeemed');
+      return err(new Error('already_redeemed'));
     }
     const error = giveaway.error();
     if (!giveaway.condition() && error) {
-      return err('general_error');
+      return err(new Error('general_error'));
     }
   }
   return ok({
@@ -145,7 +135,7 @@ const handleLightning = async ({
     const meltQuote = meltQuoteRes.value;
     const totalAmount = amount + meltQuote.fee_reserve;
     if (balance !== undefined && balance < totalAmount) {
-      return err('insufficient_balance');
+      return err(new Error('insufficient_balance'));
     }
     return ok({
       screen: 'lightningSendConfirmation',
@@ -160,13 +150,31 @@ const handleLightning = async ({
   return ok(null);
 };
 
+function handlePaymentRequest({ data }: { data: string }): HandlerResult {
+  const decodedPaymentRequest = decodePaymentRequest(data);
+
+  return ok({
+    screen: 'currency',
+    params: {
+      unit: decodedPaymentRequest.unit,
+      amount:
+        decodedPaymentRequest.unit === 'sat'
+          ? decodedPaymentRequest.amount
+          : decodedPaymentRequest.amount / 100,
+      mints: decodedPaymentRequest.mints,
+      allowedUnits: [decodedPaymentRequest.unit?.toUpperCase()],
+      paymentRequest: data,
+      to: 'ecashSendConfirmation',
+    },
+  });
+}
+
 export const handleBarcode = async ({
   scanning,
   urDecoder,
   unit,
   selectedMint,
   setProgress,
-  setLoading,
   setScanned,
   balance,
 }: BarcodeHandlerProps): Promise<HandlerResult> => {
@@ -183,23 +191,7 @@ export const handleBarcode = async ({
   } else if (isValidEcashToken(scanning.data)) {
     return handleEcash({ data: scanning.data, unit });
   } else if (isValidPaymentRequest(scanning.data)) {
-    const decodedPaymentRequest = decodePaymentRequest(scanning.data);
-    console.log({ decodedPaymentRequest });
-
-    return ok({
-      screen: 'currency',
-      params: {
-        unit: decodedPaymentRequest.unit,
-        amount:
-          decodedPaymentRequest.unit === 'sat'
-            ? decodedPaymentRequest.amount
-            : decodedPaymentRequest.amount / 100,
-        mints: decodedPaymentRequest.mints,
-        allowedUnits: [decodedPaymentRequest.unit?.toUpperCase()],
-        paymentRequest: scanning.data,
-        to: 'ecashSendConfirmation',
-      },
-    });
+    return handlePaymentRequest({ data: scanning.data });
   } else if (
     isLightningAddress(lnTrim(scanning.data)) ||
     isLnurlp(lnTrim(scanning.data)) ||
@@ -210,20 +202,19 @@ export const handleBarcode = async ({
       selectedMint,
       unit,
       balance,
-      setLoading,
     });
   }
-  return err('invalid_address');
+  return err(new Error('invalid_address'));
 };
 
 // Wrapper function to maintain current navigation behavior
 export const barcodeHandler = async (
   props: BarcodeHandlerProps & { navigation: any }
-): Promise<Result<void, string>> => {
+): Promise<HandlerResult> => {
   const { navigation, ...handlerProps } = props;
 
   if (!navigation.isFocused()) {
-    return ok(undefined);
+    return ok(null);
   }
 
   const result = await handleBarcode(handlerProps);
@@ -234,7 +225,7 @@ export const barcodeHandler = async (
         closeCurrentAndParent: true,
       });
     }
-    return ok(undefined);
+    return ok(null);
   }
 
   return err(result.error);

--- a/helper/payment-handler/handlers.ts
+++ b/helper/payment-handler/handlers.ts
@@ -140,7 +140,7 @@ const handleLightning = async ({
       mintUrl: selectedMint,
     });
     if (meltQuoteRes.isErr()) {
-      return err('general_error');
+      return err(meltQuoteRes.error);
     }
     const meltQuote = meltQuoteRes.value;
     const totalAmount = amount + meltQuote.fee_reserve;

--- a/helper/redux/cashu/actions.ts
+++ b/helper/redux/cashu/actions.ts
@@ -1,4 +1,5 @@
 import { getMint } from 'helper/cashuClient';
+import { toResult } from 'helper/toResult';
 import {
   ENSURE_PROFILE_EXISTS,
   SET_KEYSETS,
@@ -175,72 +176,68 @@ export const ensureProfileExistsAction = (profileId: number) => ({
 
 export const updateMint = ({ mintUrl }: { mintUrl: string }) => {
   return async (dispatch) => {
-    try {
-      const mint = getMint({ mintUrl });
-
-      // Fetch the keyset from the provided mintUrl if not found in cache
-      const keysets = (await (await mint).getKeySets()).keysets;
-      const keys = (await (await mint).getKeys()).keysets;
-
-      // Step 2: Set the keysets in the store
-      dispatch(
-        setKeysets({
-          mintUrl,
-          keysets,
-        })
-      );
-
-      dispatch(
-        setKeys({
-          mintUrl,
-          keys,
-        })
-      );
-
-      const mintInfo = await (await mint).getInfo();
-
-      dispatch(
-        setInfo({
-          mintUrl,
-          mintInfo,
-        })
-      );
-
-      return { success: true };
-    } catch (error) {
-      // You might want to dispatch an error action here
+    const mintRes = await getMint({ mintUrl, forceRefresh: true });
+    if (mintRes.isErr()) {
       return { success: false };
     }
+    const mint = mintRes.value;
+
+    const keysetsRes = await toResult(mint.getKeySets());
+    const keysRes = await toResult(mint.getKeys());
+    if (keysetsRes.isErr() || keysRes.isErr()) {
+      return { success: false };
+    }
+
+    dispatch(
+      setKeysets({
+        mintUrl,
+        keysets: keysetsRes.value.keysets,
+      })
+    );
+
+    dispatch(
+      setKeys({
+        mintUrl,
+        keys: keysRes.value.keysets,
+      })
+    );
+
+    const mintInfoRes = await toResult(mint.getInfo());
+    if (mintInfoRes.isErr()) {
+      return { success: false };
+    }
+
+    dispatch(
+      setInfo({
+        mintUrl,
+        mintInfo: mintInfoRes.value,
+      })
+    );
+
+    return { success: true };
   };
 };
 
 export const addMintsAction = ({ profileId, mintUrls }) => {
   return async (dispatch) => {
-    try {
-      // First update all mints (fetch and store keysets and info)
-      const updatePromises = mintUrls.map((mintUrl) => dispatch(updateMint({ mintUrl })));
+    // First update all mints (fetch and store keysets and info)
+    const updatePromises = mintUrls.map((mintUrl) => dispatch(updateMint({ mintUrl })));
 
-      // Wait for all updates to complete
-      const results = await Promise.all(updatePromises);
+    const results = await Promise.all(updatePromises);
 
-      // Check if all updates were successful
-      const allSuccessful = results.every((result) => result.success);
+    const allSuccessful = results.every((result) => result.success);
 
-      if (allSuccessful) {
-        // Add all mints to the profile
-        dispatch(
-          addMints({
-            profileId,
-            mints: mintUrls,
-          })
-        );
+    if (allSuccessful) {
+      dispatch(
+        addMints({
+          profileId,
+          mints: mintUrls,
+        })
+      );
 
-        return { success: true };
-      } else {
-        return { success: false, error: 'Some mint updates failed' };
-      }
-    } catch (error) {
-      return { success: false };
+      return { success: true };
+    } else {
+      return { success: false, error: 'Some mint updates failed' };
     }
   };
 };

--- a/helper/toResult.ts
+++ b/helper/toResult.ts
@@ -1,0 +1,12 @@
+import { ResultAsync, ok, err, Result } from 'neverthrow';
+
+export const toResult = <T>(promise: Promise<T>) =>
+  ResultAsync.fromPromise(promise, (e) => (e instanceof Error ? e : new Error(String(e))));
+
+export const toResultSync = <T>(fn: () => T): Result<T, Error> => {
+  try {
+    return ok(fn());
+  } catch (e) {
+    return err(e instanceof Error ? e : new Error(String(e)));
+  }
+};

--- a/ios/Sovran/Info.plist
+++ b/ios/Sovran/Info.plist
@@ -33,7 +33,7 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>7</string>
+    <string>8</string>
     <key>ITSAppUsesNonExemptEncryption</key>
     <false/>
     <key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
## Summary
- add neverthrow utility helpers
- refactor `cashuClient` to return `Result` objects and remove try/catch usage
- update wallet hook and transaction helpers for neverthrow
- update UI components and hooks to handle new result types

## Testing
- `npx tsc -p tsconfig.json` *(fails: expo base not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_686edc748d308325a535a5e729f882c4