### PR TITLE
chore(deps): align colada→0.1.1, dedupe nagg-ts to a single 0.3.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,7 @@
         "@scure/bip32": "^1.3.3",
         "@scure/bip39": "^1.2.2",
         "@sovranbitcoin/coco-cashu-plugin-p2pk-import": "^0.1.0",
-        "@sovranbitcoin/colada": "^0.1.0",
+        "@sovranbitcoin/colada": "^0.1.1",
         "@sovranbitcoin/nagg-ts": "^0.3.0",
         "@sovranbitcoin/schemas": "^2.0.6",
         "bitchat-module": "file:./modules/bitchat-module",
@@ -1091,7 +1091,7 @@
 
     "@sovranbitcoin/coco-cashu-plugin-p2pk-import": ["@sovranbitcoin/coco-cashu-plugin-p2pk-import@0.1.0", "https://npm.pkg.github.com/download/@sovranbitcoin/coco-cashu-plugin-p2pk-import/0.1.0/3f7be1c41a6ed5a327559cba0b915aa0e84fd697", { "dependencies": { "@noble/hashes": "^2.0.1", "nostr-tools": "^2.0.0" }, "peerDependencies": { "@cashu/coco-core": "^1.0.1" } }, "sha512-nC5/13xmdsHTLCFMjtu18CqUmbQtXp1kUAGFr9Jmx6fugrCgpL+Bfxo4GEKMrtfJ27oIjbCDXMdTgFCfAVO2rw=="],
 
-    "@sovranbitcoin/colada": ["@sovranbitcoin/colada@0.1.0", "https://npm.pkg.github.com/download/@sovranbitcoin/colada/0.1.0/6a8af1927c550cb6ad10b4078b7a1e5758f86566", { "dependencies": { "@cashu/cashu-ts": "3.5.0", "@gandlaf21/bolt11-decode": "^3.1.1", "@scure/bip39": "2.0.1", "@sovranbitcoin/nagg-ts": "^0.1.0", "@sovranbitcoin/schemas": "^2.0.6", "neverthrow": "^8.2.0", "nostr-tools": "^2.0.0", "zod": "^4.3.6" }, "peerDependencies": { "@cashu/coco-core": "^1.0.1", "react": ">=18.0.0" } }, "sha512-8fSTAUmk2TnJbECYgicRPaQ+4vi+pmPuZqgjFSXTu9hK4JXu6wPC1T8B5eEPEt/JiHlvAIIpkCoNQI0tgbSrKQ=="],
+    "@sovranbitcoin/colada": ["@sovranbitcoin/colada@0.1.1", "https://npm.pkg.github.com/download/@sovranbitcoin/colada/0.1.1/77356d300e8a6fbc23d05cd77e41dd9805aa6b3d", { "dependencies": { "@cashu/cashu-ts": "3.5.0", "@gandlaf21/bolt11-decode": "^3.1.1", "@scure/bip39": "2.0.1", "@sovranbitcoin/nagg-ts": "^0.3.0", "@sovranbitcoin/schemas": "^2.0.6", "neverthrow": "^8.2.0", "nostr-tools": "^2.0.0", "zod": "^4.3.6" }, "peerDependencies": { "@cashu/coco-core": "^1.0.1", "react": ">=18.0.0" } }, "sha512-kjBbmm3w15e805cGl/hw0pM3dfwkG4ndd9l5XWdDxATYK5ETHbyBRnw9EtYLO2U31W32vfdjs8KpUAJ7QI91fA=="],
 
     "@sovranbitcoin/nagg-ts": ["@sovranbitcoin/nagg-ts@0.3.0", "https://npm.pkg.github.com/download/@sovranbitcoin/nagg-ts/0.3.0/428597f8b5b771724862fb57d1fab068f7287bae", { "dependencies": { "neverthrow": "^8.2.0" }, "peerDependencies": { "@sovranbitcoin/schemas": "*", "zod": "^4.0.0" } }, "sha512-8qjNlHYXO64kglWpGwDTugwQbJKdNjX4ay8UCABnw5bN/p49VIKnjQ0gc5GdBta+w/ZNhYOJHv7GRENONOaGTg=="],
 
@@ -3496,8 +3496,6 @@
     "@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
     "@sovranbitcoin/colada/@scure/bip39": ["@scure/bip39@2.0.1", "", { "dependencies": { "@noble/hashes": "2.0.1", "@scure/base": "2.0.0" } }, "sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg=="],
-
-    "@sovranbitcoin/colada/@sovranbitcoin/nagg-ts": ["@sovranbitcoin/nagg-ts@0.1.0", "https://npm.pkg.github.com/download/@sovranbitcoin/nagg-ts/0.1.0/dba22d9aa9f1c27394c0685ea51ad15f82f8b975", { "dependencies": { "neverthrow": "^8.2.0" }, "peerDependencies": { "@sovranbitcoin/schemas": "*", "zod": "^4.0.0" } }, "sha512-FBCzkefPYskeRPdakeRWCEf+F22CpGxLSgDR2oMnb1X9LitqadkOAQ9X60q85ZxGPCNGwzWjQQrk3QJQTF3BEA=="],
 
     "@tailwindcss/node/lightningcss": ["lightningcss@1.31.1", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.31.1", "lightningcss-darwin-arm64": "1.31.1", "lightningcss-darwin-x64": "1.31.1", "lightningcss-freebsd-x64": "1.31.1", "lightningcss-linux-arm-gnueabihf": "1.31.1", "lightningcss-linux-arm64-gnu": "1.31.1", "lightningcss-linux-arm64-musl": "1.31.1", "lightningcss-linux-x64-gnu": "1.31.1", "lightningcss-linux-x64-musl": "1.31.1", "lightningcss-win32-arm64-msvc": "1.31.1", "lightningcss-win32-x64-msvc": "1.31.1" } }, "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ=="],
 

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@scure/bip32": "^1.3.3",
     "@scure/bip39": "^1.2.2",
     "@sovranbitcoin/coco-cashu-plugin-p2pk-import": "^0.1.0",
-    "@sovranbitcoin/colada": "^0.1.0",
+    "@sovranbitcoin/colada": "^0.1.1",
     "@sovranbitcoin/nagg-ts": "^0.3.0",
     "@sovranbitcoin/schemas": "^2.0.6",
     "bitchat-module": "file:./modules/bitchat-module",


### PR DESCRIPTION
Final workspace alignment for the unified app-view release. Bumps `@sovranbitcoin/colada` to **0.1.1** (which pins nagg-ts ^0.3.0), so the dependency tree resolves to a **single `@sovranbitcoin/nagg-ts@0.3.0`** — the old nested `colada→nagg-ts@0.1.0` is gone. type-check + lint(0) + tests green; lockfile diff is just the colada bump + nagg-ts dedup, no native-dep churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)