### PR TITLE
fix(mint): keep selector rows enriched

### DIFF
--- a/__tests__/mintSelectorStickyItems.test.ts
+++ b/__tests__/mintSelectorStickyItems.test.ts
@@ -1,0 +1,57 @@
+import { resolveStickyMintSelectorItems } from '@/features/mint/hooks/useStickyMintSelectorItems';
+import type { MintListItem } from 'coco-payment-ux';
+
+function mintItem(mintUrl: string, displayName: string, iconUrl?: string): MintListItem {
+  return {
+    mintUrl,
+    displayName,
+    iconUrl,
+    balance: 0,
+    unit: 'sat',
+    status: 'available',
+    reason: null,
+    isPreferred: false,
+  };
+}
+
+describe('resolveStickyMintSelectorItems', () => {
+  it('keeps the last live enriched rows when the machine leaves selectMint', () => {
+    const fallback = [mintItem('https://mint.example', 'https://mint.example')];
+    const enriched = [
+      mintItem('https://mint.example', 'Sovran Mint', 'https://mint.example/icon.png'),
+    ];
+
+    expect(
+      resolveStickyMintSelectorItems({
+        liveItems: null,
+        entryItems: fallback,
+        previousLiveItems: enriched,
+      })
+    ).toBe(enriched);
+  });
+
+  it('uses route-param fallback rows before live machine rows arrive', () => {
+    const fallback = [mintItem('https://mint.example', 'https://mint.example')];
+
+    expect(
+      resolveStickyMintSelectorItems({
+        liveItems: null,
+        entryItems: fallback,
+        previousLiveItems: null,
+      })
+    ).toBe(fallback);
+  });
+
+  it('prefers current live rows over older live rows', () => {
+    const previous = [mintItem('https://old.example', 'Old Mint')];
+    const current = [mintItem('https://new.example', 'New Mint')];
+
+    expect(
+      resolveStickyMintSelectorItems({
+        liveItems: current,
+        entryItems: previous,
+        previousLiveItems: previous,
+      })
+    ).toBe(current);
+  });
+});

--- a/app/(receive-flow)/mintSelect.tsx
+++ b/app/(receive-flow)/mintSelect.tsx
@@ -13,14 +13,14 @@
  * `useScreenActions`.
  */
 
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect } from 'react';
 import { Stack, router } from 'expo-router';
 import { z } from 'zod';
 
 import { useExecutionState, useScreenActions, usePaymentFlowMachine } from 'coco-payment-ux/react';
 import type { MintListItem, StepDataMap } from 'coco-payment-ux';
 
-import { MintListScreen } from '@/features/mint';
+import { MintListScreen, useStickyMintSelectorItems } from '@/features/mint';
 import { useWalletContext } from '@/shared/providers/WalletContextProvider';
 import { ScreenHeaderAction } from '@/shared/ui/composed/ScreenHeaderAction';
 import { log, useLifecycleLogger } from '@/shared/lib/logger';
