### PR TITLE
chore(repo): clarify commit body guidance

### DIFF
--- a/.cursor/rules/git-pr-commits.mdc
+++ b/.cursor/rules/git-pr-commits.mdc
@@ -65,6 +65,7 @@ Skip commit only if truly trivial or user explicitly says “no commits”.
 ## Commit & scope conventions
 
 - Conventional Commits: `type(scope): subject` (≤72 chars, imperative, no period)
+- If the subject line isn’t enough, it’s valid to add a **commit description/body** (multiple lines) to capture extra context (why, tradeoffs, edge cases). Keep the subject concise; put the longer explanation in the body.
 - Allowed `type`: `feat`, `fix`, `refactor`, `perf`, `test`, `docs`, `style`, `build`, `ci`, `chore`
 - Pick **one primary scope**. Prefer deriving scope from the **diff paths**, then feature intent.
   - Examples: `app/(mint-flow)` → `mint`, `app/(drawer)` → `nav`/tab scope, `components/ui` → `ui`, `patches/*` → `patches`, `metro.config.js` → `metro`


### PR DESCRIPTION
What / Why
- Clarify that commit bodies/descriptions are valid when the subject line needs more room.

What changed
- Updated /.cursor/rules/git-pr-commits.mdc with explicit commit body guidance.

Screenshots / Video
- N/A

Test plan
1) npm run lint
2) npm run type-check
3) npm run pretty:check
4) npm run knip

Notes / Risks
- Low risk: docs/rules-only change.
