### PR TITLE
feat(dm): default the contacts/DM list to nagg's REST app-view

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 GITHUB_TOKEN=replace_with_classic_PAT_with_read_packages
 EXPO_PUBLIC_NOSTR_APPVIEW_BASE_URL=https://nagg.up.railway.app
 EXPO_PUBLIC_NOSTR_GRAPHQL_ENDPOINT=https://nagg.up.railway.app/graphql
+# DM/contacts list uses nagg's optimized REST app-view by default. Set to
+# 'false' to fall back to the generic GraphQL query.
+EXPO_PUBLIC_NOSTR_DM_APPVIEW=true
 
 # Shared giveaway P2PK key (nsec or 64-hex). Injected into extra.giveawayP2pkSecret
 # for ALL build profiles so any install can redeem ecash locked to its pubkey.

--- a/__tests__/backendConfig.test.ts
+++ b/__tests__/backendConfig.test.ts
@@ -7,7 +7,7 @@ describe('backend config', () => {
       apiBaseUrl: 'https://api.sovran.money/api',
       scoreApiBaseUrl: 'https://nagg.up.railway.app',
       nostrGraphqlEndpoint: 'https://nagg.up.railway.app/graphql',
-      nostrDmAppView: false,
+      nostrDmAppView: true,
     });
   });
 
@@ -24,16 +24,16 @@ describe('backend config', () => {
       apiBaseUrl: 'https://api.example.test/api',
       scoreApiBaseUrl: 'http://localhost:8080',
       nostrGraphqlEndpoint: 'http://localhost:8081/graphql',
-      nostrDmAppView: false,
+      nostrDmAppView: true,
     });
   });
 
-  it('enables the DM app-view transport only when explicitly set to "true"', () => {
+  it('defaults the DM app-view transport ON, opting out only on "false"', () => {
     expect(parseBackendConfig({ EXPO_PUBLIC_NOSTR_DM_APPVIEW: 'true' }).nostrDmAppView).toBe(true);
     expect(parseBackendConfig({ EXPO_PUBLIC_NOSTR_DM_APPVIEW: 'false' }).nostrDmAppView).toBe(
       false
     );
-    expect(parseBackendConfig({}).nostrDmAppView).toBe(false);
+    expect(parseBackendConfig({}).nostrDmAppView).toBe(true);
   });
 
   it('keeps the legacy Nagg base URL env as an app-view fallback', () => {

--- a/shared/config/backend.ts
+++ b/shared/config/backend.ts
@@ -69,7 +69,12 @@ export function parseBackendConfig(env: BackendEnvInput = readBackendEnv()): Bac
     scoreApiBaseUrl: parsed.data.EXPO_PUBLIC_SCORE_API_BASE_URL ?? nostrAppViewBaseUrl,
     nostrGraphqlEndpoint:
       parsed.data.EXPO_PUBLIC_NOSTR_GRAPHQL_ENDPOINT ?? `${nostrAppViewBaseUrl}/graphql`,
-    nostrDmAppView: parsed.data.EXPO_PUBLIC_NOSTR_DM_APPVIEW === 'true',
+    // Default ON: the contacts/DM list uses nagg's purpose-built, paginated
+    // REST app-view endpoint (optimized for that page) rather than the generic
+    // GraphQL query. Set EXPO_PUBLIC_NOSTR_DM_APPVIEW=false to fall back to
+    // GraphQL. nagg returns the same encrypted envelopes either way (it never
+    // decrypts), and both transports default to NIP-04 + NIP-17 kinds.
+    nostrDmAppView: parsed.data.EXPO_PUBLIC_NOSTR_DM_APPVIEW !== 'false',
   };
 }
 


### PR DESCRIPTION
The slice of "route views through optimized REST app-view endpoints" that is **ready today**: the DM/contacts list.

`dmEnvelopeClient` already supports both transports; this flips the default from GraphQL to nagg's purpose-built, paginated **REST app-view** endpoint (opt out with `EXPO_PUBLIC_NOSTR_DM_APPVIEW=false`). nagg returns the same encrypted envelopes either way (it never decrypts), and both transports now default to NIP-04 + NIP-17 kinds (after the nagg DM-kinds change). `backendConfig` test + apiClient backend test updated; lint/type-check green.

**Not auto-merged** — it changes a core view's data source, so please give the contacts/DM list a quick on-device check before merging.

## Why only DMs
DM is the only view with a REST app-view binding in `@sovranbitcoin/nagg-ts` (`dm.ts`). The feed, thread, and notifications clients are **GraphQL-only** — routing them through REST needs new `*AppView` recipe bindings in nagg-ts (+ wiring each app client to the existing `transport: 'appview'` path). That's a larger cross-repo follow-up:
1. Add REST app-view bindings in nagg-ts for `/nostr/feed`, `/nostr/thread`, `/nostr/feed/user`, `/nostr/notes/stats` (nagg already serves these).
2. Republish nagg-ts; wire `naggFeedClient` / thread / notifications clients to pass `transport: 'appview'` + the binding.
3. Keep GraphQL as the prototyping fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)