@@ -42,15 +42,11 @@ function ReceiveMintSelectRoute() {
   const liveSelectMint =
     execution.step === 'selectMint' ? (execution.details as StepDataMap['selectMint']) : null;
 
-  const items = useMemo<MintListItem[]>(
-    () =>
-      Array.isArray(liveSelectMint?.mintListItems)
-        ? liveSelectMint.mintListItems
-        : Array.isArray(entry?.items)
-          ? (entry.items as MintListItem[])
-          : [],
-    [entry?.items, liveSelectMint?.mintListItems]
-  );
+  const liveItems = Array.isArray(liveSelectMint?.mintListItems)
+    ? liveSelectMint.mintListItems
+    : null;
+  const entryItems = Array.isArray(entry?.items) ? (entry.items as MintListItem[]) : null;
+  const items = useStickyMintSelectorItems(liveItems, entryItems);
 
   useEffect(() => {
     const available = items.filter((i) => i.status === 'available').length;

--- a/app/(send-flow)/mintSelect.tsx
+++ b/app/(send-flow)/mintSelect.tsx
@@ -13,14 +13,14 @@
  * `useScreenActions`.
  */
 
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect } from 'react';
 import { Stack, router } from 'expo-router';
 import { z } from 'zod';
 
 import { useExecutionState, useScreenActions, usePaymentFlowMachine } from 'coco-payment-ux/react';
 import type { MintListItem, StepDataMap } from 'coco-payment-ux';
 
-import { MintListScreen } from '@/features/mint';
+import { MintListScreen, useStickyMintSelectorItems } from '@/features/mint';
 import { useWalletContext } from '@/shared/providers/WalletContextProvider';
 import { ScreenHeaderAction } from '@/shared/ui/composed/ScreenHeaderAction';
 import { paymentLog, useLifecycleLogger } from '@/shared/lib/logger';
@@ -42,15 +42,11 @@ function MintSelectRoute() {
   const liveSelectMint =
     execution.step === 'selectMint' ? (execution.details as StepDataMap['selectMint']) : null;
 
-  const items = useMemo<MintListItem[]>(
-    () =>
-      Array.isArray(liveSelectMint?.mintListItems)
-        ? liveSelectMint.mintListItems
-        : Array.isArray(entry?.items)
-          ? (entry.items as MintListItem[])
-          : [],
-    [entry?.items, liveSelectMint?.mintListItems]
-  );
+  const liveItems = Array.isArray(liveSelectMint?.mintListItems)
+    ? liveSelectMint.mintListItems
+    : null;
+  const entryItems = Array.isArray(entry?.items) ? (entry.items as MintListItem[]) : null;
+  const items = useStickyMintSelectorItems(liveItems, entryItems);
 
   useEffect(() => {
     const available = items.filter((i) => i.status === 'available').length;

--- a/features/mint/hooks/useStickyMintSelectorItems.ts
+++ b/features/mint/hooks/useStickyMintSelectorItems.ts
@@ -1,0 +1,44 @@
+import { useEffect, useMemo, useRef } from 'react';
+import type { MintListItem } from 'coco-payment-ux';
+
+function hasItems(items: MintListItem[] | null | undefined): items is MintListItem[] {
+  return Array.isArray(items) && items.length > 0;
+}
+
+export function resolveStickyMintSelectorItems({
+  liveItems,
+  entryItems,
+  previousLiveItems,
+}: {
+  liveItems: MintListItem[] | null | undefined;
+  entryItems: MintListItem[] | null | undefined;
+  previousLiveItems: MintListItem[] | null | undefined;
+}): MintListItem[] {
+  if (hasItems(liveItems)) return liveItems;
+  if (hasItems(previousLiveItems)) return previousLiveItems;
+  if (hasItems(entryItems)) return entryItems;
+  return [];
+}
+
+export function useStickyMintSelectorItems(
+  liveItems: MintListItem[] | null | undefined,
+  entryItems: MintListItem[] | null | undefined
+): MintListItem[] {
+  const previousLiveItemsRef = useRef<MintListItem[] | null>(null);
+
+  useEffect(() => {
+    if (hasItems(liveItems)) {
+      previousLiveItemsRef.current = liveItems;
+    }
+  }, [liveItems]);
+
+  return useMemo(
+    () =>
+      resolveStickyMintSelectorItems({
+        liveItems,
+        entryItems,
+        previousLiveItems: previousLiveItemsRef.current,
+      }),
+    [entryItems, liveItems]
+  );
+}

--- a/features/mint/index.ts
+++ b/features/mint/index.ts
@@ -28,3 +28,4 @@ export { useAuditedMints, type AuditedMintData } from './hooks/useAuditedMints';
 export { useDebouncedMintValidation } from './hooks/useDebouncedMintValidation';
 export { useNostrDiscoveredMints } from './hooks/useNostrDiscoveredMints';
 export { useSovranDiscoveredMints } from './hooks/useSovranDiscoveredMints';
+export { useStickyMintSelectorItems } from './hooks/useStickyMintSelectorItems';


### PR DESCRIPTION
## Summary
- keep the last live enriched mint selector rows available when the payment machine leaves `selectMint`
- use the sticky row source in both send and receive mint selector routes
- add resolver coverage for live, previous-live, and route-param fallback precedence

## Verification
- npm test -- __tests__/mintSelectorStickyItems.test.ts --runInBand
- git diff --check
- npm run pretty:check
- npm run type-check
- npm run knip
- npm run lint (0 errors, existing warning floor)
- npm test -- --runInBand reported 37/37 suites and 251/251 tests passing, then hung on an existing open-handle/logger warning; process was stopped after the pass result
- git diff --cached --check
- staged secret scan

Security-impact: low
Touches-keys: false