### PR TITLE
fix(feed): empty feeds/notifications — send the query's operation name on the GraphQL path (+ diagnostics)

### DIFF
--- a/__tests__/naggFeedClientTransport.test.ts
+++ b/__tests__/naggFeedClientTransport.test.ts
@@ -167,6 +167,25 @@ describe('naggFeedClient transport equivalence', () => {
     expect(appViewResult.paginationOffset).toBe(graphqlResult.paginationOffset);
   });
 
+  it('sends the query document operation name on the GraphQL path, not the app-view binding label', async () => {
+    // Regression: runNaggQuery used to send the app-view binding's REST label
+    // ('UserFeed' / 'RankedFeed' / 'Notifications') as the GraphQL operationName.
+    // nagg rejects that with "Unknown operation named …", silently EMPTYING the
+    // feed. The GraphQL request must use the query document's operation name.
+    setupEnv(); // flags off -> GraphQL transport, with the userFeedAppView binding present
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ data: { events: { nodes: [rootGql], pageInfo: { hasNextPage: false } } } })
+    );
+    await loadClient().getUserFeed({ pubkey: PAD('alice') });
+
+    const requestInit = mockFetch.mock.calls[0][1] as { body?: string };
+    const body = JSON.parse(requestInit.body ?? '{}') as { query?: string; operationName?: string };
+    expect(body.operationName).toMatch(/^NaggGraphql/);
+    expect(body.operationName).not.toBe('UserFeed');
+    // …and the document actually defines that operation (so nagg can run it).
+    expect(body.query).toContain(`query ${body.operationName}`);
+  });
+
   // Thread intentionally has NO dual-transport equivalence case: it is the
   // documented exception to "prefer app-view" and stays GraphQL-only, because
   // nagg's REST `/nostr/thread` cannot reproduce the viewer-specific relevance

--- a/features/feed/components/HomeFeed.tsx
+++ b/features/feed/components/HomeFeed.tsx
@@ -22,7 +22,7 @@ import { Spacer } from '@/shared/ui/primitives/View/Spacer';
 import Icon from 'assets/icons';
 import opacity from 'hex-color-opacity';
 import { useLatestRef } from '@/shared/hooks/useLatestRef';
