### PR TITLE
feat(app): add offline shell, NFC rollback, and release automation

### DIFF
--- a/app/(drawer)/(tabs)/_layout.tsx
+++ b/app/(drawer)/(tabs)/_layout.tsx
@@ -6,6 +6,7 @@ import { BlurView } from 'expo-blur';
 import { supportsLiquidGlass } from '@/helper/version';
 import { Colors } from '@/constants/theme';
 import { IconSymbol } from '@/components/ui/icon-symbol';
+import { OfflineProvider } from '@/providers/OfflineProvider';
 
 // Fallback tab bar background for pre-liquid glass devices
 const TabBarBackground = () => (
@@ -17,52 +18,56 @@ export default function TabLayout() {
   if (supportsLiquidGlass()) {
     return (
       <BackgroundProvider>
-        <NativeTabs
-          labelStyle={{
-            color: Platform.select({
-              ios: DynamicColorIOS({
-                dark: Colors.dark.text,
-                light: Colors.light.text,
+        <OfflineProvider>
+          <NativeTabs
+            labelStyle={{
+              color: Platform.select({
+                ios: DynamicColorIOS({
+                  dark: Colors.dark.text,
+                  light: Colors.light.text,
+                }),
               }),
-            }),
-          }}
-          tintColor={Platform.select({
-            ios: DynamicColorIOS({
-              dark: Colors.dark.tint,
-              light: Colors.light.tint,
-            }),
-          })}
-          disableTransparentOnScrollEdge>
-          <NativeTabs.Trigger name="payments">
-            <NativeTabs.Trigger.Icon
-              sf={{
-                default: 'arrow.up.arrow.down',
-                selected: 'arrow.up.arrow.down',
-              }}
-            />
-            <NativeTabs.Trigger.Label>Payments</NativeTabs.Trigger.Label>
-          </NativeTabs.Trigger>
+            }}
+            tintColor={Platform.select({
+              ios: DynamicColorIOS({
+                dark: Colors.dark.tint,
+                light: Colors.light.tint,
+              }),
+            })}
+            disableTransparentOnScrollEdge>
+            <NativeTabs.Trigger name="payments">
+              <NativeTabs.Trigger.Icon
+                sf={{
+                  default: 'arrow.up.arrow.down',
+                  selected: 'arrow.up.arrow.down',
+                }}
+              />
+              <NativeTabs.Trigger.Label>Payments</NativeTabs.Trigger.Label>
+            </NativeTabs.Trigger>
 
-          <NativeTabs.Trigger name="index">
-            <NativeTabs.Trigger.Icon
-              sf={{
-                default: 'wallet.bifold',
-                selected: 'wallet.bifold',
-              }}
-            />
-            <NativeTabs.Trigger.Label>Wallet</NativeTabs.Trigger.Label>
-          </NativeTabs.Trigger>
+            <NativeTabs.Trigger name="index">
+              <NativeTabs.Trigger.Icon
+                sf={{
+                  default: 'wallet.bifold',
+                  selected: 'wallet.bifold',
+                }}
+              />
+              <NativeTabs.Trigger.Label>Wallet</NativeTabs.Trigger.Label>
+            </NativeTabs.Trigger>
 
-          <NativeTabs.Trigger name="explore">
+            <NativeTabs.Trigger name="explore">
+              <NativeTabs.Trigger.Icon
+                sf={{ default: 'paperplane', selected: 'paperplane.fill' }}
+              />
+              <NativeTabs.Trigger.Label>Explore</NativeTabs.Trigger.Label>
+            </NativeTabs.Trigger>
+
+            {/* <NativeTabs.Trigger name="example">
             <NativeTabs.Trigger.Icon sf={{ default: 'paperplane', selected: 'paperplane.fill' }} />
-            <NativeTabs.Trigger.Label>Explore</NativeTabs.Trigger.Label>
-          </NativeTabs.Trigger>
-
-          {/* <NativeTabs.Trigger name="example">
-          <NativeTabs.Trigger.Icon sf={{ default: 'paperplane', selected: 'paperplane.fill' }} />
-          <NativeTabs.Trigger.Label>Example</NativeTabs.Trigger.Label>
-        </NativeTabs.Trigger> */}
-        </NativeTabs>
+            <NativeTabs.Trigger.Label>Example</NativeTabs.Trigger.Label>
+          </NativeTabs.Trigger> */}
+          </NativeTabs>
+        </OfflineProvider>
       </BackgroundProvider>
     );
   }
@@ -70,48 +75,52 @@ export default function TabLayout() {
   // Fallback for pre-iOS 26 and Android
   return (
     <BackgroundProvider>
-      <Tabs
-        screenOptions={{
-          headerShown: false,
-          tabBarBackground: () => <TabBarBackground />,
-          tabBarStyle: {
-            position: 'absolute',
-            backgroundColor: 'transparent',
-            borderTopColor: 'transparent',
-            elevation: 0,
-          },
-          tabBarActiveTintColor: Colors.dark.tint,
-          tabBarInactiveTintColor: Colors.dark.text,
-        }}>
-        <Tabs.Screen
-          name="payments"
-          options={{
-            title: 'Payments',
-            tabBarIcon: ({ color }) => (
-              <IconSymbol name="arrow.up.arrow.down" color={color} size={24} />
-            ),
-          }}
-        />
-        <Tabs.Screen
-          name="index"
-          options={{
-            title: 'Wallet',
-            tabBarIcon: ({ color }) => <IconSymbol name="wallet.bifold" color={color} size={24} />,
-          }}
-        />
-        <Tabs.Screen
-          name="explore"
-          options={{
-            href: null, // Hide from tab bar
-          }}
-        />
-        <Tabs.Screen
-          name="example"
-          options={{
-            href: null, // Hide from tab bar
-          }}
-        />
-      </Tabs>
+      <OfflineProvider>
+        <Tabs
+          screenOptions={{
+            headerShown: false,
+            tabBarBackground: () => <TabBarBackground />,
+            tabBarStyle: {
+              position: 'absolute',
+              backgroundColor: 'transparent',
+              borderTopColor: 'transparent',
+              elevation: 0,
+            },
+            tabBarActiveTintColor: Colors.dark.tint,
+            tabBarInactiveTintColor: Colors.dark.text,
+          }}>
+          <Tabs.Screen
+            name="payments"
+            options={{
+              title: 'Payments',
+              tabBarIcon: ({ color }) => (
+                <IconSymbol name="arrow.up.arrow.down" color={color} size={24} />
+              ),
+            }}
+          />
+          <Tabs.Screen
+            name="index"
+            options={{
+              title: 'Wallet',
+              tabBarIcon: ({ color }) => (
+                <IconSymbol name="wallet.bifold" color={color} size={24} />
+              ),
+            }}
+          />
+          <Tabs.Screen
+            name="explore"
+            options={{
+              href: null, // Hide from tab bar
+            }}
+          />
+          <Tabs.Screen
+            name="example"
+            options={{
+              href: null, // Hide from tab bar
+            }}
+          />
+        </Tabs>
+      </OfflineProvider>
     </BackgroundProvider>
   );
 }

--- a/app/(drawer)/(tabs)/index/_layout.tsx
+++ b/app/(drawer)/(tabs)/index/_layout.tsx
@@ -126,6 +126,19 @@ export default function HomeLayout() {
       let lastOperationId: string | null = null;
       // Track the last scanned raw data for linking to transaction
       let lastScannedRaw: string | null = null;
+      const rollbackPendingNfcSend = async () => {
+        if (!lastOperationId) return;
+        try {
+          const operation = await manager.send.getOperation(lastOperationId);
+          if (operation && ['prepared', 'executing', 'pending'].includes(operation.state)) {
+            console.log(`[NFC Payment] Fallback rollback for operation: ${lastOperationId}`);
+            await manager.send.rollback(lastOperationId);
+            console.log('[NFC Payment] Fallback rollback successful');
+          }
+        } catch (rollbackError) {
+          console.warn('[NFC Payment] Fallback rollback failed:', rollbackError);
+        }
+      };
 
       try {
         const result = await NfcPayment.performPayment({
@@ -226,6 +239,7 @@ export default function HomeLayout() {
               break;
             case 'TAG_LOST':
             case 'TRANSCEIVE_FAILED':
+              await rollbackPendingNfcSend();
               Alert.alert(
                 'Connection Lost',
                 'Lost connection to the terminal. Please hold your device steady and try again.'

--- a/app/settings-pages/index.tsx
+++ b/app/settings-pages/index.tsx
@@ -177,6 +177,8 @@ const ModalScreen = () => {
   const setDevMode = useSettingsStore((state) => state.setExperimental);
   const mockMode = useSettingsStore((state) => state.mockMode);
   const setMockMode = useSettingsStore((state) => state.setMockMode);
+  const mockOffline = useSettingsStore((state) => state.mockOffline);
+  const setMockOffline = useSettingsStore((state) => state.setMockOffline);
 
   const tapCountRef = useRef(0);
   const lastTapRef = useRef(0);
@@ -324,8 +326,6 @@ const ModalScreen = () => {
                 backgroundColor: getPrimaryColor('800'),
                 borderColor: getPrimaryColor('700'),
                 borderTopWidth: 1,
-                borderBottomLeftRadius: 12,
-                borderBottomRightRadius: 12,
                 padding: 12,
               }}>
               <HStack align="center" justify="space-between">
@@ -335,6 +335,30 @@ const ModalScreen = () => {
                 <Switch
                   value={mockMode}
                   onValueChange={setMockMode}
+                  trackColor={{
+                    false: getPrimaryColor('700'),
+                    true: getShadeColor('300'),
+                  }}
+                  thumbColor={getPrimaryColor('0')}
+                />
+              </HStack>
+            </View>
+            <View
+              style={{
+                backgroundColor: getPrimaryColor('800'),
+                borderColor: getPrimaryColor('700'),
+                borderTopWidth: 1,
+                borderBottomLeftRadius: 12,
+                borderBottomRightRadius: 12,
+                padding: 12,
+              }}>
+              <HStack align="center" justify="space-between">
+                <Text size={16} style={{ color: getPrimaryColor('0') }}>
+                  Mock Offline
+                </Text>
+                <Switch
+                  value={mockOffline}
+                  onValueChange={setMockOffline}
                   trackColor={{
                     false: getPrimaryColor('700'),
                     true: getShadeColor('300'),

--- a/components/screens/SendTokenScreen.tsx
+++ b/components/screens/SendTokenScreen.tsx
@@ -301,12 +301,43 @@ export function SendTokenScreen({
   const handleNFCSend = useCallback(
     async (close: (event: any) => void): Promise<void> => {
       if (!token) return;
-      const success = await writeTokenToNFC(getEncodedTokenV4(token));
-      if (success) {
+      const writeResult = await writeTokenToNFC(getEncodedTokenV4(token));
+      if (writeResult.success) {
         popup({ message: 'ecash_token_shared_via_nfc', type: 'success', onClose: () => close({}) });
+        return;
       }
+
+      const operationId = currentTransaction?.operationId;
+      const lostConnection =
+        writeResult.errorCode === 'TAG_LOST' || writeResult.errorCode === 'TRANSCEIVE_FAILED';
+
+      // If NFC delivery failed due lost connection, reclaim the pending send immediately.
+      if (lostConnection && operationId) {
+        try {
+          await manager.send.rollback(operationId);
+          popup({
+            message: 'NFC connection lost. Send was rolled back.',
+            type: 'warning',
+          });
+          return;
+        } catch (rollbackError) {
+          console.error('[SendTokenScreen] NFC rollback failed:', rollbackError);
+          popup({
+            message: 'NFC send failed and rollback failed',
+            text: rollbackError instanceof Error ? rollbackError.message : String(rollbackError),
+            type: 'error',
+          });
+          return;
+        }
+      }
+
+      popup({
+        message: 'NFC send failed',
+        text: writeResult.errorMessage || 'Unable to write token via NFC.',
+        type: 'error',
+      });
     },
-    [token]
+    [token, currentTransaction?.operationId, manager]
   );
 
   const handleCopy = useCallback(

--- a/helper/nfc.ts
+++ b/helper/nfc.ts
@@ -160,6 +160,13 @@ interface PaymentResult {
   amount: number;
 }
 
+/** Result of writing a token to NFC */
+export interface NfcTokenWriteResult {
+  success: boolean;
+  errorCode?: string;
+  errorMessage?: string;
+}
+
 // ============================================================================
 // UTILITY FUNCTIONS
 // ============================================================================
@@ -587,22 +594,26 @@ function selectBestMint(
  * separate from the POS payment flow. Useful for P2P token sharing.
  *
  * @param token - The encoded Cashu token string to write
- * @returns true if successful, false otherwise
+ * @returns Write result with success flag and optional error details
  */
-export async function writeTokenToNFC(token: string): Promise<boolean> {
+export async function writeTokenToNFC(token: string): Promise<NfcTokenWriteResult> {
   log('Starting NFC token write...');
 
   // Pre-flight checks
   const supported = await NfcPayment.isSupported();
   if (!supported) {
     logError('NFC is not supported on this device');
-    return false;
+    return {
+      success: false,
+      errorCode: 'NOT_SUPPORTED',
+      errorMessage: 'NFC is not supported on this device',
+    };
   }
 
   const enabled = await NfcPayment.isEnabled();
   if (!enabled) {
     logError('NFC is disabled');
-    return false;
+    return { success: false, errorCode: 'NOT_ENABLED', errorMessage: 'NFC is disabled' };
   }
 
   try {
@@ -663,10 +674,16 @@ export async function writeTokenToNFC(token: string): Promise<boolean> {
     }
 
     log('Token written to NFC successfully!');
-    return true;
+    return { success: true };
   } catch (error) {
     logError('NFC token write failed:', error);
-    return false;
+
+    if (error instanceof NfcError) {
+      return { success: false, errorCode: error.code, errorMessage: error.message };
+    }
+
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return { success: false, errorCode: 'WRITE_FAILED', errorMessage };
   } finally {
     try {
       await NfcManager.cancelTechnologyRequest();

--- a/hooks/coco/useSendWithHistory.ts
+++ b/hooks/coco/useSendWithHistory.ts
@@ -60,6 +60,7 @@ export function useSendWithHistory() {
       let capturedEntry: SendHistoryEntry | null = null;
       let resolveEntryPromise: (entry: SendHistoryEntry) => void;
       let targetOperationId: string | null = null;
+      let preparedOperationId: string | null = null;
 
       const entryPromise = new Promise<SendHistoryEntry>((resolve) => {
         resolveEntryPromise = resolve;
@@ -82,6 +83,7 @@ export function useSendWithHistory() {
         // Step 1: Prepare the send operation using new v3 API
         const prepared = await manager.send.prepareSend(mintUrl, amount);
         targetOperationId = prepared.id;
+        preparedOperationId = prepared.id;
 
         // Step 2: Execute the prepared send operation
         const { token, operation } = await manager.send.executePreparedSend(prepared.id);
@@ -127,6 +129,22 @@ export function useSendWithHistory() {
         return result;
       } catch (e) {
         unsubscribe(); // Clean up listener on error
+
+        // Coco docs recommend rolling back prepared/executing/pending sends on failure.
+        if (preparedOperationId) {
+          try {
+            const operation = await manager.send.getOperation(preparedOperationId);
+            if (operation && ['prepared', 'executing', 'pending'].includes(operation.state)) {
+              await manager.send.rollback(preparedOperationId);
+            }
+          } catch (rollbackError) {
+            console.warn(
+              '[useSendWithHistory] Failed to rollback failed send operation:',
+              rollbackError
+            );
+          }
+        }
+
         const err = e instanceof Error ? e : new Error(String(e));
         setError(err);
         setStatus('error');

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "expo-localization": "~55.0.2",
         "expo-location": "~55.0.3",
         "expo-maps": "~55.0.2",
+        "expo-network": "~55.0.6",
         "expo-router": "~55.0.0-beta.3",
         "expo-secure-store": "~55.0.2",
         "expo-sensors": "~55.0.2",
@@ -10036,6 +10037,16 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-network": {
+      "version": "55.0.6",
+      "resolved": "https://registry.npmjs.org/expo-network/-/expo-network-55.0.6.tgz",
+      "integrity": "sha512-UasiVwwd06u6Nyk41W4wRqOJ/mJI+ln8TxrkH4y7weDiHOo4wsoc/f0Yq4RQKE28URRxklOs7ZhuupZUlpo1EA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*"
       }
     },
     "node_modules/expo-router": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "build:themes": "node scripts/build-background-themes.js",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "screenshots": "node scripts/resize-screenshots.js"
+    "screenshots": "node scripts/resize-screenshots.js",
+    "release:freedomstore:pr": "bash scripts/create-freedomstore-pr.sh"
   },
   "dependencies": {
     "@babel/runtime": "^7.28.0",
@@ -87,6 +88,7 @@
     "expo-localization": "~55.0.2",
     "expo-location": "~55.0.3",
     "expo-maps": "~55.0.2",
+    "expo-network": "~55.0.6",
     "expo-router": "~55.0.0-beta.3",
     "expo-secure-store": "~55.0.2",
     "expo-sensors": "~55.0.2",

--- a/providers/OfflineProvider.tsx
+++ b/providers/OfflineProvider.tsx
@@ -1,0 +1,230 @@
+import React, { createContext, useEffect, useMemo, useRef, useState } from 'react';
+import { AppState, Platform, StyleSheet, View } from 'react-native';
+import * as Network from 'expo-network';
+import { useSafeAreaFrame, useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { Text } from '@/components/ui/Text';
+import { useSettingsStore } from '@/stores/settingsStore';
+import { useTheme } from '@/providers/ThemeProvider';
+
+type OfflineContextValue = {
+  isOffline: boolean;
+};
+
+const OfflineContext = createContext<OfflineContextValue>({ isOffline: false });
+
+const BORDER_WIDTH = 2;
+const BANNER_HEIGHT = 14;
+const CONNECTIVITY_POLL_MS = 3000;
+
+// iOS uses continuous corners. React Native doesn't expose the exact hardware corner radius,
+// so this is a best-effort map by point height for modern rounded-corner iPhones.
+const IOS_PHONE_CORNER_RADIUS_BY_HEIGHT: readonly { height: number; radius: number }[] = [
+  { height: 812, radius: 39 },
+  { height: 844, radius: 47.33 },
+  { height: 852, radius: 55 },
+  { height: 874, radius: 62 },
+  { height: 896, radius: 41.5 },
+  { height: 926, radius: 53.33 },
+  { height: 932, radius: 55 },
+];
+
+type OfflineProviderProps = {
+  children: React.ReactNode;
+};
+
+function getIosCornerRadius(frameWidth: number, frameHeight: number): number {
+  if (Platform.OS !== 'ios') return 0;
+  if (Platform.isPad) return 18;
+
+  const longEdge = Math.round(Math.max(frameWidth, frameHeight));
+  const nearest = IOS_PHONE_CORNER_RADIUS_BY_HEIGHT.reduce((best, candidate) => {
+    const bestDistance = Math.abs(best.height - longEdge);
+    const candidateDistance = Math.abs(candidate.height - longEdge);
+    return candidateDistance < bestDistance ? candidate : best;
+  }, IOS_PHONE_CORNER_RADIUS_BY_HEIGHT[0]);
+
+  // Tighter match for known screens, sensible fallback for newer iPhones.
+  if (Math.abs(nearest.height - longEdge) <= 3) {
+    return nearest.radius;
+  }
+  return longEdge >= 850 ? 55 : 47.33;
+}
+
+function isOfflineFromState(state: Network.NetworkState): boolean {
+  return state.isConnected === false || state.isInternetReachable === false;
+}
+
+export function OfflineProvider({ children }: OfflineProviderProps) {
+  const [networkOffline, setNetworkOffline] = useState(false);
+  const { getPrimaryColor } = useTheme();
+  const insets = useSafeAreaInsets();
+  const frame = useSafeAreaFrame();
+  const isCheckingRef = useRef(false);
+  const mockOffline = useSettingsStore((state) => state.mockOffline);
+  const isOffline = mockOffline || networkOffline;
+  const offlineAccentColor = useMemo(() => getPrimaryColor('500'), [getPrimaryColor]);
+  const offlineTextColor = useMemo(() => getPrimaryColor('0'), [getPrimaryColor]);
+  const screenCornerRadius = useMemo(
+    () => getIosCornerRadius(frame.width, frame.height),
+    [frame.height, frame.width]
+  );
+  const shellCornerStyle = useMemo(
+    () => ({
+      borderRadius: screenCornerRadius,
+      ...(Platform.OS === 'ios'
+        ? ({
+            borderCurve: 'continuous',
+          } as const)
+        : null),
+    }),
+    [screenCornerRadius]
+  );
+
+  useEffect(() => {
+    let mounted = true;
+    let interval: ReturnType<typeof setInterval> | null = null;
+    let networkSubscription: { remove: () => void } | null = null;
+
+    const applyState = (state: Network.NetworkState) => {
+      if (!mounted) return;
+      setNetworkOffline(isOfflineFromState(state));
+    };
+
+    const runConnectivityCheck = async () => {
+      if (!mounted || isCheckingRef.current) return;
+      isCheckingRef.current = true;
+      try {
+        const state = await Network.getNetworkStateAsync();
+        applyState(state);
+      } catch {
+        // Keep previous state if the check fails.
+      } finally {
+        isCheckingRef.current = false;
+      }
+    };
+
+    runConnectivityCheck();
+    networkSubscription = Network.addNetworkStateListener(applyState);
+    interval = setInterval(runConnectivityCheck, CONNECTIVITY_POLL_MS);
+
+    const appStateSubscription = AppState.addEventListener('change', (nextAppState) => {
+      if (nextAppState === 'active') {
+        runConnectivityCheck();
+      }
+    });
+
+    const onWebOnline = () => {
+      setNetworkOffline(false);
+      runConnectivityCheck();
+    };
+
+    const onWebOffline = () => {
+      setNetworkOffline(true);
+    };
+
+    if (Platform.OS === 'web' && typeof window !== 'undefined') {
+      window.addEventListener('online', onWebOnline);
+      window.addEventListener('offline', onWebOffline);
+    }
+
+    return () => {
+      mounted = false;
+      if (interval) {
+        clearInterval(interval);
+      }
+      networkSubscription?.remove();
+      appStateSubscription.remove();
+      if (Platform.OS === 'web' && typeof window !== 'undefined') {
+        window.removeEventListener('online', onWebOnline);
+        window.removeEventListener('offline', onWebOffline);
+      }
+    };
+  }, []);
+
+  const outerShellStyle = useMemo(
+    () => ({
+      backgroundColor: isOffline ? offlineAccentColor : 'transparent',
+    }),
+    [isOffline, offlineAccentColor]
+  );
+
+  const topSectionStyle = useMemo(
+    () => ({
+      height: isOffline ? BANNER_HEIGHT + insets.top : 0,
+    }),
+    [insets.top, isOffline]
+  );
+
+  const contentShellStyle = useMemo(() => {
+    const inset = isOffline ? BORDER_WIDTH : 0;
+    const contentRadius = Math.max(0, screenCornerRadius - inset);
+    return {
+      marginTop: inset,
+      marginBottom: inset,
+      marginHorizontal: inset,
+      borderRadius: contentRadius,
+    };
+  }, [isOffline, screenCornerRadius]);
+
+  const contextValue = useMemo(() => ({ isOffline }), [isOffline]);
+
+  return (
+    <OfflineContext.Provider value={contextValue}>
+      <View style={[styles.outerShell, shellCornerStyle, outerShellStyle]}>
+        <View style={[styles.topSection, topSectionStyle]}>
+          {isOffline ? (
+            <View
+              style={[
+                styles.banner,
+                { paddingTop: insets.top, backgroundColor: offlineAccentColor },
+              ]}>
+              <Text style={[styles.bannerText, { color: offlineTextColor }]}>YOU ARE OFFLINE</Text>
+            </View>
+          ) : null}
+        </View>
+
+        <View style={styles.contentShell}>
+          <View style={[styles.contentContainer, contentShellStyle]}>
+            <View style={styles.contentFill}>{children}</View>
+          </View>
+        </View>
+      </View>
+    </OfflineContext.Provider>
+  );
+}
+
+const styles = StyleSheet.create({
+  outerShell: {
+    flex: 1,
+    overflow: 'hidden',
+  },
+  topSection: {
+    overflow: 'hidden',
+  },
+  contentShell: {
+    flex: 1,
+  },
+  contentContainer: {
+    flex: 1,
+    overflow: 'hidden',
+    ...(Platform.OS === 'ios'
+      ? ({
+          borderCurve: 'continuous',
+        } as const)
+      : null),
+  },
+  contentFill: {
+    flex: 1,
+  },
+  banner: {
+    alignItems: 'center',
+    flex: 1,
+    justifyContent: 'center',
+  },
+  bannerText: {
+    fontSize: 11,
+    fontFamily: 'OverpassBold',
+    letterSpacing: 0.8,
+  },
+});

--- a/scripts/create-freedomstore-pr.sh
+++ b/scripts/create-freedomstore-pr.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FREEDOMSTORE_DIR="${ROOT_DIR}/freedomstore"
+ALTSTORE_JSON="${FREEDOMSTORE_DIR}/altstore-source.json"
+BUNDLE_ID="com.sovranbitcoin"
+UPSTREAM_REPO="freedomstore/freedomstore"
+BASE_BRANCH="main"
+FORK_REMOTE="fork"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "Error: gh CLI is required."
+  exit 1
+fi
+
+if [ ! -d "${FREEDOMSTORE_DIR}/.git" ]; then
+  echo "Error: freedomstore repo not found at ${FREEDOMSTORE_DIR}."
+  exit 1
+fi
+
+if [ ! -f "${ALTSTORE_JSON}" ]; then
+  echo "Error: altstore-source.json not found at ${ALTSTORE_JSON}."
+  exit 1
+fi
+
+if ! gh auth status -h github.com >/dev/null 2>&1; then
+  echo "Error: gh is not authenticated for github.com."
+  echo "Run: gh auth login -h github.com"
+  exit 1
+fi
+
+GH_LOGIN="$(gh api user --jq .login)"
+if [ -z "${GH_LOGIN}" ]; then
+  echo "Error: could not determine GitHub login from gh auth."
+  exit 1
+fi
+
+read -r VERSION BUILD DOWNLOAD_URL FIRST_SCREENSHOT < <(
+  node -e '
+    const fs = require("fs");
+    const file = process.argv[1];
+    const bundleId = process.argv[2];
+    const data = JSON.parse(fs.readFileSync(file, "utf8"));
+    const app = data.apps.find((x) => x.bundleIdentifier === bundleId);
+    if (!app) {
+      console.error("Sovran app entry not found");
+      process.exit(1);
+    }
+    const latest = app.versions?.[0];
+    if (!latest) {
+      console.error("No version entry found for Sovran");
+      process.exit(1);
+    }
+    const out = [
+      String(latest.version || "").replace(/\s+/g, ""),
+      String(latest.buildVersion || "").replace(/\s+/g, ""),
+      String(latest.downloadURL || "").replace(/\s+/g, ""),
+      String(app.screenshots?.[0] || "").replace(/\s+/g, ""),
+    ];
+    console.log(out.join(" "));
+  ' "${ALTSTORE_JSON}" "${BUNDLE_ID}"
+)
+
+if [ -z "${VERSION}" ] || [ -z "${BUILD}" ]; then
+  echo "Error: could not parse Sovran version/build from altstore-source.json."
+  exit 1
+fi
+
+ADP_ID="$(echo "${DOWNLOAD_URL}" | sed -nE 's#.*releases/([0-9a-fA-F-]+)/.*#\1#p')"
+TITLE="Sovran release ${VERSION}"
+BRANCH="sovran-release-${VERSION}"
+FORK_REPO="${GH_LOGIN}/freedomstore"
+FORK_REMOTE_URL="https://github.com/${FORK_REPO}.git"
+
+# Ensure your fork exists.
+if ! gh repo view "${FORK_REPO}" >/dev/null 2>&1; then
+  echo "Creating fork ${FORK_REPO} from ${UPSTREAM_REPO}..."
+  gh repo fork "${UPSTREAM_REPO}" --clone=false
+fi
+
+# Ensure local remote points to your fork.
+if git -C "${FREEDOMSTORE_DIR}" remote get-url "${FORK_REMOTE}" >/dev/null 2>&1; then
+  git -C "${FREEDOMSTORE_DIR}" remote set-url "${FORK_REMOTE}" "${FORK_REMOTE_URL}"
+else
+  git -C "${FREEDOMSTORE_DIR}" remote add "${FORK_REMOTE}" "${FORK_REMOTE_URL}"
+fi
+
+# Reuse existing local branch if present.
+if git -C "${FREEDOMSTORE_DIR}" show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+  git -C "${FREEDOMSTORE_DIR}" checkout "${BRANCH}"
+else
+  git -C "${FREEDOMSTORE_DIR}" checkout -b "${BRANCH}"
+fi
+
+# Commit if altstore-source.json changed.
+if ! git -C "${FREEDOMSTORE_DIR}" diff --quiet -- altstore-source.json; then
+  git -C "${FREEDOMSTORE_DIR}" add altstore-source.json
+  git -C "${FREEDOMSTORE_DIR}" commit -m "${TITLE}"
+fi
+
+git -C "${FREEDOMSTORE_DIR}" push -u "${FORK_REMOTE}" "${BRANCH}"
+
+EXISTING_PR_URL="$(
+  gh pr list \
+    -R "${UPSTREAM_REPO}" \
+    --head "${GH_LOGIN}:${BRANCH}" \
+    --base "${BASE_BRANCH}" \
+    --state open \
+    --json url \
+    --jq '.[0].url'
+)"
+
+if [ -n "${EXISTING_PR_URL}" ] && [ "${EXISTING_PR_URL}" != "null" ]; then
+  echo
+  echo "PR already open: ${EXISTING_PR_URL}"
+  exit 0
+fi
+
+if [ -n "${ADP_ID}" ]; then
+  BODY="Automated Sovran release update from sync scripts.
+
+- Version: ${VERSION} (build ${BUILD})
+- ADP ID: ${ADP_ID}
+- First screenshot: ${FIRST_SCREENSHOT}
+
+Please review the \`altstore-source.json\` update."
+else
+  BODY="Automated Sovran release update from sync scripts.
+
+- Version: ${VERSION} (build ${BUILD})
+- First screenshot: ${FIRST_SCREENSHOT}
+
+Please review the \`altstore-source.json\` update."
+fi
+
+PR_URL="$(
+  gh pr create \
+    -R "${UPSTREAM_REPO}" \
+    --base "${BASE_BRANCH}" \
+    --head "${GH_LOGIN}:${BRANCH}" \
+    --title "${TITLE}" \
+    --body "${BODY}"
+)"
+
+echo
+echo "Created PR: ${PR_URL}"

--- a/scripts/sync-altstore.mjs
+++ b/scripts/sync-altstore.mjs
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+
+/**
+ * Sync AltStore Script
+ *
+ * Downloads an Alternative Distribution Package (ADP) from AltStore's API
+ * and updates the Freedom Store listing with the new version.
+ *
+ * Usage:
+ *   node scripts/sync-altstore.mjs
+ */
+
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import readline from 'readline';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT_DIR = path.resolve(__dirname, '..');
+
+// Paths
+const RELEASES_DIR = path.join(ROOT_DIR, 'sovran.money/public/ios/releases');
+const ALTSTORE_SOURCE_PATH = path.join(ROOT_DIR, 'freedomstore/altstore-source.json');
+const SOVRAN_BUNDLE_ID = 'com.sovranbitcoin';
+const ALTSTORE_API_BASE = 'https://api.altstore.io/adps';
+
+// Readline interface for prompts
+let rl;
+
+function prompt(question) {
+  return new Promise((resolve) => {
+    if (!rl) {
+      rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+      });
+    }
+    rl.question(question, (answer) => resolve(answer.trim()));
+  });
+}
+
+function closeReadline() {
+  if (rl) rl.close();
+}
+
+async function fetchAdpStatus(adpId) {
+  const url = `${ALTSTORE_API_BASE}/${adpId}`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ADP: ${response.status} ${response.statusText}`);
+  }
+  return response.json();
+}
+
+async function downloadAndExtract(downloadUrl, adpId) {
+  const outputDir = path.join(RELEASES_DIR, adpId);
+  const zipPath = path.join(RELEASES_DIR, `${adpId}.zip`);
+
+  fs.mkdirSync(RELEASES_DIR, { recursive: true });
+
+  if (fs.existsSync(outputDir) && fs.existsSync(path.join(outputDir, 'manifest.json'))) {
+    console.log(`\n   📁 Release already exists, overwriting...`);
+    fs.rmSync(outputDir, { recursive: true });
+  }
+
+  console.log(`\n   ⬇️  Downloading ADP package...`);
+  execSync(`curl -sL -o "${zipPath}" "${downloadUrl}"`, { stdio: 'pipe' });
+
+  console.log(`   📦 Extracting...`);
+  fs.mkdirSync(outputDir, { recursive: true });
+  execSync(`unzip -q -o "${zipPath}" -d "${outputDir}"`, { stdio: 'pipe' });
+
+  fs.unlinkSync(zipPath);
+  console.log(`   ✓ Extracted to releases/${adpId}/`);
+
+  return outputDir;
+}
+
+function parseManifest(releaseDir) {
+  const manifestPath = path.join(releaseDir, 'manifest.json');
+  if (!fs.existsSync(manifestPath)) {
+    throw new Error(`manifest.json not found in release`);
+  }
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+  return {
+    bundleId: manifest.bundleId,
+    version: manifest.shortVersionString,
+    buildVersion: manifest.bundleVersion,
+    minOSVersion: manifest.minimumSystemVersions?.ios || '15.1',
+  };
+}
+
+function updateAltstoreSource(adpId, manifestData) {
+  const fileContent = fs.readFileSync(ALTSTORE_SOURCE_PATH, 'utf-8');
+  const source = JSON.parse(fileContent);
+
+  const sovranApp = source.apps.find((app) => app.bundleIdentifier === SOVRAN_BUNDLE_ID);
+  if (!sovranApp) {
+    throw new Error('Could not find Sovran in altstore-source.json');
+  }
+
+  // Check for existing version
+  const existingIdx = sovranApp.versions.findIndex(
+    (v) => v.version === manifestData.version && v.buildVersion === manifestData.buildVersion
+  );
+
+  if (existingIdx !== -1) {
+    console.log(`   ⚠️  Version ${manifestData.version} already exists, updating...`);
+    sovranApp.versions[existingIdx].downloadURL = `https://sovran.money/ios/releases/${adpId}/`;
+    sovranApp.versions[existingIdx].date = new Date().toISOString().split('T')[0];
+  } else {
+    // Use surgical insert to avoid reformatting other apps
+    const sovranPattern = /"bundleIdentifier":\s*"com\.sovranbitcoin"[\s\S]*?"versions":\s*\[/;
+    const match = fileContent.match(sovranPattern);
+
+    if (!match) {
+      throw new Error('Could not find Sovran versions array');
+    }
+
+    const newVersion = {
+      downloadURL: `https://sovran.money/ios/releases/${adpId}/`,
+      size: 10000000,
+      version: manifestData.version,
+      buildVersion: manifestData.buildVersion,
+      date: new Date().toISOString().split('T')[0],
+      localizedDescription: null,
+      minOSVersion: manifestData.minOSVersion,
+    };
+
+    const insertPosition = match.index + match[0].length;
+    const versionJson = JSON.stringify(newVersion, null, 2)
+      .split('\n')
+      .map((line, i) => (i === 0 ? line : '        ' + line))
+      .join('\n');
+
+    const newContent =
+      fileContent.slice(0, insertPosition) +
+      '\n        ' +
+      versionJson +
+      ',' +
+      fileContent.slice(insertPosition);
+
+    fs.writeFileSync(ALTSTORE_SOURCE_PATH, newContent);
+    console.log(`   ✓ Added new version to altstore-source.json`);
+    return newVersion;
+  }
+
+  fs.writeFileSync(ALTSTORE_SOURCE_PATH, JSON.stringify(source, null, 2) + '\n');
+  return sovranApp.versions[existingIdx];
+}
+
+async function main() {
+  console.log(`
+╔═══════════════════════════════════════════════════════════╗
+║           📦 Sovran AltStore Sync Tool                    ║
+╠═══════════════════════════════════════════════════════════╣
+║  This tool downloads your ADP from AltStore and updates   ║
+║  the Freedom Store listing with the new version.          ║
+╚═══════════════════════════════════════════════════════════╝
+`);
+
+  console.log(`📋 To find your ADP ID:`);
+  console.log(
+    `   1. Go to: https://appstoreconnect.apple.com/apps/6499554529/distribution/activity/ios/versions`
+  );
+  console.log(`   2. Click on the version you want to distribute`);
+  console.log(`   3. Find the "Alternative Distribution Package ID" in the details`);
+  console.log(`   4. Copy the UUID (e.g., 955b20d5-8417-4a3d-88f6-05d72eec18aa)\n`);
+
+  try {
+    // Step 1: Get ADP ID (or use CLI argument)
+    let adpId = process.argv[2];
+
+    if (adpId) {
+      console.log(`📌 Using ADP ID from command line: ${adpId}`);
+    } else {
+      adpId = await prompt('🔑 Enter your ADP ID (UUID format): ');
+    }
+
+    // Validate format
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (!uuidRegex.test(adpId)) {
+      console.error('\n❌ Invalid ADP ID format. Expected a UUID like:');
+      console.error('   955b20d5-8417-4a3d-88f6-05d72eec18aa');
+      process.exit(1);
+    }
+
+    // Step 2: Fetch ADP status
+    console.log('\n📡 Checking ADP status...');
+    const adpData = await fetchAdpStatus(adpId);
+
+    console.log(`   Status: ${adpData.status}`);
+    console.log(`   Created: ${adpData.created}`);
+
+    if (adpData.status !== 'success') {
+      console.error(`\n❌ ADP is not ready yet. Current status: ${adpData.status}`);
+      console.error('   Please wait for processing to complete and try again.');
+      process.exit(1);
+    }
+
+    if (!adpData.downloadURL) {
+      console.error('\n❌ No download URL available. The ADP may still be processing.');
+      process.exit(1);
+    }
+
+    if (adpData.downloadExpired) {
+      console.error('\n❌ Download URL has expired.');
+      console.error(`   Expiration was: ${adpData.downloadExpiration}`);
+      console.error('   Please request a new ADP from App Store Connect.');
+      process.exit(1);
+    }
+
+    console.log(`   Download expires: ${adpData.downloadExpiration}`);
+
+    // Step 3: Download and extract
+    const releaseDir = await downloadAndExtract(adpData.downloadURL, adpId);
+
+    // Step 4: Parse manifest
+    console.log('\n📋 Reading version info...');
+    const manifestData = parseManifest(releaseDir);
+    console.log(`   Version: ${manifestData.version}`);
+    console.log(`   Build: ${manifestData.buildVersion}`);
+    console.log(`   Min iOS: ${manifestData.minOSVersion}`);
+
+    // Step 5: Update altstore-source.json
+    console.log('\n📝 Updating Freedom Store listing...');
+    const versionEntry = updateAltstoreSource(adpId, manifestData);
+
+    // Summary
+    console.log(`
+╔═══════════════════════════════════════════════════════════╗
+║                    ✅ Sync Complete!                      ║
+╠═══════════════════════════════════════════════════════════╣
+║  Version: ${(manifestData.version + ' (build ' + manifestData.buildVersion + ')').padEnd(45)}║
+║  ADP ID: ${adpId.padEnd(46)}║
+║  Download URL: sovran.money/ios/releases/${adpId.slice(0, 8)}...  ║
+╠═══════════════════════════════════════════════════════════╣
+║  📋 Next Steps:                                           ║
+║  1. Run sync-screenshots.mjs if you haven't already       ║
+║  2. Commit all changes                                    ║
+║  3. Push to deploy sovran.money and freedomstore          ║
+║  4. Your app will be available on Freedom Store!          ║
+╚═══════════════════════════════════════════════════════════╝
+`);
+  } catch (error) {
+    console.error(`\n❌ Error: ${error.message}`);
+    process.exit(1);
+  } finally {
+    closeReadline();
+  }
+}
+
+main();

--- a/scripts/sync-screenshots.mjs
+++ b/scripts/sync-screenshots.mjs
@@ -1,0 +1,452 @@
+#!/usr/bin/env node
+
+/**
+ * Sync Screenshots Script
+ *
+ * Downloads screenshots from App Store Connect and syncs them to sovran.money
+ * for use in the AltStore/Freedom Store listing.
+ *
+ * Usage:
+ *   node scripts/sync-screenshots.mjs
+ */
+
+import fs from 'fs';
+import path from 'path';
+import readline from 'readline';
+import { fileURLToPath } from 'url';
+import jwt from 'jsonwebtoken';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT_DIR = path.resolve(__dirname, '..');
+
+// Paths
+const SOVRAN_IOS_DIR = path.join(ROOT_DIR, 'sovran.money/public/ios');
+const ALTSTORE_SOURCE_PATH = path.join(ROOT_DIR, 'freedomstore/altstore-source.json');
+const SCREENSHOTS_TS_PATH = path.join(ROOT_DIR, 'sovran.money/src/screenshots.ts');
+const SOVRAN_BUNDLE_ID = 'com.sovranbitcoin';
+const PREFERRED_LOCALES = ['en-US', 'en-GB'];
+
+// Load .env file
+const envPath = path.join(ROOT_DIR, '.env');
+if (fs.existsSync(envPath)) {
+  const envContent = fs.readFileSync(envPath, 'utf-8');
+  for (const line of envContent.split('\n')) {
+    const match = line.match(/^([^#=]+)=(.*)$/);
+    if (match) {
+      const key = match[1].trim();
+      let value = match[2].trim();
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+      value = value.replace(/\\n/g, '\n');
+      process.env[key] = value;
+    }
+  }
+}
+
+const ISSUER_ID = process.env.ASC_ISSUER_ID;
+const KEY_ID = process.env.ASC_KEY_ID;
+const PRIVATE_KEY = process.env.ASC_PRIVATE_KEY;
+const APP_ID = '6499554529';
+const API_BASE = 'https://api.appstoreconnect.apple.com/v1';
+
+// Readline interface for prompts
+let rl;
+
+function prompt(question) {
+  return new Promise((resolve) => {
+    if (!rl) {
+      rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+      });
+    }
+    rl.question(question, (answer) => resolve(answer.trim()));
+  });
+}
+
+function closeReadline() {
+  if (rl) rl.close();
+}
+
+function generateToken() {
+  if (!ISSUER_ID || !KEY_ID || !PRIVATE_KEY) {
+    console.error('\n❌ Missing App Store Connect credentials in .env file');
+    console.error('   Required: ASC_ISSUER_ID, ASC_KEY_ID, ASC_PRIVATE_KEY\n');
+    process.exit(1);
+  }
+
+  return jwt.sign(
+    {
+      iss: ISSUER_ID,
+      aud: 'appstoreconnect-v1',
+      exp: Math.floor(Date.now() / 1000) + 15 * 60,
+    },
+    PRIVATE_KEY,
+    { algorithm: 'ES256', header: { kid: KEY_ID } }
+  );
+}
+
+async function apiRequest(endpoint) {
+  const token = generateToken();
+  const url = endpoint.startsWith('http') ? endpoint : `${API_BASE}${endpoint}`;
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+  });
+  if (!response.ok) {
+    throw new Error(`API request failed: ${response.status} ${response.statusText}`);
+  }
+  return response.json();
+}
+
+async function downloadFile(url, outputPath) {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`Failed to download: ${response.status}`);
+  const buffer = await response.arrayBuffer();
+  fs.writeFileSync(outputPath, Buffer.from(buffer));
+}
+
+async function getAppVersions() {
+  const data = await apiRequest(`/apps/${APP_ID}/appStoreVersions`);
+  return data.data;
+}
+
+async function getVersionLocalizations(versionId) {
+  const data = await apiRequest(`/appStoreVersions/${versionId}/appStoreVersionLocalizations`);
+  return data.data;
+}
+
+async function getScreenshotSets(localizationId) {
+  const data = await apiRequest(
+    `/appStoreVersionLocalizations/${localizationId}/appScreenshotSets`
+  );
+  return data.data;
+}
+
+async function getScreenshots(screenshotSetId) {
+  const data = await apiRequest(`/appScreenshotSets/${screenshotSetId}/appScreenshots`);
+  return data.data;
+}
+
+function updateAltstoreScreenshots(screenshotUrls) {
+  const fileContent = fs.readFileSync(ALTSTORE_SOURCE_PATH, 'utf-8');
+  const sovranPattern =
+    /("bundleIdentifier":\s*"com\.sovranbitcoin"[\s\S]*?"screenshots":\s*)\[[\s\S]*?\](\s*,\s*"versions":\s*\[)/;
+  const match = fileContent.match(sovranPattern);
+
+  if (!match) {
+    throw new Error('Could not find Sovran screenshots array in altstore-source.json');
+  }
+
+  const screenshotsBlock =
+    '[\n' + screenshotUrls.map((url) => `        "${url}"`).join(',\n') + '\n      ]';
+
+  const newContent = fileContent.replace(sovranPattern, `$1${screenshotsBlock}$2`);
+  fs.writeFileSync(ALTSTORE_SOURCE_PATH, newContent);
+}
+
+function normalizeDate(value) {
+  const parsed = Date.parse(value ?? '');
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function compareVersionStrings(a, b) {
+  const split = (v) =>
+    String(v ?? '')
+      .split(/[^0-9]+/)
+      .filter(Boolean)
+      .map((n) => Number(n));
+
+  const left = split(a);
+  const right = split(b);
+  const maxLength = Math.max(left.length, right.length);
+
+  for (let i = 0; i < maxLength; i++) {
+    const l = left[i] ?? 0;
+    const r = right[i] ?? 0;
+    if (l !== r) return l - r;
+  }
+
+  return String(a ?? '').localeCompare(String(b ?? ''), undefined, {
+    numeric: true,
+    sensitivity: 'base',
+  });
+}
+
+function sortVersionsNewestFirst(versions) {
+  return [...versions].sort((a, b) => {
+    const byVersion = compareVersionStrings(
+      b.attributes?.versionString,
+      a.attributes?.versionString
+    );
+    if (byVersion !== 0) {
+      return byVersion;
+    }
+
+    const dateA = normalizeDate(a.attributes?.releaseDate || a.attributes?.createdDate);
+    const dateB = normalizeDate(b.attributes?.releaseDate || b.attributes?.createdDate);
+    return dateB - dateA;
+  });
+}
+
+function sortScreenshotsForListing(screenshots) {
+  const hasSortOrder = screenshots.some((shot) => Number.isFinite(shot.attributes?.sortOrder));
+  if (!hasSortOrder) {
+    return screenshots;
+  }
+
+  return [...screenshots].sort(
+    (a, b) =>
+      (a.attributes?.sortOrder ?? Number.MAX_SAFE_INTEGER) -
+      (b.attributes?.sortOrder ?? Number.MAX_SAFE_INTEGER)
+  );
+}
+
+function generateScreenshotsTs(deviceScreenshots, primaryDevice) {
+  const primaryUrls = deviceScreenshots[primaryDevice] || [];
+
+  // Convert full URLs to relative paths
+  const toRelativePath = (url) => url.replace('https://sovran.money', '');
+
+  const lines = [
+    '/**',
+    ' * Screenshot URLs for Sovran',
+    ' * ',
+    ' * This file is auto-generated by scripts/sync-screenshots.mjs',
+    ' * Do not edit manually - run the sync script to update.',
+    ' */',
+    '',
+    'export const screenshots = {',
+    `  // Primary screenshots for the website (uses ${primaryDevice})`,
+    '  primary: [',
+  ];
+
+  for (const url of primaryUrls) {
+    lines.push(`    "${toRelativePath(url)}",`);
+  }
+  lines.push('  ],');
+  lines.push('');
+  lines.push('  // All device types available');
+  lines.push('  devices: {');
+
+  for (const [device, urls] of Object.entries(deviceScreenshots)) {
+    lines.push(`    "${device}": [`);
+    for (const url of urls) {
+      lines.push(`      "${toRelativePath(url)}",`);
+    }
+    lines.push('    ],');
+  }
+
+  lines.push('  },');
+  lines.push('};');
+  lines.push('');
+  lines.push('// Helper to get screenshot by index (0-based)');
+  lines.push('export const getScreenshot = (index: number): string => {');
+  lines.push('  return screenshots.primary[index] || screenshots.primary[0];');
+  lines.push('};');
+  lines.push('');
+  lines.push('// Semantic aliases for specific use cases');
+  lines.push('export const heroScreenshot = screenshots.primary[0];');
+  lines.push('export const walletScreenshot = screenshots.primary[0];');
+  lines.push('export const socialScreenshot = screenshots.primary[2] || screenshots.primary[0];');
+  lines.push('');
+  lines.push('export default screenshots;');
+  lines.push('');
+
+  fs.writeFileSync(SCREENSHOTS_TS_PATH, lines.join('\n'));
+}
+
+async function main() {
+  console.log(`
+╔═══════════════════════════════════════════════════════════╗
+║           📸 Sovran Screenshot Sync Tool                  ║
+╠═══════════════════════════════════════════════════════════╣
+║  This tool syncs App Store screenshots to sovran.money    ║
+║  and updates the Freedom Store listing.                   ║
+╚═══════════════════════════════════════════════════════════╝
+`);
+
+  try {
+    // Step 1: Fetch available versions
+    console.log('📡 Fetching app versions from App Store Connect...\n');
+    const versions = sortVersionsNewestFirst(await getAppVersions());
+
+    console.log('Available versions:');
+    versions.slice(0, 5).forEach((v, i) => {
+      const state = v.attributes.appStoreState;
+      const stateIcon = state === 'READY_FOR_SALE' ? '✅' : state.includes('PENDING') ? '⏳' : '📝';
+      console.log(`  ${i + 1}. ${v.attributes.versionString} ${stateIcon} (${state})`);
+    });
+    if (versions.length > 5) {
+      console.log(`  ... and ${versions.length - 5} more`);
+    }
+
+    // Step 2: Ask which version to sync (or use CLI argument)
+    const defaultVersion = versions[0]?.attributes?.versionString;
+    if (!defaultVersion) {
+      throw new Error('No app versions returned from App Store Connect');
+    }
+    const cliVersion = process.argv[2];
+
+    let selectedVersionString;
+    if (cliVersion) {
+      selectedVersionString = cliVersion;
+      console.log(`\n📌 Using version from command line: ${cliVersion}`);
+    } else {
+      const versionInput = await prompt(`\n📌 Which version to sync? [${defaultVersion}]: `);
+      selectedVersionString = versionInput || defaultVersion;
+    }
+
+    const selectedVersion = versions.find(
+      (v) => v.attributes.versionString === selectedVersionString
+    );
+    if (!selectedVersion) {
+      console.error(`\n❌ Version ${selectedVersionString} not found`);
+      process.exit(1);
+    }
+
+    console.log(`\n✓ Selected version: ${selectedVersionString}`);
+
+    // Step 3: Fetch screenshots
+    console.log('\n📥 Fetching screenshots...');
+    const localizations = await getVersionLocalizations(selectedVersion.id);
+
+    if (localizations.length === 0) {
+      console.error('❌ No localizations found for this version');
+      process.exit(1);
+    }
+
+    const localization =
+      localizations.find((loc) => PREFERRED_LOCALES.includes(loc.attributes.locale)) ||
+      localizations[0];
+    console.log(`   Locale: ${localization.attributes.locale}`);
+
+    const screenshotSets = await getScreenshotSets(localization.id);
+
+    // Filter to iPhone screenshot sets only
+    const iphoneSets = screenshotSets.filter((s) =>
+      s.attributes.screenshotDisplayType.startsWith('APP_IPHONE')
+    );
+
+    if (iphoneSets.length === 0) {
+      console.error('❌ No iPhone screenshot sets found');
+      process.exit(1);
+    }
+
+    console.log(`   Found ${iphoneSets.length} iPhone screenshot set(s)`);
+
+    // Step 4: Download all screenshots organized by device type
+    console.log(`\n📂 Downloading to ${SOVRAN_IOS_DIR}/...\n`);
+
+    let totalScreenshots = 0;
+    const deviceScreenshots = {}; // { deviceType: [urls] }
+
+    // Device type display names for nicer output
+    const deviceNames = {
+      APP_IPHONE_67: 'iPhone 6.7" (14/15/16 Pro Max)',
+      APP_IPHONE_65: 'iPhone 6.5" (11/XS Max)',
+      APP_IPHONE_55: 'iPhone 5.5" (8 Plus)',
+      APP_IPHONE_61: 'iPhone 6.1" (14/15)',
+      APP_IPHONE_58: 'iPhone 5.8" (X/XS/11 Pro)',
+    };
+
+    for (const screenshotSet of iphoneSets) {
+      const deviceType = screenshotSet.attributes.screenshotDisplayType;
+      const deviceName = deviceNames[deviceType] || deviceType;
+
+      const screenshots = sortScreenshotsForListing(await getScreenshots(screenshotSet.id));
+
+      if (screenshots.length === 0) {
+        continue;
+      }
+
+      console.log(`   📱 ${deviceName}: ${screenshots.length} screenshots`);
+
+      // Reset folder so only latest selected-version screenshots are listed
+      const deviceDir = path.join(SOVRAN_IOS_DIR, deviceType);
+      fs.rmSync(deviceDir, { recursive: true, force: true });
+      fs.mkdirSync(deviceDir, { recursive: true });
+
+      deviceScreenshots[deviceType] = [];
+
+      for (const screenshot of screenshots) {
+        const imageAsset = screenshot.attributes.imageAsset;
+
+        if (!imageAsset?.templateUrl) {
+          console.log(`      ⚠️  Screenshot has no image URL, skipping`);
+          continue;
+        }
+
+        const width = imageAsset.width;
+        const height = imageAsset.height;
+        const finalUrl = imageAsset.templateUrl
+          .replace('{w}', width)
+          .replace('{h}', height)
+          .replace('{f}', 'png');
+
+        // Use the screenshot ID as filename (it's Apple's unique identifier)
+        const filename = `${screenshot.id}.png`;
+        const outputPath = path.join(deviceDir, filename);
+
+        console.log(`      ⬇️  ${filename}`);
+        await downloadFile(finalUrl, outputPath);
+
+        const publicUrl = `https://sovran.money/ios/${deviceType}/${filename}`;
+        deviceScreenshots[deviceType].push(publicUrl);
+        totalScreenshots++;
+      }
+    }
+
+    // Step 5: Update altstore-source.json and screenshots.ts
+    console.log('\n📝 Updating configuration files...');
+
+    const primaryDevice = Object.keys(deviceScreenshots)[0] || null;
+    const listingUrls = primaryDevice ? deviceScreenshots[primaryDevice] : [];
+
+    if (listingUrls.length > 0) {
+      // Update altstore-source.json
+      updateAltstoreScreenshots(listingUrls);
+      console.log(
+        `   ✓ altstore-source.json updated (${listingUrls.length} ${primaryDevice} screenshots)`
+      );
+
+      // Update screenshots.ts
+      generateScreenshotsTs(deviceScreenshots, primaryDevice);
+      console.log(
+        `   ✓ screenshots.ts updated (${Object.keys(deviceScreenshots).length} device types)`
+      );
+    }
+
+    // Summary
+    console.log(`
+╔═══════════════════════════════════════════════════════════╗
+║                    ✅ Sync Complete!                      ║
+╠═══════════════════════════════════════════════════════════╣
+║  Total screenshots: ${String(totalScreenshots).padEnd(36)}║
+║  Device types: ${String(Object.keys(deviceScreenshots).length).padEnd(41)}║
+║  Source: App Store Connect v${selectedVersionString.padEnd(27)}║
+╠═══════════════════════════════════════════════════════════╣
+║  📁 Files updated:                                        ║
+║  • sovran.money/public/ios/<device>/*.png                 ║
+║  • sovran.money/src/screenshots.ts                        ║
+║  • freedomstore/altstore-source.json                      ║
+╠═══════════════════════════════════════════════════════════╣
+║  📋 Next Steps:                                           ║
+║  1. Review the screenshots in sovran.money/public/ios/    ║
+║  2. Commit and push the changes                           ║
+║  3. Run sync-altstore.mjs to add the new app version      ║
+╚═══════════════════════════════════════════════════════════╝
+`);
+  } catch (error) {
+    console.error(`\n❌ Error: ${error.message}`);
+    process.exit(1);
+  } finally {
+    closeReadline();
+  }
+}
+
+main();

--- a/stores/settingsStore.ts
+++ b/stores/settingsStore.ts
@@ -39,6 +39,7 @@ interface SettingsState {
   passcode: string;
   experimental: boolean;
   mockMode: boolean;
+  mockOffline: boolean;
   termsAccepted: TermsAccepted | null;
   quickAccessP2PK: boolean;
   sendLocationEnabled: boolean;
@@ -78,6 +79,8 @@ interface SettingsActions {
   // Mock mode (demo data)
   setMockMode: (enabled: boolean) => void;
   getMockMode: () => boolean;
+  setMockOffline: (enabled: boolean) => void;
+  getMockOffline: () => boolean;
 
   // Terms acceptance
   acceptTerms: (date: string) => void;
@@ -119,6 +122,7 @@ export const useSettingsStore = create<SettingsStore>()(
       passcode: '',
       experimental: false,
       mockMode: false,
+      mockOffline: false,
       termsAccepted: null,
       quickAccessP2PK: false,
       sendLocationEnabled: false,
@@ -215,6 +219,14 @@ export const useSettingsStore = create<SettingsStore>()(
         return get().mockMode;
       },
 
+      setMockOffline: (enabled: boolean) => {
+        set({ mockOffline: enabled });
+      },
+
+      getMockOffline: () => {
+        return get().mockOffline;
+      },
+
       // Terms acceptance
       acceptTerms: (date: string) => {
         set({
@@ -292,6 +304,7 @@ export const useSettingsStore = create<SettingsStore>()(
           passcode: '',
           experimental: false,
           mockMode: false,
+          mockOffline: false,
           termsAccepted: null,
           quickAccessP2PK: false,
           sendLocationEnabled: false,
@@ -321,6 +334,7 @@ export const useSettingsStore = create<SettingsStore>()(
             passcode: '',
             experimental: false,
             mockMode: false,
+            mockOffline: false,
             termsAccepted: null,
             quickAccessP2PK: false,
             sendLocationEnabled: false,
@@ -351,6 +365,7 @@ export const useSettingsStore = create<SettingsStore>()(
         displayCurrency: state.displayCurrency,
         experimental: state.experimental,
         mockMode: state.mockMode,
+        mockOffline: state.mockOffline,
         termsAccepted: state.termsAccepted,
         quickAccessP2PK: state.quickAccessP2PK,
         sendLocationEnabled: state.sendLocationEnabled,


### PR DESCRIPTION
What / Why
- Add app-level offline UI state so users can clearly see connectivity status.
- Improve NFC send reliability by rolling back pending sends on disconnect-style failures.
- Add release automation for Freedom Store/AltStore update workflows.

What changed
- Added `OfflineProvider` and wrapped tab layouts to render an offline shell and banner.
- Added `mockOffline` setting (store + settings UI toggle) for testing offline behavior.
- Updated NFC send flow to return structured write results and rollback prepared/executing/pending operations when delivery fails.
- Added release scripts (`sync-screenshots`, `sync-altstore`, `create-freedomstore-pr`) plus `expo-network` and `release:freedomstore:pr` script wiring.

Screenshots / Video
- N/A

Test plan
1) npm run lint
2) npm run type-check
3) npm run pretty:check
4) npm run knip

Notes / Risks
- `npm run lint` reports existing warnings in `components/blocks/AccountPagerView.tsx`; no new lint errors from this change.
- Local untracked `freedomstore/` folder is intentionally excluded from this PR.