### PR TITLE
feat(feed): route ranked feed / profile / thread through nagg REST app-view (flag-gated)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,12 @@ GITHUB_TOKEN=replace_with_classic_PAT_with_read_packages
 EXPO_PUBLIC_NOSTR_APPVIEW_BASE_URL=https://nagg.up.railway.app
 EXPO_PUBLIC_NOSTR_GRAPHQL_ENDPOINT=https://nagg.up.railway.app/graphql
 
+# Route the feed / thread / profile feeds through nagg's REST app-view
+# (`/nostr/feed*`, `/nostr/thread`) instead of GraphQL. Defaults to off (GraphQL).
+# When "true" these views fetch over REST — device-test the REST routes before
+# enabling. Notifications and quoted-event enrichment stay on GraphQL regardless.
+# EXPO_PUBLIC_NOSTR_FEED_APPVIEW=false
+
 # Shared giveaway P2PK key (nsec or 64-hex). Injected into extra.giveawayP2pkSecret
 # for ALL build profiles so any install can redeem ecash locked to its pubkey.
 # Generate with: node scripts/gen-giveaway-key.mjs  — never commit the real value.

--- a/__tests__/backendConfig.test.ts
+++ b/__tests__/backendConfig.test.ts
@@ -8,6 +8,7 @@ describe('backend config', () => {
       scoreApiBaseUrl: 'https://nagg.up.railway.app',
       nostrGraphqlEndpoint: 'https://nagg.up.railway.app/graphql',
       nostrDmAppView: false,
+      nostrFeedAppView: false,
     });
   });
 
@@ -25,6 +26,7 @@ describe('backend config', () => {
       scoreApiBaseUrl: 'http://localhost:8080',
       nostrGraphqlEndpoint: 'http://localhost:8081/graphql',
       nostrDmAppView: false,
+      nostrFeedAppView: false,
     });
   });
 
