### PR TITLE
chore(repo): document how to reword commit messages

### DIFF
--- a/.cursor/rules/available-rules.md
+++ b/.cursor/rules/available-rules.md
@@ -18,6 +18,16 @@ This project has several important rules that should be followed. Always check a
   - Available icon libraries: Material Symbols, Fluent UI, Lucide, Font Awesome 6, etc.
 - **When to follow**: Whenever using icons in components
 
+## @git-pr-commits.mdc
+
+- **Purpose**: End-to-end git + GitHub workflow (branching, commit standards, safety, validation, PR template)
+- **When to follow**: Always (this rule is always applied)
+
+## @reword-commit-message.mdc
+
+- **Purpose**: Safely reword a commit title/body (amend vs rebase vs filter-branch) without changing code
+- **When to follow**: When you need to edit an existing commit message (especially if already pushed)
+
 ## Other Rules
 
 - Check `.cursor/rules/` directory for additional project-specific rules

--- a/.cursor/rules/reword-commit-message.mdc
+++ b/.cursor/rules/reword-commit-message.mdc
@@ -1,0 +1,68 @@
+---
+description: How to edit an existing commit title/body (reword) safely in this repo
+globs:
+  - "**/*"
+alwaysApply: false
+---
+
+## Goal
+
+Edit **only** a commit’s title/description (no code changes), while following Conventional Commits and repo safety rules.
+
+## Before you rewrite anything
+
+```bash
+git status
+git branch --show-current
+git log --oneline --decorate -n 30
+```
+
+- **Never rewrite `main` directly**: create a branch first.
+
+```bash
+git checkout -b chore/git-reword-<short-kebab>
+```
+
+## Case A: commit is `HEAD` (latest)
+
+```bash
+git commit --amend
+```
+
+## Case B: older commit, *linear* history (no merges to preserve)
+
+```bash
+git rebase -i <sha>^
+```
+
+- Change `pick` → `reword` for the target commit, save, then edit the message when prompted.
+
+## Case C: older commit, merge-heavy history (or rebase is risky)
+
+Prefer `git filter-repo` (if installed). If not available, use `git filter-branch` to rewrite **only** the target commit message:
+
+```bash
+FILTER_BRANCH_SQUELCH_WARNING=1 git filter-branch -f --msg-filter '
+if [ "$GIT_COMMIT" = "<target_sha>" ]; then
+  cat << "EOF"
+type(scope): subject
+
+- Bullet 1 describing user-facing change
+- Bullet 2 describing user-facing change
+EOF
+else
+  cat
+fi
+' HEAD
+```
+
+## Publishing after rewriting history
+
+- If the branch is already pushed, use **force-with-lease**:
+
+```bash
+git push --force-with-lease -u origin HEAD
+```
+
+- If you truly must update `origin/main`, coordinate first (this rewrites shared history).
+


### PR DESCRIPTION
What / Why
- Document a safe, repo-specific way to reword commit titles/bodies (amend vs rebase vs filter-branch).

What changed
- Added @reword-commit-message rule.
- Listed the rule in available rules for discoverability.

Screenshots / Video
- N/A

Test plan
1) Read `.cursor/rules/reword-commit-message.mdc`.
2) Confirm `.cursor/rules/available-rules.md` references it.

Notes / Risks
- N/A
