### PR TITLE
fix(ci): drop vestigial coco/colada/schemas source checkouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,6 @@ on:
 
 env:
   APP_DIR: sovran-app
-  COCO_DIR: coco
-  COCO_REF: feat/onchain
-  COLADA_DIR: colada
-  SCHEMAS_DIR: sovran-schemas
 
 jobs:
   code-quality:
@@ -25,44 +21,19 @@ jobs:
         with:
           path: ${{ env.APP_DIR }}
 
-      - name: Checkout Coco onchain PR
-        uses: actions/checkout@v4
-        with:
-          repository: cashubtc/coco
-          ref: ${{ env.COCO_REF }}
-          path: ${{ env.COCO_DIR }}
-
-      - name: Checkout Sovran schemas
-        uses: actions/checkout@v4
-        with:
-          repository: SovranBitcoin/sovran-schemas
-          ref: main
-          path: ${{ env.SCHEMAS_DIR }}
-          token: ${{ secrets.SOVRAN_CI_TOKEN || secrets.GITHUB_TOKEN }}
-
-      - name: Checkout Colada
-        uses: actions/checkout@v4
-        with:
-          repository: Kelbie/colada
-          ref: main
-          path: ${{ env.COLADA_DIR }}
-          token: ${{ secrets.SOVRAN_CI_TOKEN || secrets.GITHUB_TOKEN }}
-
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: ${{ env.APP_DIR }}/package.json
 
-      - name: Build Coco packages
-        working-directory: ${{ env.COCO_DIR }}
-        run: |
-          bun install --no-save
-          bun run build
-
+      # The gates run entirely against published packages — @cashu/coco-* from
+      # npm, @sovranbitcoin/* from GitHub Packages — resolved by the lockfile.
+      # SOVRAN_CI_TOKEN carries cross-repo GitHub Packages read; GITHUB_TOKEN is
+      # the fallback. (No coco/colada/schemas source checkout: nothing links it.)
       - name: Install dependencies
         working-directory: ${{ env.APP_DIR }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SOVRAN_CI_TOKEN || secrets.GITHUB_TOKEN }}
         run: bun install --frozen-lockfile
 
       - name: Lint
@@ -108,44 +79,15 @@ jobs:
           fetch-depth: 0
           path: ${{ env.APP_DIR }}
 
-      - name: Checkout Coco onchain PR
-        uses: actions/checkout@v4
-        with:
-          repository: cashubtc/coco
-          ref: ${{ env.COCO_REF }}
-          path: ${{ env.COCO_DIR }}
-
-      - name: Checkout Sovran schemas
-        uses: actions/checkout@v4
-        with:
-          repository: SovranBitcoin/sovran-schemas
-          ref: main
-          path: ${{ env.SCHEMAS_DIR }}
-          token: ${{ secrets.SOVRAN_CI_TOKEN || secrets.GITHUB_TOKEN }}
-
-      - name: Checkout Colada
-        uses: actions/checkout@v4
-        with:
-          repository: Kelbie/colada
-          ref: main
-          path: ${{ env.COLADA_DIR }}
-          token: ${{ secrets.SOVRAN_CI_TOKEN || secrets.GITHUB_TOKEN }}
-
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: ${{ env.APP_DIR }}/package.json
 
-      - name: Build Coco packages
-        working-directory: ${{ env.COCO_DIR }}
-        run: |
-          bun install --no-save
-          bun run build
-
       - name: Install dependencies
         working-directory: ${{ env.APP_DIR }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SOVRAN_CI_TOKEN || secrets.GITHUB_TOKEN }}
         run: bun install --frozen-lockfile
 
       - name: Run analyze-structure


### PR DESCRIPTION
## Why CI was red
Every run failed in ~10s at the **3rd step, "Checkout Coco onchain PR"** — `cashubtc/coco` ref `feat/onchain` no longer exists — aborting before any gate ran (Lint/Type Check/Prettier/Knip/Test all skipped).

## Why the checkouts are dead weight
The app consumes **published** packages — `@cashu/coco-*` from npm, `@sovranbitcoin/*` from GitHub Packages — resolved by the lockfile via `bun install --frozen-lockfile`. Nothing links the `coco/`/`colada/`/`sovran-schemas/` source checkouts (no `file:`/`link:` in package.json; `tsconfig` excludes `coco/**`), so the gates never used them. They're leftovers from when the app was built against unreleased local builds.

## Change
- Remove all three source checkouts + "Build Coco packages" from both jobs.
- Point `bun install` at `SOVRAN_CI_TOKEN` (falls back to `GITHUB_TOKEN`) for cross-repo GitHub Packages read of `@sovranbitcoin/*` — these now resolve from the registry (after the colada→published switch in #199), which the default `GITHUB_TOKEN` may 403 on.

CI is now: **checkout app → setup bun → install → gates.** Gates verified green locally (type-check, lint, prettier, knip, **516 tests**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)