@@ -34,6 +36,16 @@ describe('backend config', () => {
       false
     );
     expect(parseBackendConfig({}).nostrDmAppView).toBe(false);
+  });
+
+  it('enables the feed app-view transport only when explicitly set to "true"', () => {
+    expect(parseBackendConfig({ EXPO_PUBLIC_NOSTR_FEED_APPVIEW: 'true' }).nostrFeedAppView).toBe(
+      true
+    );
+    expect(parseBackendConfig({ EXPO_PUBLIC_NOSTR_FEED_APPVIEW: 'false' }).nostrFeedAppView).toBe(
+      false
+    );
+    expect(parseBackendConfig({}).nostrFeedAppView).toBe(false);
   });
 
   it('keeps the legacy Nagg base URL env as an app-view fallback', () => {

--- a/__tests__/naggFeedClient.test.ts
+++ b/__tests__/naggFeedClient.test.ts
@@ -23,6 +23,7 @@ const ENV_KEYS = [
   'EXPO_PUBLIC_API_BASE_URL',
   'EXPO_PUBLIC_SCORE_API_BASE_URL',
   'EXPO_PUBLIC_NOSTR_GRAPHQL_ENDPOINT',
+  'EXPO_PUBLIC_NOSTR_FEED_APPVIEW',
 ] as const;
 
 const originalFetchDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'fetch');
@@ -2085,6 +2086,185 @@ describe('createNaggFeedClient', () => {
     expect(repostsCall.variables.rank).toMatchObject({
       references: { kinds: [6, 16], limit: 500 },
       metric: { name: 'reposts', op: 'COUNT_DISTINCT', distinctField: 'PUBKEY' },
+    });
+  });
+});
+
+describe('createNaggFeedClient with the REST app-view transport enabled', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockFetch.mockReset();
+    Object.defineProperty(globalThis, 'fetch', {
+      configurable: true,
+      writable: true,
+      value: mockFetch as unknown as typeof fetch,
+    });
+    for (const key of ENV_KEYS) delete process.env[key];
+    process.env.EXPO_PUBLIC_NOSTR_APPVIEW_BASE_URL = 'http://nagg.test/';
+    process.env.EXPO_PUBLIC_NOSTR_FEED_APPVIEW = 'true';
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const value = originalEnv[key as (typeof ENV_KEYS)[number]];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  afterAll(() => {
+    if (originalFetchDescriptor) {
+      Object.defineProperty(globalThis, 'fetch', originalFetchDescriptor);
+      return;
+    }
+    Reflect.deleteProperty(globalThis, 'fetch');
+  });
+
+  it('fetches the For You ranked feed over the REST app-view', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({
+        items: [{ type: 'note', event: { ...root } }],
+        metrics: { root: { likeCount: 7, repostCount: 0, replyCount: 0, satsZapped: 0 } },
+        profiles: { alice: { name: 'Alice' } },
+        quoted: {},
+        paginationUntil: 100,
+        paginationOffset: 1,
+      }),
+    });
+
+    const { createNaggFeedClient } = jest.requireActual<
+      typeof import('@/features/feed/data/naggFeedClient')
+    >('@/features/feed/data/naggFeedClient');
+
+    const result = await createNaggFeedClient().getFeed({
+      spec: JSON.stringify({ id: 'for-you', kind: 'notes', hours: 24 }),
+      userPubkey: 'viewer',
+      limit: 12,
+    });
+
+    const requestUrl = new URL(String(mockFetch.mock.calls[0][0]));
+    expect(`${requestUrl.origin}${requestUrl.pathname}`).toBe(
+      'http://nagg.test/v1/nostr/feed/ranked'
+    );
+    expect(mockFetch.mock.calls[0][1].method).toBe('POST');
+    expect(result.orderedFeedItems).toHaveLength(1);
+    expect(result.orderedFeedItems[0]).toMatchObject({
+      type: 'note',
+      event: expect.objectContaining({ id: 'root' }),
+    });
+    expect(result.metricsMap.get('root')?.likeCount).toBe(7);
+    expect(result.profilesMap.get('alice')).toEqual({ name: 'Alice' });
+    // Ranked feeds keep the offset-based pagination sentinel on both transports.
+    expect(result.paginationUntil).toBe(1);
+    expect(result.paginationOffset).toBe(1);
+  });
+
+  it('fetches a user feed over the REST app-view', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({
+        items: [{ type: 'note', event: { ...root, pubkey: 'alice' } }],
+        metrics: {},
+        profiles: { alice: { name: 'Alice' } },
+        quoted: {},
+        paginationUntil: 100,
+        paginationOffset: 1,
+      }),
+    });
+
+    const { createNaggFeedClient } = jest.requireActual<
+      typeof import('@/features/feed/data/naggFeedClient')
+    >('@/features/feed/data/naggFeedClient');
+
+    const result = await createNaggFeedClient().getUserFeed({
+      pubkey: 'alice',
+      authorName: 'Alice',
+    });
+
+    const requestUrl = new URL(String(mockFetch.mock.calls[0][0]));
+    expect(`${requestUrl.origin}${requestUrl.pathname}`).toBe(
+      'http://nagg.test/v1/nostr/feed/user'
+    );
+    expect(requestUrl.searchParams.get('pubkey')).toBe('alice');
+    expect(result.orderedFeedItems).toHaveLength(1);
+    expect(result.orderedFeedItems[0]).toMatchObject({
+      type: 'note',
+      event: expect.objectContaining({ id: 'root', pubkey: 'alice' }),
+    });
+  });
+
+  it('builds a thread result from the REST app-view payload', async () => {
+    const reply = {
+      id: 'reply',
+      kind: 1,
+      pubkey: 'bob',
+      content: 'reply',
+      tags: [['e', 'root', '', 'reply']],
+      created_at: 101,
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({
+        root: { ...root },
+        events: [{ ...root }, reply],
+        metrics: { root: { likeCount: 0, repostCount: 0, replyCount: 1, satsZapped: 0 } },
+        profiles: { bob: { name: 'Bob' } },
+        quoted: {},
+      }),
+    });
+
+    const { createNaggFeedClient } = jest.requireActual<
+      typeof import('@/features/feed/data/naggFeedClient')
+    >('@/features/feed/data/naggFeedClient');
+
+    const result = await createNaggFeedClient().getThread({ eventId: 'root' });
+
+    const requestUrl = new URL(String(mockFetch.mock.calls[0][0]));
+    expect(`${requestUrl.origin}${requestUrl.pathname}`).toBe('http://nagg.test/v1/nostr/thread');
+    expect(requestUrl.searchParams.get('id')).toBe('root');
+    expect(result.thread.target?.id).toBe('root');
+    expect(result.thread.replies.map((event) => event.id)).toEqual(['reply']);
+    expect(result.replyPageEventIds).toEqual(['reply']);
+    expect(result.metrics.get('root')?.replyCount).toBe(1);
+    expect(result.profiles.get('bob')).toEqual({ name: 'Bob' });
+    expect(result.hasMoreReplies).toBe(false);
+  });
+
+  it('keeps notifications on GraphQL even with the feed app-view enabled', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({
+        data: {
+          notifications: {
+            nodes: [{ reason: 'mention', actorVertexScore: 1, event: rootGql }],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      }),
+    });
+
+    const { createNaggFeedClient } = jest.requireActual<
+      typeof import('@/features/feed/data/naggFeedClient')
+    >('@/features/feed/data/naggFeedClient');
+
+    const result = await createNaggFeedClient().getNotifications({
+      viewerPubkey: 'viewer'.padEnd(64, '0'),
+      limit: 12,
+    });
+
+    const requestUrl = new URL(String(mockFetch.mock.calls[0][0]));
+    expect(requestUrl.pathname).toBe('/graphql');
+    expect(result.notifications[0]).toMatchObject({
+      event: expect.objectContaining({ id: 'root' }),
     });
   });
 });

