### PR TITLE
perf(modals): cut JS-thread work that gates native-stack modal opens

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -249,81 +249,101 @@ function ProfileMetadataSync() {
   return null;
 }
 
+// Stable, memoized modal close button. Defined at module scope (not inside
+// RootLayoutContent) so its component identity never changes between renders —
+// otherwise React Navigation tears down and remounts the header's left button
+// (re-parsing its SVG icon) on every root re-render.
+const CloseButton = React.memo(function CloseButton({ foreground }: { foreground: string }) {
+  return (
+    <Pressable onPress={() => router.back()} style={{ padding: 8 }}>
+      <Icon name="material-symbols:close-rounded" size={24} color={foreground} />
+    </Pressable>
+  );
+});
+
 // Inner component that can access theme context
 function RootLayoutContent() {
   const { currentTheme } = useTheme();
   const [foreground, background] = useThemeColor(['foreground', 'background'] as const);
   const { keys: nostrKeys } = useNostrKeysContext();
 
-  // Close button component for modal presentations
-  const CloseButton = () => (
-    <Pressable onPress={() => router.back()} style={{ padding: 8 }}>
-      <Icon name="material-symbols:close-rounded" size={24} color={foreground} />
-    </Pressable>
+  // Screen options builder. Memoized so unrelated root re-renders don't rebuild
+  // every modal screen's options object on each render.
+  const getScreenOptions = useCallback(
+    (screen: ModalConfig) => {
+      // Base header styling options from shared config
+      const backgroundColor = nostrKeys?.pubkey ? background : 'transparent';
+      const baseHeaderOptions = getBaseModalHeaderOptions(foreground, backgroundColor);
+
+      // Check if this is a modal/formSheet presentation
+      const isModalPresentation =
+        screen.options?.presentation === 'modal' || screen.options?.presentation === 'formSheet';
+
+      // If headerShown is explicitly false, the nested layout handles headers
+      // Don't add any header-related options
+      if (screen.options?.headerShown === false) {
+        return {
+          ...screen.options,
+          // Ensure no header-related options leak through
+          headerBackButtonDisplayMode: 'minimal' as const,
+        };
+      }
+
+      // If the screen has explicit options, merge with base options
+      if (screen.options) {
+        // If headerTransparent is true, use transparent background to avoid opaque header
+        const headerStyleOverride = screen.options.headerTransparent
+          ? {
+              headerStyle: { backgroundColor: 'transparent' },
+              headerLargeStyle: { backgroundColor: 'transparent' },
+            }
+          : {};
+
+        return {
+          ...baseHeaderOptions,
+          ...screen.options,
+          headerShown: true,
+          ...headerStyleOverride,
+          ...(screen.title !== undefined ? { headerTitle: screen.title } : {}),
+          // Add close button for modal presentations (only when header is shown)
+          ...(isModalPresentation
+            ? { headerLeft: () => <CloseButton foreground={foreground} /> }
+            : {}),
+        };
+      }
+
+      // Default options for screens with titles (non-modal screens)
+      if (screen.title !== undefined) {
+        return {
+          ...baseHeaderOptions,
+          headerShown: true,
+          headerTitle: screen.title,
+          headerBlurEffect: 'regular' as const,
+          headerTransparent: true,
+          headerStyle: { backgroundColor: 'transparent' },
+          headerLargeStyle: { backgroundColor: 'transparent' },
+          headerBackTitle: 'Back',
+        };
+      }
+
+      // Default: no special options
+      return {};
+    },
+    [foreground, background, nostrKeys?.pubkey]
   );
-
-  // Screen options builder
-  const getScreenOptions = (screen: ModalConfig) => {
-    // Base header styling options from shared config
-    const backgroundColor = nostrKeys?.pubkey ? background : 'transparent';
-    const baseHeaderOptions = getBaseModalHeaderOptions(foreground, backgroundColor);
-
-    // Check if this is a modal/formSheet presentation
-    const isModalPresentation =
-      screen.options?.presentation === 'modal' || screen.options?.presentation === 'formSheet';
-
-    // If headerShown is explicitly false, the nested layout handles headers
-    // Don't add any header-related options
-    if (screen.options?.headerShown === false) {
-      return {
-        ...screen.options,
-        // Ensure no header-related options leak through
-        headerBackButtonDisplayMode: 'minimal' as const,
-      };
-    }
-
-    // If the screen has explicit options, merge with base options
-    if (screen.options) {
-      // If headerTransparent is true, use transparent background to avoid opaque header
-      const headerStyleOverride = screen.options.headerTransparent
-        ? {
-            headerStyle: { backgroundColor: 'transparent' },
-            headerLargeStyle: { backgroundColor: 'transparent' },
-          }
-        : {};
-
-      return {
-        ...baseHeaderOptions,
-        ...screen.options,
-        headerShown: true,
-        ...headerStyleOverride,
-        ...(screen.title !== undefined ? { headerTitle: screen.title } : {}),
-        // Add close button for modal presentations (only when header is shown)
-        ...(isModalPresentation ? { headerLeft: CloseButton } : {}),
-      };
-    }
-
-    // Default options for screens with titles (non-modal screens)
-    if (screen.title !== undefined) {
-      return {
-        ...baseHeaderOptions,
-        headerShown: true,
-        headerTitle: screen.title,
-        headerBlurEffect: 'regular' as const,
-        headerTransparent: true,
-        headerStyle: { backgroundColor: 'transparent' },
-        headerLargeStyle: { backgroundColor: 'transparent' },
-        headerBackTitle: 'Back',
-      };
-    }
-
-    // Default: no special options
-    return {};
-  };
 
   // For iOS 26+ with Liquid Glass, use transparent background to enable glass effects
   const { liquidGlass } = useCapabilities();
   const contentBackgroundColor = liquidGlass ? 'transparent' : background;
+
+  // Memoize the modal screen list so it isn't rebuilt on every root re-render.
+  const modalScreenElements = useMemo(
+    () =>
+      MODAL_SCREENS.map((screen) => (
+        <Stack.Screen key={screen.name} name={screen.name} options={getScreenOptions(screen)} />
+      )),
+    [getScreenOptions]
+  );
 
   return (
     <NavigationThemeProvider value={DarkTheme}>
@@ -339,10 +359,17 @@ function RootLayoutContent() {
       />
       <OfflineShell>
         <Stack
+          // NOTE: keyed on the theme so a theme/wallpaper change re-applies
+          // contentStyle/header colors. This remounts the navigator on theme
+          // switch (not on the modal-open hot path). Removing it needs on-device
+          // verification that native-stack re-applies colors to already-mounted
+          // screens — left in place until that's confirmed (see perf plan §4).
           key={currentTheme}
           screenOptions={{
             headerShown: false,
             gestureEnabled: true,
+            // Stop the covered drawer/tab tree from re-rendering under a modal.
+            freezeOnBlur: true,
             contentStyle: {
               backgroundColor: contentBackgroundColor,
             },
@@ -351,9 +378,7 @@ function RootLayoutContent() {
           <Stack.Screen name="(drawer)" options={{ headerShown: false }} />
 
           {/* All modal screens configured from MODAL_SCREENS */}
-          {MODAL_SCREENS.map((screen) => (
-            <Stack.Screen key={screen.name} name={screen.name} options={getScreenOptions(screen)} />
-          ))}
+          {modalScreenElements}
         </Stack>
       </OfflineShell>
     </NavigationThemeProvider>

--- a/config/flowLayoutOptions.tsx
+++ b/config/flowLayoutOptions.tsx
@@ -5,6 +5,7 @@
  * (receive-flow, send-flow, mint-flow, transactions-flow) to ensure consistency.
  */
 
+import { memo } from 'react';
 import type { NativeStackNavigationOptions } from '@react-navigation/native-stack';
 import type { ParamListBase, NavigationProp } from '@react-navigation/native';
 import { router } from 'expo-router';
@@ -20,23 +21,27 @@ interface FlowColors {
  * Shared header button component for flow layouts.
  * Shows close button on first screen, back button on subsequent screens.
  */
-const FlowHeaderButton = ({
+// Memoized so re-rendering the navigation header (which happens on any root
+// re-render) doesn't re-parse the SVG icon unless isFirstScreen/foreground change.
+const FlowHeaderButton = memo(function FlowHeaderButton({
   isFirstScreen,
   foreground,
 }: {
   isFirstScreen: boolean;
   foreground: string;
-}) => (
-  <Pressable onPress={() => router.back()} style={{ padding: 8 }}>
-    <Icon
-      name={
-        isFirstScreen ? 'material-symbols:close-rounded' : 'material-symbols:arrow-back-rounded'
-      }
-      size={24}
-      color={foreground}
-    />
-  </Pressable>
-);
+}) {
+  return (
+    <Pressable onPress={() => router.back()} style={{ padding: 8 }}>
+      <Icon
+        name={
+          isFirstScreen ? 'material-symbols:close-rounded' : 'material-symbols:arrow-back-rounded'
+        }
+        size={24}
+        color={foreground}
+      />
+    </Pressable>
+  );
+});
 
 /**
  * Get the base screen options for flow layouts (used inside modal stacks).

--- a/features/mint/screens/MintAddScreen.tsx
+++ b/features/mint/screens/MintAddScreen.tsx
@@ -722,7 +722,10 @@ export function MintAddScreen() {
       scroll="custom"
       onHeaderHeightChange={setTotalHeaderHeight}
       footer={bottomButtons}
-      bgColor={surface}>
+      bgColor={surface}
+      // Renders an autoFocus mint-URL input; mount synchronously so the
+      // keyboard opens without racing the modal slide-in.
+      deferContent={false}>
       <Stack.Screen options={screenOptions} />
       <Spacer size={16} />
       {!showContent ? (

--- a/shared/hooks/useDeferredMount.ts
+++ b/shared/hooks/useDeferredMount.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import { InteractionManager } from 'react-native';
+
+/**
+ * Defer a screen's heavy content until just after its first commit.
+ *
+ * Native-stack modals gate their present/slide animation on the new screen's
+ * first rendered frame. Rendering the whole subtree synchronously on mount
+ * therefore stretches the tap → present delay — badly under Low Power Mode,
+ * where the JS thread is throttled. By returning `false` on the first commit
+ * and flipping to `true` after interactions, callers can render a cheap frame
+ * (themed background only) so the present starts immediately, then mount the
+ * real content while the modal slides in.
+ *
+ * In native-stack the opening transition isn't a JS InteractionManager handle,
+ * so `runAfterInteractions` fires on the next tick rather than after the slide
+ * completes — content fills in during the animation, not after it.
+ *
+ * @param enabled when false the hook is a no-op and returns `true` immediately
+ *   (use for screens that must render synchronously, e.g. auto-focus inputs).
+ */
+export function useDeferredMount(enabled = true): boolean {
+  const [ready, setReady] = useState(!enabled);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const task = InteractionManager.runAfterInteractions(() => setReady(true));
+    return () => task.cancel();
+  }, [enabled]);
+
+  return ready;
+}

--- a/shared/lib/loggerCore.ts
+++ b/shared/lib/loggerCore.ts
@@ -118,6 +118,13 @@ export interface Logger {
   fatal(event: string, params?: Record<string, unknown>): void;
   child(context: Record<string, unknown>): Logger;
   setLevel(level: LogLevel): void;
+  /**
+   * Cheap predicate for whether `level` would currently be emitted. Mirrors the
+   * short-circuit at the top of `emit` (SHOW_LOGS + enabled + severity), so hot
+   * callers can skip building expensive params — e.g. the `<Log>` UI wrapper's
+   * recursive tree walk — when logging is disabled. Dynamic: respects setLevel.
+   */
+  isLevelEnabled(level: LogLevel): boolean;
   /** Get the ring buffer contents (useful for crash reports or LLM context dumps) */
   getRecentLogs(): LogEntry[];
   /** Clear the ring buffer */
@@ -744,6 +751,8 @@ function makeLogger(core: LoggerCore, context: Record<string, unknown>): Logger 
     setLevel: (newLevel) => {
       core.minSeverity = LEVEL_SEVERITY[newLevel];
     },
+    isLevelEnabled: (queryLevel) =>
+      SHOW_LOGS && core.enabled && LEVEL_SEVERITY[queryLevel] >= core.minSeverity,
     getRecentLogs: () => core.buffer.getAll(),
     clearRecentLogs: () => core.buffer.clear(),
     dumpForLLM: (dumpOpts?: DumpOptions) => {

--- a/shared/lib/loggerUI.tsx
+++ b/shared/lib/loggerUI.tsx
@@ -13,7 +13,7 @@
 
 import { createContext, useContext, useEffect, useRef } from 'react';
 import React, { type ReactNode } from 'react';
-import type { StyleProp, ViewStyle } from 'react-native';
+import { View, type StyleProp, type ViewStyle } from 'react-native';
 
 import { log, type Logger } from './loggerCore';
 
@@ -147,6 +147,11 @@ export function Log({
   const prevContent = useRef<string[]>([]);
 
   useEffect(() => {
+    // Skip the recursive element-tree walk entirely when debug logging won't be
+    // emitted (always in production, where this effect otherwise ran on every
+    // render of every screen). Dynamic so dev / log-doctor builds still capture
+    // `ui.screen` events after a runtime setLevel('debug').
+    if (!screenLogger.isLevelEnabled('debug')) return;
     try {
       const content = extractVisibleContent(children);
       const contentKey = content.join('|');
@@ -175,7 +180,6 @@ export function Log({
   // default `flex: 1` style makes the wrapper fill its parent; an explicit
   // `style` prop overrides it.
   if (resolvedTestID) {
-    const { View } = require('react-native');
     return React.createElement(
       UIPathContext.Provider,
       { value: path },
@@ -192,7 +196,6 @@ export function Log({
   }
 
   if (style) {
-    const { View } = require('react-native');
     return React.createElement(
       UIPathContext.Provider,
       { value: path },

--- a/shared/ui/composed/ModalLayoutWrapper.tsx
+++ b/shared/ui/composed/ModalLayoutWrapper.tsx
@@ -5,7 +5,15 @@
  */
 
 import React, { ReactNode, useCallback, useContext, useEffect, useState } from 'react';
-import { NativeScrollEvent, Platform, ScrollView, StyleSheet, View } from 'react-native';
+import {
+  NativeScrollEvent,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
 import Animated, {
   useAnimatedScrollHandler,
   useSharedValue,
@@ -38,6 +46,50 @@ const DebugRow = ({
     </Text>
   </View>
 );
+
+/**
+ * Owns the Reanimated shared value + scroll handler for the animated-scroll
+ * mode. Split out of ModalLayoutWrapper so those hooks only run when a screen
+ * actually opts into animated scroll — keeping the per-mount cost off the
+ * common (non-animated) modal path. Shared-value access stays inside the
+ * worklet (never read/written during render), so it's React Compiler safe.
+ */
+function AnimatedScrollContainer({
+  externalScrollY,
+  contentContainerStyle,
+  scrollIndicatorInsets,
+  showHeaderSpacer,
+  totalHeaderHeight,
+  children,
+}: {
+  externalScrollY?: SharedValue<number>;
+  contentContainerStyle: StyleProp<ViewStyle>;
+  scrollIndicatorInsets?: { top?: number; right?: number; bottom?: number; left?: number };
+  showHeaderSpacer: boolean;
+  totalHeaderHeight: number;
+  children: ReactNode;
+}) {
+  const internalScrollY = useSharedValue(0);
+  const scrollY = externalScrollY ?? internalScrollY;
+
+  const animatedScrollHandler = useAnimatedScrollHandler({
+    onScroll: (event) => {
+      scrollY.value = Math.max(0, event.contentOffset.y);
+    },
+  });
+
+  return (
+    <Animated.ScrollView
+      style={{ flex: 1 }}
+      contentContainerStyle={contentContainerStyle}
+      onScroll={animatedScrollHandler}
+      scrollEventThrottle={16}
+      scrollIndicatorInsets={scrollIndicatorInsets}>
+      {showHeaderSpacer && <View style={{ height: totalHeaderHeight }} />}
+      {children}
+    </Animated.ScrollView>
+  );
+}
 
 interface ModalLayoutWrapperProps {
   children: ReactNode;
@@ -113,14 +165,9 @@ export function ModalLayoutWrapper({
 
   const [adjustedInsets, setAdjustedInsets] = useState({ top: 0, bottom: 0, left: 0, right: 0 });
 
-  const internalScrollY = useSharedValue(0);
-  const scrollY = externalScrollY ?? internalScrollY;
-
-  const animatedScrollHandler = useAnimatedScrollHandler({
-    onScroll: (event) => {
-      scrollY.value = Math.max(0, event.contentOffset.y);
-    },
-  });
+  // The animated-scroll shared value + handler live in AnimatedScrollContainer
+  // below, so every non-animated modal (the common case) doesn't pay the
+  // per-mount Reanimated worklet/shared-value registration.
 
   const handleScroll = useCallback((event: { nativeEvent: NativeScrollEvent }) => {
     const { contentInset } = event.nativeEvent;
@@ -199,15 +246,14 @@ export function ModalLayoutWrapper({
         {useCustomScrollView ? (
           <View style={{ flex: 1 }}>{children}</View>
         ) : useAnimatedScroll ? (
-          <Animated.ScrollView
-            style={{ flex: 1 }}
+          <AnimatedScrollContainer
+            externalScrollY={externalScrollY}
             contentContainerStyle={scrollContentStyle}
-            onScroll={animatedScrollHandler}
-            scrollEventThrottle={16}
-            scrollIndicatorInsets={scrollIndicatorInsets}>
-            {!disableHeaderSpacer && <View style={{ height: totalHeaderHeight }} />}
+            scrollIndicatorInsets={scrollIndicatorInsets}
+            showHeaderSpacer={!disableHeaderSpacer}
+            totalHeaderHeight={totalHeaderHeight}>
             {children}
-          </Animated.ScrollView>
+          </AnimatedScrollContainer>
         ) : (
           <ScrollView
             className="flex-1"

--- a/shared/ui/composed/Screen.tsx
+++ b/shared/ui/composed/Screen.tsx
@@ -32,6 +32,7 @@ import type { NativeStackNavigationOptions } from '@react-navigation/native-stac
 
 import { Log } from '@/shared/lib/logger';
 import { useThemeColor } from '@/shared/hooks/useThemeColor';
+import { useDeferredMount } from '@/shared/hooks/useDeferredMount';
 import { ModalLayoutWrapper } from './ModalLayoutWrapper';
 import { ScreenBackgroundContext, ScreenFooterContext } from './ScreenFooterContext';
 
@@ -70,6 +71,15 @@ interface ScreenProps {
   onHeaderHeightChange?: (height: number) => void;
   scrollIndicatorInsets?: { top?: number; right?: number; bottom?: number; left?: number };
   /**
+   * Defer mounting the content subtree until just after the first commit so the
+   * native-stack present/slide can start on a cheap frame (themed background
+   * only), then fill in the content. Default `true`. Set `false` for screens
+   * that must render synchronously on mount — e.g. ones that auto-focus a text
+   * input or measure a child immediately (the input/child would otherwise not
+   * exist when the focus/measure fires). See `useDeferredMount`.
+   */
+  deferContent?: boolean;
+  /**
    * Apply safe-area top/bottom padding to the content frame. Only meaningful
    * with `scroll="custom"` or `scroll="none"` — when a ScrollView is used it
    * handles the insets itself via `contentInsetAdjustmentBehavior="automatic"`.
@@ -107,6 +117,7 @@ export function Screen({
   onHeaderHeightChange,
   scrollIndicatorInsets,
   safeArea = false,
+  deferContent = true,
 }: ScreenProps) {
   const [measuredFooterHeight, setMeasuredFooterHeight] = useState(0);
   // Track what we last committed to state so we can ignore onLayout callbacks
@@ -127,6 +138,12 @@ export function Screen({
     () => ({ setFooterHeight: updateFooterHeight }),
     [updateFooterHeight]
   );
+
+  // Defer the content subtree so the modal present starts on a cheap frame.
+  // The Log boundary + ModalLayoutWrapper background stay mounted immediately,
+  // so the modal shows its themed background (no white flash) and log-doctor's
+  // screen testID appears right away; only `children`/`footer` wait one tick.
+  const contentReady = useDeferredMount(deferContent);
 
   const insets = useSafeAreaInsets();
   // Match ModalLayoutWrapper: read header height directly so this is safe to
@@ -176,8 +193,8 @@ export function Screen({
             onHeaderHeightChange={onHeaderHeightChange}
             scrollIndicatorInsets={scrollIndicatorInsets}
             bgColor={bgColor}
-            bottomContent={footer}>
-            {framedChildren}
+            bottomContent={contentReady ? footer : undefined}>
+            {contentReady ? framedChildren : null}
           </ModalLayoutWrapper>
         </ScreenFooterContext.Provider>
       </ScreenBackgroundContext.Provider>


### PR DESCRIPTION
## Why

Flow modals (`(send-flow)`, `(receive-flow)`, `(settings-flow)`, …) opened slowly **across the board** — every modal, not just heavy ones — and noticeably worse on low battery / Low Power Mode, even in production TestFlight.

Root cause: all flow screens are **native-stack modals**, and react-native-screens gates the slide animation on the new screen's *first JS render*. So perceived open latency = `tap → finished rendering modal content`. Low Power Mode throttles the CPU, stretching that render. Several cross-cutting JS costs sat on that present-gating path.

## What changed

- **Logger** — add `Logger.isLevelEnabled` and gate the `<Log>` wrapper's recursive element-tree walk behind it, so it no longer runs on every render in production (where the resulting debug log was discarded anyway). Hoist the inline `require('react-native')` out of the render path.
- **Screen** — defer the content subtree (new `useDeferredMount` hook): the modal presents on a cheap themed-background frame, then fills in after interactions. Opt out with `deferContent={false}` (applied to `MintAddScreen` so its `autoFocus` input keyboard isn't raced by the slide-in).
- **Navigator** — `freezeOnBlur` on the root Stack; hoist `CloseButton` to a stable memoized module component (was redefined every render → header button remount) and memoize `getScreenOptions` + the screen list. Memoize `FlowHeaderButton` so its close/back SVG isn't re-parsed on header renders.
- **ModalLayoutWrapper** — move the Reanimated shared value + scroll handler into `AnimatedScrollContainer`, mounted only for `scroll="animated"`, so every other modal skips that per-mount worklet registration.

## Out of scope / notes

- **Blur left untouched** — the intensity-200 wallpaper `BlurView` is a global singleton (one mount under the tabs), not per-modal, so it isn't recomposited on open.
- **`<Stack key={currentTheme}>` remount** left in place pending on-device verification that native-stack re-applies colors to mounted screens without it.

## Verification

- `tsc --noEmit`: clean. `eslint`: 0 errors (pre-existing `react-perf` warnings only). `jest`: no new failures (the 6 failing `naggFeedClient` tests fail identically with this change stashed — pre-existing, unrelated).
- **Still needs on-device:** Time Profiler + Core Animation FPS on a device in **Low Power Mode**, before vs after, to rank the causes; visual check that modals fill in with no white flash and `MintAddScreen`'s keyboard opens.