### PR TITLE
chore(ci): bump checkout@v6 + github-script@v9 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       packages: read
     steps:
       - name: Checkout app
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ env.APP_DIR }}
 
@@ -72,7 +72,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout app
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Full history needed for `--history` (churn × complexity,
           # temporal coupling, stale-file signals).
@@ -99,7 +99,7 @@ jobs:
 
       - name: Post structural-health comment on PR
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
`actions/checkout@v4` and `actions/github-script@v7` run on **Node 20**, which GitHub force-retires on **2026-06-16** — after that the runner forces Node 24 and Node-20 actions may break. Bumps both to their Node-24-native majors so CI keeps passing past the deadline. `setup-bun@v2` wasn't flagged (stays).

Validated by this PR's own run — both `code-quality` and `structural-health` (the latter exercises `github-script@v9`) must be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)