--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,7 @@
         "@scure/bip39": "^1.2.2",
         "@sovranbitcoin/coco-cashu-plugin-p2pk-import": "^0.1.0",
         "@sovranbitcoin/colada": "^0.1.0",
-        "@sovranbitcoin/nagg-ts": "^0.1.0",
+        "@sovranbitcoin/nagg-ts": "^0.2.0",
         "@sovranbitcoin/schemas": "^2.0.6",
         "bitchat-module": "file:./modules/bitchat-module",
         "buffer": "^6.0.3",
@@ -1093,7 +1093,7 @@
 
     "@sovranbitcoin/colada": ["@sovranbitcoin/colada@0.1.0", "https://npm.pkg.github.com/download/@sovranbitcoin/colada/0.1.0/6a8af1927c550cb6ad10b4078b7a1e5758f86566", { "dependencies": { "@cashu/cashu-ts": "3.5.0", "@gandlaf21/bolt11-decode": "^3.1.1", "@scure/bip39": "2.0.1", "@sovranbitcoin/nagg-ts": "^0.1.0", "@sovranbitcoin/schemas": "^2.0.6", "neverthrow": "^8.2.0", "nostr-tools": "^2.0.0", "zod": "^4.3.6" }, "peerDependencies": { "@cashu/coco-core": "^1.0.1", "react": ">=18.0.0" } }, "sha512-8fSTAUmk2TnJbECYgicRPaQ+4vi+pmPuZqgjFSXTu9hK4JXu6wPC1T8B5eEPEt/JiHlvAIIpkCoNQI0tgbSrKQ=="],
 
-    "@sovranbitcoin/nagg-ts": ["@sovranbitcoin/nagg-ts@0.1.0", "https://npm.pkg.github.com/download/@sovranbitcoin/nagg-ts/0.1.0/dba22d9aa9f1c27394c0685ea51ad15f82f8b975", { "dependencies": { "neverthrow": "^8.2.0" }, "peerDependencies": { "@sovranbitcoin/schemas": "*", "zod": "^4.0.0" } }, "sha512-FBCzkefPYskeRPdakeRWCEf+F22CpGxLSgDR2oMnb1X9LitqadkOAQ9X60q85ZxGPCNGwzWjQQrk3QJQTF3BEA=="],
+    "@sovranbitcoin/nagg-ts": ["@sovranbitcoin/nagg-ts@0.2.0", "https://npm.pkg.github.com/download/@sovranbitcoin/nagg-ts/0.2.0/0834a76176fc43730676e33222e05f6367c23210", { "dependencies": { "neverthrow": "^8.2.0" }, "peerDependencies": { "@sovranbitcoin/schemas": "*", "zod": "^4.0.0" } }, "sha512-yJjiklLjNxZSUoI9ur6Qv36dQUAG9U5g1UVuR7JTB7ISin1HFz6E10TqedLkuw9QauABbqdU4Sq07sRi5kQ2/g=="],
 
     "@sovranbitcoin/schemas": ["@sovranbitcoin/schemas@2.0.6", "https://npm.pkg.github.com/download/@sovranbitcoin/schemas/2.0.6/94d6c7854bf189100c65e0c299380d55cfbabe21", { "peerDependencies": { "neverthrow": "^8.0.0", "zod": "^4.0.0" } }, "sha512-yHELA3Dl2lEn1Eudi/Z6ORreUbBLGc4xGasuoj2j8x5Cz9IATt5q957ZK31U/sEPaEaulQLkEcAoG4ijeDeRhA=="],
 
