### PR TITLE
feat(transactions): show source and P2PK details

### DIFF
--- a/components/blocks/Transaction/TransactionSourceSection.tsx
+++ b/components/blocks/Transaction/TransactionSourceSection.tsx
@@ -1,0 +1,20 @@
+import { useScanHistoryStore, ScanSource } from 'stores/scanHistoryStore';
+
+const SOURCE_LABELS: Record<ScanSource, string> = {
+  qr: 'QR Code',
+  nfc: 'NFC',
+  paste: 'Clipboard',
+  deeplink: 'Deep Link',
+};
+
+/**
+ * Returns the human-readable source label for a transaction, or null if none is linked.
+ * Intended for use as a row in DetailsSection.
+ */
+export function useTransactionSource(transactionId: string | undefined): string | null {
+  return useScanHistoryStore((state) => {
+    if (!transactionId) return null;
+    const entry = state.entries.find((e) => e.transactionId === transactionId);
+    return entry?.source ? SOURCE_LABELS[entry.source] : null;
+  });
+}

--- a/components/screens/MeltQuoteScreen.tsx
+++ b/components/screens/MeltQuoteScreen.tsx
@@ -44,6 +44,7 @@ import { useHistoryEntry } from '@/hooks/coco/useHistoryEntry';
 import { useMintManagement } from '@/hooks/coco/useMintManagement';
 import { captureAndStoreLocation } from '@/hooks/useTransactionLocation';
 import { useScanHistoryStore } from 'stores/scanHistoryStore';