-import { log, Log } from '@/shared/lib/logger';
+import { log, Log, feedLog } from '@/shared/lib/logger';
 import {
   LegendList,
   type LegendListRenderItemProps,
@@ -261,6 +261,12 @@ export function HomeFeed({ activeFilter }: HomeFeedProps) {
     async (specIndex: number, isRefresh = false) => {
       const spec = feedSpecs[specIndex]?.spec;
       if (!spec) return;
+      feedLog.info('feed.ui.load', {
+        spec: feedSpecs[specIndex]?.name,
+        specIndex,
+        isRefresh,
+        hasViewer: !!userPubkey,
+      });
       const cacheKey = feedPageKey(spec, userPubkey);
 
       // Applies a page-0 result to state + pagination refs. Used both for the
@@ -343,6 +349,12 @@ export function HomeFeed({ activeFilter }: HomeFeedProps) {
 
         if (!isActiveLoad(requestId)) return;
 
+        feedLog.info('feed.ui.fetch.applied', {
+          spec: feedSpecs[specIndex]?.name,
+          items: phase1.orderedFeedItems.length,
+          paginationUntil: phase1.paginationUntil,
+          isRefresh,
+        });
         applyPhase1(phase1);
         feedPageCache.setEntry(cacheKey, phase1, { viewerKey: userPubkey || '' });
         feedPageCache.markTouched(cacheKey);
@@ -718,6 +730,20 @@ export function HomeFeed({ activeFilter }: HomeFeedProps) {
   useEffect(() => {
     feedRowsRef.current = feedRows;
   }, [feedRows]);
+
+  // Render boundary: how many feed items became rendered rows, and whether the
+  // screen is currently showing the empty state. `feedItems > 0 && rows === 0`
+  // means a render-stage drop; `empty: true` with items 0 after load means the
+  // data layer returned nothing (cross-check feed.nagg.* logs above).
+  useEffect(() => {
+    feedLog.info('feed.ui.render', {
+      spec: feedSpecs[activeSpecIndex]?.name,
+      feedItems: feedItems.length,
+      rows: feedRows.length,
+      isLoading,
+      empty: !isLoading && feedRows.length === 0,
+    });
+  }, [feedItems.length, feedRows.length, isLoading, activeSpecIndex, feedSpecs]);
 
   const renderFeedItem = useCallback(
     ({ item: row, index }: LegendListRenderItemProps<FeedRow, string | undefined>) => {

--- a/features/feed/data/naggFeedClient.ts
+++ b/features/feed/data/naggFeedClient.ts
@@ -820,10 +820,20 @@ async function runNaggQuery<TSchema extends z.ZodType>(
   refresh: boolean | undefined,
   options: NaggQueryOptions<TSchema>
 ): Promise<z.infer<TSchema>> {
-  const operationName = options.appView?.operationName ?? graphqlOperationName(query);
   // App-view only when explicitly selected AND a binding exists; otherwise the
   // nagg client falls through to GraphQL (so the switch degrades per-query).
   const transport = options.transport === 'appview' && options.appView ? 'appview' : 'graphql';
+  // The GraphQL request's operationName MUST match the query document's operation
+  // (e.g. `NaggGraphqlRankedFeed`). The app-view binding's label ('RankedFeed',
+  // 'Notifications', …) is a REST identifier, NOT a GraphQL operation name —
+  // sending it on the GraphQL path makes nagg reject the request with
+  // "Unknown operation named RankedFeed", which silently empties the feed. So
+  // only use the binding label on the app-view path; on GraphQL, always derive
+  // the operation name from the query document.
+  const operationName =
+    transport === 'appview'
+      ? (options.appView?.operationName ?? graphqlOperationName(query))
+      : graphqlOperationName(query);
   const startedAt = Date.now();
   const requestFields = {
     operationName,

--- a/features/feed/data/naggFeedClient.ts
+++ b/features/feed/data/naggFeedClient.ts
@@ -834,6 +834,7 @@ async function runNaggQuery<TSchema extends z.ZodType>(
     ...endpointLogFields(),
   };
 
+  logBackendConfigOnce();
   apiLog.info('nagg.graphql.request.start', requestFields);
 
   const client = createNaggClient({
@@ -868,6 +869,24 @@ async function runNaggQuery<TSchema extends z.ZodType>(
         ...requestFields,
         durationMs,
       });
+    } else if (error.type === 'schema') {
+      // The canonical shape failed `dataSchema.safeParse` — this is the prime
+      // suspect for an EMPTY feed/notifications: the request succeeded but the
+      // client rejected the payload, so nothing reaches the UI. Log the exact
+      // failing field(s) so we can see which part of the live data the schema
+      // rejected.
+      apiLog.error('nagg.graphql.request.schema_error', {
+        ...requestFields,
+        durationMs,
+        issueCount: error.issues?.length ?? 0,
+        issues: (error.issues ?? []).slice(0, 10).map((issue) => ({
+          path: Array.isArray(issue.path)
+            ? issue.path.join('.')
+            : String((issue as { path?: unknown }).path ?? ''),
+          code: issue.code,
+          message: issue.message,
+        })),
+      });
     } else {
       const thrown = errorFromNaggError(error);
       const params = {
@@ -888,8 +907,41 @@ async function runNaggQuery<TSchema extends z.ZodType>(
     ...requestFields,
     durationMs,
     dataKeys: dataKeysOf(result.value),
+    resultCount: countCanonical(result.value),
   });
   return result.value;
+}
+
+// Logs the resolved backend config once per session: the endpoint + which
+// transport each view uses (GraphQL vs REST app-view). If feeds are empty
+// because a flag is unexpectedly enabling the REST path, this surfaces it.
+let loggedBackendConfig = false;
+function logBackendConfigOnce(): void {
+  if (loggedBackendConfig) return;
+  loggedBackendConfig = true;
+  apiLog.info('nagg.backend.config', {
+    graphqlEndpoint: backendConfig.nostrGraphqlEndpoint,
+    appViewBaseUrl: backendConfig.nostrAppViewBaseUrl,
+    feedAppView: backendConfig.nostrFeedAppView,
+    notificationsAppView: backendConfig.nostrNotificationsAppView,
+    dmAppView: backendConfig.nostrDmAppView,
+  });
+}
+
+// Counts the rows in a parsed canonical payload (feed items / notification nodes
+// / thread events) for log diagnostics — distinguishes "request returned data"
+// from "request returned an empty page".
+function countCanonical(value: unknown): number {
+  if (!value || typeof value !== 'object') return 0;
+  const v = value as {
+    items?: unknown[];
+    notifications?: { nodes?: unknown[] };
+    events?: unknown[];
+  };
+  if (Array.isArray(v.items)) return v.items.length;
+  if (v.notifications && Array.isArray(v.notifications.nodes)) return v.notifications.nodes.length;
+  if (Array.isArray(v.events)) return v.events.length;
+  return 0;
 }
 
 /**
@@ -1379,9 +1431,24 @@ type NaggFeedPageOf = NaggFeedPage<FeedEvent, ProfileInfo>;
  * connection into the canonical {@link NaggFeedPage}. Offset/until pagination is
  * the page's min `created_at` (set by `graphqlNodesToNaggPage`).
  */
+// Logs the GraphQL distiller's node→item conversion. A large drop (many nodes
+// in, few/zero items out) means the distiller is discarding the response — a key
+// EMPTY-feed signal, distinct from "no nodes returned" or "schema rejected".
+function logDistill(distiller: string, nodesIn: number, itemsOut: number): void {
+  feedLog.info('feed.nagg.distill', {
+    distiller,
+    nodesIn,
+    itemsOut,
+    dropped: nodesIn - itemsOut,
+  });
+}
+
 function eventsFeedToPage(data: unknown): NaggFeedPageOf {
   const feed = data as GraphqlFeedData;
-  return graphqlNodesToNaggPage(feed.events?.nodes ?? []) as NaggFeedPageOf;
+  const nodes = feed.events?.nodes ?? [];
+  const page = graphqlNodesToNaggPage(nodes) as NaggFeedPageOf;
+  logDistill('events', nodes.length, page.items.length);
+  return page;
 }
 
 /**
@@ -1396,13 +1463,17 @@ function rankedFeedToPage(data: unknown): NaggFeedPageOf {
   if (feed.rankedEvents) {
     const nodes = feed.rankedEvents.nodes ?? [];
     const page = graphqlNodesToNaggPage(nodes) as NaggFeedPageOf;
+    logDistill('ranked', nodes.length, page.items.length);
     return {
       ...page,
       paginationUntil: nodes.length > 0 ? 1 : 0,
       paginationOffset: nodes.length,
     };
   }
-  return graphqlNodesToNaggPage(feed.events?.nodes ?? []) as NaggFeedPageOf;
+  const nodes = feed.events?.nodes ?? [];
+  const page = graphqlNodesToNaggPage(nodes) as NaggFeedPageOf;
+  logDistill('ranked-events-fallback', nodes.length, page.items.length);
+  return page;
 }
 
 /**
@@ -1412,13 +1483,16 @@ function rankedFeedToPage(data: unknown): NaggFeedPageOf {
  */
 function followingRepliesToPage(data: unknown): NaggFeedPageOf {
   const feed = data as GraphqlFeedData;
-  return graphqlNodesToNaggPage(feed.events?.nodes ?? [], {
+  const nodes = feed.events?.nodes ?? [];
+  const page = graphqlNodesToNaggPage(nodes, {
     parentForNode: (node) =>
       node.rootContext?.nodes?.[0] ??
       node.parentReplyRefs?.nodes?.[0] ??
       node.parentRootRefs?.nodes?.[0] ??
       node.eventRefs?.nodes?.[0],
   }) as NaggFeedPageOf;
+  logDistill('following-replies', nodes.length, page.items.length);
+  return page;
 }
 
 /**
@@ -1676,6 +1750,7 @@ function notificationsToPage(data: unknown): NaggNotificationsPage {
       ...target,
     });
   }
+  logDistill('notifications', sourceNodes.length, nodes.length);
   return {
     notifications: {
       nodes,
@@ -2093,7 +2168,19 @@ export function createNaggFeedClient(): FeedClient {
         signal,
         timeoutMs,
       });
-      return notificationsResultFromPage(page);
+      const result = notificationsResultFromPage(page);
+      feedLog.info('feed.notifications.fetch.done', {
+        transport: backendConfig.nostrNotificationsAppView ? 'appview' : 'graphql',
+        tab,
+        policy,
+        replyScope,
+        pageNodes: page.notifications.nodes.length,
+        results: result.notifications.length,
+        metrics: result.metricsMap.size,
+        profiles: result.profilesMap.size,
+        paginationUntil: result.paginationUntil,
+      });
+      return result;
     },
 
     async getThread({

--- a/features/feed/screens/NotificationsScreen.tsx
+++ b/features/feed/screens/NotificationsScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FlatList, RefreshControl, StyleSheet } from 'react-native';
 import { useFocusEffect } from 'expo-router';
 import { guardedRouter as router } from '@/shared/hooks/useGuardedRouter';
@@ -50,7 +50,7 @@ import { VStack } from '@/shared/ui/primitives/View/VStack';
 // hits the server. ALL/MENTIONS are the server-backed tabs.
 type NotificationTab = FeedNotificationTab | 'APP';
 
-const NOTIFICATION_TABS: Array<{ id: NotificationTab; label: string }> = [
+const NOTIFICATION_TABS: { id: NotificationTab; label: string }[] = [
   { id: 'ALL', label: 'All' },
   { id: 'MENTIONS', label: 'Mentions' },
   { id: 'APP', label: 'App' },
@@ -124,6 +124,11 @@ export function NotificationsScreen() {
     paginationUntilRef.current = page?.paginationUntil ?? 0;
     hasMoreRef.current =
       !!page && page.paginationUntil > 0 && page.notifications.length >= NOTIFICATIONS_PAGE_SIZE;
+    feedLog.info('feed.notifications.ui.applied', {
+      notifications: page?.notifications.length ?? 0,
+      hasPage: !!page,
+      paginationUntil: page?.paginationUntil ?? 0,
+    });
     setResult(page);
   }, []);
 
@@ -355,6 +360,18 @@ export function NotificationsScreen() {
     }
     return buildNotificationListItems(notifications);
   }, [notifications, activeTab, seedCreatedAt, termsDate]);
+
+  // Render boundary for notifications: result rows → rendered list items, and
+  // whether the screen is empty. Cross-check with feed.notifications.fetch.done
+  // (data layer) to localize an empty notifications screen.
+  useEffect(() => {
+    feedLog.info('feed.notifications.ui.render', {
+      tab: activeTab,
+      notifications: notifications.length,
+      items: notificationItems.length,
+      empty: notificationItems.length === 0,
+    });
+  }, [notifications.length, notificationItems.length, activeTab]);
 
   return (
     <Screen name="NotificationsScreen" scroll="custom" bgColor={surface}>


### PR DESCRIPTION
Adds stage-by-stage logging across the **feed + notifications** pipeline so a captured session log shows exactly where data drops to empty. Every stage logs a count → binary-search the failure.

### Data layer (`naggFeedClient.ts`)
- **`nagg.backend.config`** (once/session): endpoint + which transport each view uses (GraphQL vs REST app-view) — catches a flag unexpectedly routing feeds to REST.
- **`nagg.graphql.request.schema_error`** (new error branch): the payload failed `Nagg*Schema.safeParse` — logs the **exact failing field(s)** (zod issues). *Prime suspect for an empty feed:* request succeeds, client rejects the payload.
- **`nagg.graphql.request.done`**: now carries `resultCount`.
- **`feed.nagg.distill`** (new): per-distiller `nodesIn → itemsOut (dropped)` — catches the distiller discarding the response.
- **`feed.notifications.fetch.done`** (new): page nodes → result count + transport.

### UI layer
- **HomeFeed:** `feed.ui.load`, `feed.ui.fetch.applied`, `feed.ui.render` (feedItems → rendered rows + `empty` flag).
- **NotificationsScreen:** `feed.notifications.ui.applied`, `feed.notifications.ui.render` (rows → list items + `empty` flag).

### How to read it
For an empty feed, the missing/zero stage localizes the cause:
- no `request.start` → UI never fetched (spec/cache issue)
- `graphql_error` / `schema_error` → server rejected query / client rejected payload (with the field)
- `distill dropped` → distiller discarded nodes
- `page.done items:0` → genuinely empty page (cross-check railway)
- `ui.render empty:true` with `feedItems>0` → render-stage drop

All in the existing `apiLog`/`feedLog` namespaces, so `log-doctor` ingests them directly. type-check + lint + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)