@@ -3496,6 +3496,8 @@
     "@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
     "@sovranbitcoin/colada/@scure/bip39": ["@scure/bip39@2.0.1", "", { "dependencies": { "@noble/hashes": "2.0.1", "@scure/base": "2.0.0" } }, "sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg=="],
+
+    "@sovranbitcoin/colada/@sovranbitcoin/nagg-ts": ["@sovranbitcoin/nagg-ts@0.1.0", "https://npm.pkg.github.com/download/@sovranbitcoin/nagg-ts/0.1.0/dba22d9aa9f1c27394c0685ea51ad15f82f8b975", { "dependencies": { "neverthrow": "^8.2.0" }, "peerDependencies": { "@sovranbitcoin/schemas": "*", "zod": "^4.0.0" } }, "sha512-FBCzkefPYskeRPdakeRWCEf+F22CpGxLSgDR2oMnb1X9LitqadkOAQ9X60q85ZxGPCNGwzWjQQrk3QJQTF3BEA=="],
 
     "@tailwindcss/node/lightningcss": ["lightningcss@1.31.1", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.31.1", "lightningcss-darwin-arm64": "1.31.1", "lightningcss-darwin-x64": "1.31.1", "lightningcss-freebsd-x64": "1.31.1", "lightningcss-linux-arm-gnueabihf": "1.31.1", "lightningcss-linux-arm64-gnu": "1.31.1", "lightningcss-linux-arm64-musl": "1.31.1", "lightningcss-linux-x64-gnu": "1.31.1", "lightningcss-linux-x64-musl": "1.31.1", "lightningcss-win32-arm64-msvc": "1.31.1", "lightningcss-win32-x64-msvc": "1.31.1" } }, "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ=="],
 

--- a/features/feed/data/naggFeedClient.ts
+++ b/features/feed/data/naggFeedClient.ts
@@ -2,6 +2,7 @@ import {
   createNaggClient,
   NAGG_CAPABILITIES,
   NaggUnknownDataSchema,
+  type NaggAppViewBinding,
   type NaggCapability,
   type NaggError,
 } from '@sovranbitcoin/nagg-ts';
@@ -10,11 +11,15 @@ import {
   followingRecentEventsInput,
   followingRepliesEventsInput,
   followingPopularRankedEventsInput,
+  followsFeedAppView,
   forYouRankedEventsInput,
   mergeRelevantReplyNodes as mergeNaggRelevantReplyNodes,
   notificationsInput,
+  rankedFeedAppView,
   recentNotesEventsInput,
+  threadAppView,
   threadReplyRankInput as buildThreadReplyRankInput,
+  userFeedAppView,
   withEventExclusions,
   withRankedTargetExclusions,
   type EventQueryInput,
@@ -26,6 +31,7 @@ import {
   metricsFromGraphqlNode,
   normalizeGraphqlEvent,
   profileFromMetadataEvent,
+  type NaggFeedPage,
   type NaggGraphqlConnection as GraphqlConnection,
   type NaggGraphqlEventNode as GraphqlEventNode,
 } from '@sovranbitcoin/nagg-ts/map';
@@ -798,18 +804,33 @@ function graphqlDataKeys(value: unknown): string[] {
   return record ? Object.keys(record).slice(0, 8) : [];
 }
 
+/**
+ * Optional REST app-view binding to ride alongside a GraphQL query. When
+ * {@link backendConfig.nostrFeedAppView} is on AND a binding is provided, the
+ * request is served by nagg's REST app-view (the binding `normalize` returns the
+ * SAME canonical shape the GraphQL `data` field carries); otherwise the GraphQL
+ * path runs. Mirrors `dmEnvelopeClient`'s per-query transport switch.
+ */
+type AppViewControls = {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  appView?: NaggAppViewBinding;
+};
+
 async function postGraphql<T>(
   query: string,
   variables: Record<string, unknown>,
   refresh: boolean | undefined,
-  controls: { signal?: AbortSignal; timeoutMs?: number } = {}
+  controls: AppViewControls = {}
 ): Promise<T> {
   const operationName = graphqlOperationName(query);
+  const useAppView = backendConfig.nostrFeedAppView && !!controls.appView;
   const startedAt = Date.now();
   const requestFields = {
     operationName,
     refresh: !!refresh,
     timeoutMs: controls.timeoutMs,
+    transport: useAppView ? 'appview' : 'graphql',
     variables: summarizeGraphqlVariables(variables),
     ...endpointLogFields(),
   };
@@ -817,7 +838,10 @@ async function postGraphql<T>(
 
   apiLog.info('nagg.graphql.request.start', requestFields);
 
-  const client = createNaggClient({ endpoint: graphqlEndpoint() });
+  const client = createNaggClient({
+    endpoint: graphqlEndpoint(),
+    appView: { baseUrl: backendConfig.nostrAppViewBaseUrl, version: 'v1' },
+  });
   const result = await client.query({
     query,
     variables,
@@ -826,6 +850,8 @@ async function postGraphql<T>(
     refresh,
     signal: controls.signal,
     timeoutMs: controls.timeoutMs,
+    transport: useAppView ? 'appview' : 'graphql',
+    appView: controls.appView,
   });
   const durationMs = Date.now() - startedAt;
 
@@ -1253,6 +1279,35 @@ function feedQueryOptionsFromPreferences(filters: FeedPreferenceFilters): FeedQu
   };
 }
 
+/**
+ * Resolve a query to the canonical {@link NaggFeedPage} regardless of transport.
+ * When the feed app-view flag is on AND a binding is supplied, nagg-ts serves the
+ * REST route and the binding's `normalize` already returns a `NaggFeedPage` — so
+ * we return it as-is. Otherwise we run the GraphQL query and distill its raw
+ * nodes with `graphqlToPage` (defaults to `graphqlNodesToNaggPage`). Downstream
+ * `mapNaggFeedPage` mapping is identical for both paths.
+ */
+async function fetchNaggFeedPage(
+  query: string,
+  variables: Record<string, unknown>,
+  refresh: boolean | undefined,
+  controls: AppViewControls,
+  graphqlToPage: (data: GraphqlFeedData) => NaggFeedPage<FeedEvent, ProfileInfo>
+): Promise<NaggFeedPage<FeedEvent, ProfileInfo>> {
+  if (backendConfig.nostrFeedAppView && controls.appView) {
+    return postGraphql<NaggFeedPage<FeedEvent, ProfileInfo>>(query, variables, refresh, controls);
+  }
+  const data = await postGraphql<GraphqlFeedData>(query, variables, refresh, {
+    signal: controls.signal,
+    timeoutMs: controls.timeoutMs,
+  });
+  return graphqlToPage(data);
+}
+
+function pageFromEventNodes(data: GraphqlFeedData): NaggFeedPage<FeedEvent, ProfileInfo> {
+  return graphqlNodesToNaggPage(data.events?.nodes ?? []) as NaggFeedPage<FeedEvent, ProfileInfo>;
+}
+
 function mapGraphqlFeed(nodes: GraphqlEventNode[], options: FeedQueryOptions = {}) {
   return mapNaggFeedPage(graphqlNodesToNaggPage(nodes), options);
 }
@@ -1263,6 +1318,25 @@ function mapRankedGraphqlFeed(nodes: GraphqlEventNode[], options: FeedQueryOptio
     ...result,
     paginationUntil: nodes.length > 0 ? 1 : 0,
     paginationOffset: nodes.length,
+  };
+}
+
+/**
+ * Map a {@link NaggFeedPage} (from either transport) the same way
+ * {@link mapRankedGraphqlFeed} maps GraphQL nodes: offset-based pagination
+ * driven by the page's item count (the `paginationUntil: 1` sentinel), so ranked
+ * REST results paginate identically to the GraphQL ranked path.
+ */
+function mapRankedNaggFeedPage(
+  page: NaggFeedPage<FeedEvent, ProfileInfo>,
+  options: FeedQueryOptions = {}
+): FeedParseResult {
+  const result = mapNaggFeedPage(page, options);
+  const itemCount = page.items.length;
+  return {
+    ...result,
+    paginationUntil: itemCount > 0 ? 1 : 0,
+    paginationOffset: itemCount,
   };
 }
 
@@ -1477,6 +1551,59 @@ function addThreadNode(
   for (const childNode of node.childFollowedReply?.nodes ?? []) addThreadNode(childNode, buckets);
 }
 
+/** Canonical thread shape produced by `threadAppView(...).normalize`. */
+type NaggThreadAppViewResult = {
+  root: FeedEvent;
+  events: FeedEvent[];
+  metrics: Record<string, NoteMetrics>;
+  profiles: Record<string, ProfileInfo>;
+  quoted: Record<string, FeedEvent>;
+};
+
+/**
+ * Build a {@link ThreadResult} from the REST thread payload. The flat `events`
+ * list (root + descendants) seeds the same buckets the GraphQL path fills, then
+ * `buildThreadStructure` derives parents/replies identically. Reply paging is
+ * derived from the resulting structure (the REST endpoint returns an already
+ * server-ranked event list rather than the GraphQL relevant/author-chain
+ * preview metadata, so we page over the flattened replies).
+ */
+function threadResultFromAppView(
+  eventId: string,
+  limit: number,
+  result: NaggThreadAppViewResult,
+  seed: ThreadRequest['seed']
+): ThreadResult {
+  const buckets = {
+    allEvents: seed ? new Map(seed.allEvents) : new Map<string, FeedEvent>(),
+    profiles: seed ? new Map(seed.profiles) : new Map<string, ProfileInfo>(),
+    metrics: seed ? new Map(seed.metrics) : new Map<string, NoteMetrics>(),
+    quotedEvents: seed ? new Map(seed.quotedEvents) : new Map<string, FeedEvent>(),
+  };
+  const allEventNodes = [result.root, ...result.events].filter(
+    (event): event is FeedEvent => !!event && !!event.id
+  );
+  for (const event of allEventNodes) buckets.allEvents.set(event.id, event);
+  for (const [id, metrics] of Object.entries(result.metrics)) buckets.metrics.set(id, metrics);
+  for (const [pubkey, profile] of Object.entries(result.profiles)) {
+    buckets.profiles.set(pubkey, profile);
+  }
+  for (const [id, quote] of Object.entries(result.quoted)) buckets.quotedEvents.set(id, quote);
+
+  const thread = buildThreadStructure(eventId, buckets.allEvents);
+  const replyPageEventIds = thread.replies.slice(0, limit).map((event) => event.id);
+  const hasMoreReplies = thread.replies.length > limit;
+
+  return {
+    ...buckets,
+    thread,
+    replyPageEventIds,
+    replyPageSize: limit,
+    loadedReplyCount: replyPageEventIds.length,
+    hasMoreReplies,
+  };
+}
+
 export function createNaggFeedClient(): FeedClient {
   return {
     async getFeed({
@@ -1516,6 +1643,17 @@ export function createNaggFeedClient(): FeedClient {
           }),
           preferenceFilters
         );
+        if (backendConfig.nostrFeedAppView) {
+          // REST ranked feed: a single normalized `NaggFeedPage` (no GraphQL
+          // capability/timeout fallback chain), mapped via the same ranked path.
+          const page = await postGraphql<NaggFeedPage<FeedEvent, ProfileInfo>>(
+            RANKED_FEED_QUERY,
+            { input },
+            refresh,
+            { signal, timeoutMs, appView: rankedFeedAppView(input) }
+          );
+          return logResult('for-you', mapRankedNaggFeedPage(page, feedOptions));
+        }
         const timeoutFallbackInput = withPreferenceEventFilters(
           recentInputFromSpec({ parsed: parsedSpec, limit, offset }),
           preferenceFilters
@@ -1578,6 +1716,15 @@ export function createNaggFeedClient(): FeedClient {
           }),
           preferenceFilters
         );
+        if (backendConfig.nostrFeedAppView) {
+          const page = await postGraphql<NaggFeedPage<FeedEvent, ProfileInfo>>(
+            FOLLOWING_POPULAR_QUERY,
+            { input },
+            refresh,
+            { signal, timeoutMs, appView: rankedFeedAppView(input) }
+          );
+          return logResult('following-popular', mapRankedNaggFeedPage(page, feedOptions));
+        }
         const timeoutFallbackInput = withPreferenceEventFilters(
           followingRecentEventsInput({
             viewerPubkey: userPubkey,
@@ -1645,7 +1792,7 @@ export function createNaggFeedClient(): FeedClient {
       signal,
       timeoutMs,
     }: UserFeedPageRequest) {
-      const data = await postGraphql<GraphqlFeedData>(
+      const page = await fetchNaggFeedPage(
         FEED_QUERY,
         {
           input: {
@@ -1657,9 +1804,10 @@ export function createNaggFeedClient(): FeedClient {
           },
         },
         refresh,
-        { signal, timeoutMs }
+        { signal, timeoutMs, appView: userFeedAppView({ pubkey, until, limit, offset }) },
+        pageFromEventNodes
       );
-      return mapGraphqlFeed(data.events?.nodes ?? [], {
+      return mapNaggFeedPage(page, {
         includeNote: (event) => event.pubkey === pubkey && isRootNote(event),
         includeRepost: (event) => event.pubkey === pubkey,
         extraProfile: authorName
@@ -1681,7 +1829,7 @@ export function createNaggFeedClient(): FeedClient {
         return mapGraphqlFeed([], { includeNote: () => false, includeRepost: () => false });
       }
       const pubkeySet = new Set(pubkeys);
-      const data = await postGraphql<GraphqlFeedData>(
+      const page = await fetchNaggFeedPage(
         FEED_QUERY,
         {
           input: {
@@ -1693,9 +1841,10 @@ export function createNaggFeedClient(): FeedClient {
           },
         },
         refresh,
-        { signal, timeoutMs }
+        { signal, timeoutMs, appView: followsFeedAppView({ pubkeys, until, limit, offset }) },
+        pageFromEventNodes
       );
-      return mapGraphqlFeed(data.events?.nodes ?? [], {
+      return mapNaggFeedPage(page, {
         includeNote: (event) => pubkeySet.has(event.pubkey) && isRootNote(event),
         includeRepost: (event) => pubkeySet.has(event.pubkey),
       });
@@ -1838,6 +1987,30 @@ export function createNaggFeedClient(): FeedClient {
       timeoutMs,
     }: ThreadRequest): Promise<ThreadResult> {
       const startedAt = Date.now();
+      if (backendConfig.nostrFeedAppView) {
+        // REST thread: a single normalized `{ root, events, ... }` payload built
+        // into the same `ThreadResult` buckets as the GraphQL path.
+        const result = await postGraphql<NaggThreadAppViewResult>(
+          THREAD_NEW_QUERY,
+          { id: eventId, limit, offset },
+          false,
+          { signal, timeoutMs, appView: threadAppView({ id: eventId, limit }) }
+        );
+        const threadResult = threadResultFromAppView(eventId, limit, result, seed);
+        feedLog.info('thread.nagg.appview.result', {
+          eventId,
+          sort,
+          limit,
+          offset,
+          durationMs: Date.now() - startedAt,
+          seedEvents: seed?.allEvents.size ?? 0,
+          allEvents: threadResult.allEvents.size,
+          renderedReplies: threadResult.thread.replies.length,
+          loadedReplyCount: threadResult.loadedReplyCount,
+          hasMoreReplies: threadResult.hasMoreReplies,
+        });
+        return threadResult;
+      }
       const rank = threadReplyRankInput(sort, viewerPubkey);
       const isRelevantSort = sort === 'relevant' && !!rank;
       const candidateLimit = threadRankCandidateLimit(limit, offset);

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@scure/bip39": "^1.2.2",
     "@sovranbitcoin/coco-cashu-plugin-p2pk-import": "^0.1.0",
     "@sovranbitcoin/colada": "^0.1.0",
-    "@sovranbitcoin/nagg-ts": "^0.1.0",
+    "@sovranbitcoin/nagg-ts": "^0.2.0",
     "@sovranbitcoin/schemas": "^2.0.6",
     "bitchat-module": "file:./modules/bitchat-module",
     "buffer": "^6.0.3",

--- a/shared/config/backend.ts
+++ b/shared/config/backend.ts
@@ -26,6 +26,10 @@ const BackendEnv = z.object({
   // Flip the contacts/DM-list fetch from GraphQL `dmEnvelopes` to the dedicated
   // REST app-view `/nostr/dm/envelopes` once it's deployed. Defaults to GraphQL.
   EXPO_PUBLIC_NOSTR_DM_APPVIEW: z.preprocess(emptyStringToUndefined, z.string().optional()),
+  // Flip the feed / thread / notifications fetches from GraphQL to nagg's REST
+  // app-view (`/nostr/feed*`, `/nostr/thread`). Defaults to GraphQL; opt in only
+  // after device testing the REST routes.
+  EXPO_PUBLIC_NOSTR_FEED_APPVIEW: z.preprocess(emptyStringToUndefined, z.string().optional()),
 });
 
 type BackendEnvInput = Partial<Record<keyof z.input<typeof BackendEnv>, string | undefined>>;
@@ -37,6 +41,8 @@ type BackendConfig = {
   nostrGraphqlEndpoint: string;
   /** Prefer the REST app-view `/nostr/dm/envelopes` for the contacts/DM list. */
   nostrDmAppView: boolean;
+  /** Route feed / thread / notifications fetches through nagg's REST app-view. */
+  nostrFeedAppView: boolean;
 };
 
 function readBackendEnv(): BackendEnvInput {
@@ -47,6 +53,7 @@ function readBackendEnv(): BackendEnvInput {
     EXPO_PUBLIC_SCORE_API_BASE_URL: process.env.EXPO_PUBLIC_SCORE_API_BASE_URL,
     EXPO_PUBLIC_NOSTR_GRAPHQL_ENDPOINT: process.env.EXPO_PUBLIC_NOSTR_GRAPHQL_ENDPOINT,
     EXPO_PUBLIC_NOSTR_DM_APPVIEW: process.env.EXPO_PUBLIC_NOSTR_DM_APPVIEW,
+    EXPO_PUBLIC_NOSTR_FEED_APPVIEW: process.env.EXPO_PUBLIC_NOSTR_FEED_APPVIEW,
   };
 }
 
@@ -70,6 +77,7 @@ export function parseBackendConfig(env: BackendEnvInput = readBackendEnv()): Bac
     nostrGraphqlEndpoint:
       parsed.data.EXPO_PUBLIC_NOSTR_GRAPHQL_ENDPOINT ?? `${nostrAppViewBaseUrl}/graphql`,
     nostrDmAppView: parsed.data.EXPO_PUBLIC_NOSTR_DM_APPVIEW === 'true',
+    nostrFeedAppView: parsed.data.EXPO_PUBLIC_NOSTR_FEED_APPVIEW === 'true',
   };
 }
 


### PR DESCRIPTION
Phase 3 of the GraphQL→REST app-view migration (after Kelbie/nagg#3 REST endpoints + nagg-ts 0.2.0 bindings). Bumps `@sovranbitcoin/nagg-ts` to 0.2.0 (minimal lockfile diff — no native-dep churn) and routes feed views through nagg's optimized REST app-view, **behind `EXPO_PUBLIC_NOSTR_FEED_APPVIEW` which DEFAULTS OFF** — the merge is inert until enabled.

## Wired to REST (when flag on)
- **For You** + **Following Popular** ranked feeds → `rankedFeedAppView` (`POST /nostr/feed/ranked`) — same ranking as GraphQL (shared nagg fn).
- **Profile feed** → `userFeedAppView`; **posts-by-pubkeys** → `followsFeedAppView`; **thread** → `threadAppView`.
- A `fetchNaggFeedPage` seam yields the same `NaggFeedPage` regardless of transport, so `mapNaggFeedPage` downstream is unchanged.

## Left on GraphQL (REST can't faithfully reproduce — not forced, per guardrail)
- **Notifications** — REST rows lack the per-row reference sub-trees the mapper needs for `targetEvent`.
- **Following-recent / global feed** — rely on server-side kind:3 follow-list resolution; the REST follows-feed needs an explicit pubkey list.
- **enrich** — needs quoted + profiles + metrics together; the note-stats endpoint returns metrics only.

## Rollout
Default OFF. Enable `EXPO_PUBLIC_NOSTR_FEED_APPVIEW=true` and device-test the For You feed / profile / thread, then flip the default on in a follow-up. type-check + 50 backendConfig/feed tests pass; lint 0 new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)