+import { useTransactionSource } from '@/components/blocks/Transaction/TransactionSourceSection';
 
 interface MeltQuoteScreenProps {
   /** For viewing existing transaction - either parsed entry or JSON string */
@@ -169,6 +170,7 @@ export function MeltQuoteScreen({
 
   // The history entry to display - prefer newly created (e.g., after mint change) over initial prop
   const currentTransaction = createdHistoryEntry || trackedHistoryEntry;
+  const sourceLabel = useTransactionSource(currentTransaction?.id);
 
   // The quote to display - either derived from history entry or created
   const displayQuote: MeltQuoteBolt11Response | null =
@@ -536,6 +538,7 @@ export function MeltQuoteScreen({
         {/* Technical details - collapsed by default */}
         <DetailsSection
           items={[
+            ...(sourceLabel ? [{ title: 'Source', value: sourceLabel }] : []),
             {
               title: 'Date',
               value: displayQuote?.request

--- a/components/screens/MintQuoteScreen.tsx
+++ b/components/screens/MintQuoteScreen.tsx
@@ -28,6 +28,7 @@ import { HistoryEntryTimeline } from 'components/blocks/Transaction/HistoryEntry
 import { TransactionLocationSection } from 'components/blocks/TransactionLocationSection';
 import type { MintHistoryEntry } from 'coco-cashu-core';
 import { HistoryEntryHeader } from '@/components/blocks/Transaction/HistoryEntryHeader';
+import { useTransactionSource } from '@/components/blocks/Transaction/TransactionSourceSection';
 import { BottomButtons } from 'components/ui/BottomButtons';
 import { ModalLayoutWrapper } from 'app/debugModal';
 import { useHistoryEntry } from '@/hooks/coco/useHistoryEntry';
@@ -50,6 +51,7 @@ export function MintQuoteScreen({
   // Use the generic history entry hook for parsing, state, and event subscription
   const { entry: currentTransaction, error: parseError } =
     useHistoryEntry<MintHistoryEntry>(mintHistoryEntryProp);
+  const sourceLabel = useTransactionSource(currentTransaction?.id);
 
   useEffect(() => {
     if (currentTransaction?.mintUrl) {
@@ -145,6 +147,7 @@ export function MintQuoteScreen({
         {/* Technical details - collapsed by default */}
         <DetailsSection
           items={[
+            ...(sourceLabel ? [{ title: 'Source', value: sourceLabel }] : []),
             {
               title: 'Invoice',
               value: truncateMiddle(currentTransaction.paymentRequest, 10),

--- a/components/screens/ReceiveTokenScreen.tsx
+++ b/components/screens/ReceiveTokenScreen.tsx
@@ -5,7 +5,7 @@
  * It is used by both standalone and flow-based route wrappers.
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { popup } from '@/helper/popup';
 import { router } from 'expo-router';
 import { ButtonHandler } from 'components/ui/ButtonHandler';
@@ -31,6 +31,7 @@ import { getDecodedToken } from '@cashu/cashu-ts';
 import { captureAndStoreLocation } from '@/hooks/useTransactionLocation';
 import { useScanHistoryStore } from 'stores/scanHistoryStore';
 import { useSettingsStore } from 'stores/settingsStore';
+import { useTransactionSource } from '@/components/blocks/Transaction/TransactionSourceSection';
 
 interface ReceiveTokenScreenProps {
   /** Either the parsed entry or a JSON string to be parsed internally */
@@ -79,10 +80,28 @@ export function ReceiveTokenScreen({
   // Use the generic history entry hook for parsing, state, and event subscription
   const { entry: receiveHistoryEntry, error: parseError } =
     useHistoryEntry<ReceiveHistoryEntry>(receiveHistoryEntryProp);
+  const sourceLabel = useTransactionSource(finalizedTransactionId ?? receiveHistoryEntry?.id);
 
   const tokenString = receiveHistoryEntry?.token
     ? manager.wallet.encodeToken(receiveHistoryEntry.token)
     : undefined;
+
+  // Extract P2PK locking pubkey from token proofs (if any)
+  const p2pkPubkey = useMemo(() => {
+    const proofs = receiveHistoryEntry?.token?.proofs;
+    if (!proofs?.length) return null;
+    for (const proof of proofs) {
+      try {
+        const parsed = JSON.parse(proof.secret);
+        if (Array.isArray(parsed) && parsed[0] === 'P2PK' && parsed[1]?.data) {
+          return parsed[1].data as string;
+        }
+      } catch {
+        // not a structured secret
+      }
+    }
+    return null;
+  }, [receiveHistoryEntry?.token?.proofs]);
 
   // Detect if this is a scan placeholder (created by useProcessPaymentString before redeem)
   const isScanPlaceholder = receiveHistoryEntry?.id?.startsWith('receive-') ?? false;
@@ -345,6 +364,8 @@ export function ReceiveTokenScreen({
         {/* Technical details - collapsed by default */}
         <DetailsSection
           items={[
+            ...(sourceLabel ? [{ title: 'Source', value: sourceLabel }] : []),
+            ...(p2pkPubkey ? [{ title: 'P2PK', value: truncateMiddle(p2pkPubkey, 8) }] : []),
             ...(tokenString ? [{ title: 'Token', value: truncateMiddle(tokenString, 6) }] : []),
           ]}
         />

--- a/components/screens/SendTokenScreen.tsx
+++ b/components/screens/SendTokenScreen.tsx
@@ -52,6 +52,7 @@ import { useMintManagement } from '@/hooks/coco/useMintManagement';
 import { useSendWithHistory } from '@/hooks/coco/useSendWithHistory';
 import { useNostrDirectMessage } from '@/hooks/useNostrDirectMessage';
 import { TransactionLocationSection } from 'components/blocks/TransactionLocationSection';
+import { useTransactionSource } from '@/components/blocks/Transaction/TransactionSourceSection';
 import { useTheme } from 'providers/ThemeProvider';
 import opacity from 'hex-color-opacity';
 import { captureAndStoreLocation } from '@/hooks/useTransactionLocation';
@@ -187,6 +188,7 @@ export function SendTokenScreen({
   // Use the generic history entry hook for parsing, state, and event subscription
   const { entry: currentTransaction, error: parseError } =
     useHistoryEntry<SendHistoryEntry>(entryToUse);
+  const sourceLabel = useTransactionSource(currentTransaction?.id);
 
   // Determine mode: payment request mode if we have paymentRequest and no transaction yet
   const isPaymentRequestMode = !!paymentRequest && !currentTransaction;
@@ -879,6 +881,7 @@ export function SendTokenScreen({
         {/* Technical details - collapsed by default */}
         <DetailsSection
           items={[
+            ...(sourceLabel ? [{ title: 'Source', value: sourceLabel }] : []),
             // Payment request mode items
             ...(isPaymentRequestMode && recipientInfo
               ? [


### PR DESCRIPTION
## Summary
- Add transaction source (QR Code, NFC, Clipboard, Deep Link) as a row in the collapsible Details section on all four transaction detail screens (mint, melt, send, receive)
- Show P2PK locking pubkey (truncated) in the receive transaction Details section when the token contains P2PK-locked proofs
- Add `useTransactionSource` hook that resolves the scan source label from the scan history store

## Test plan
- [ ] Open a transaction that was initiated via QR scan — verify "Source: QR Code" appears in Details
- [ ] Open a transaction initiated via NFC — verify "Source: NFC" appears
- [ ] Open a transaction initiated via clipboard paste — verify "Source: Clipboard" appears
- [ ] Open a transaction initiated via deep link — verify "Source: Deep Link" appears
- [ ] Open a receive transaction with a P2PK-locked token — verify truncated pubkey appears under "P2PK"
- [ ] Open a receive transaction without P2PK — verify no P2PK row appears
- [ ] Open a transaction with no linked scan source — verify no Source row appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)