### PR TITLE
fix(nav): point Wallet link at the resolvable wallet route + graceful +not-found (#212)

### DIFF
--- a/__tests__/notFoundScreen.test.tsx
+++ b/__tests__/notFoundScreen.test.tsx
@@ -81,6 +81,6 @@ describe('NotFoundScreen', () => {
       (button.props as { onPress: () => void }).onPress();
     });
     expect(mockReplace).toHaveBeenCalledTimes(1);
-    expect(mockReplace).toHaveBeenCalledWith('/(drawer)/(tabs)/index');
+    expect(mockReplace).toHaveBeenCalledWith('/');
   });
 });

--- a/__tests__/notFoundScreen.test.tsx
+++ b/__tests__/notFoundScreen.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * @jest-environment node
+ */
+
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+
+import { NotFoundScreen } from '@/shared/blocks/NotFoundScreen';
+
+// react-test-renderer needs this flag to support act() under the node env.
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mockWarn = jest.fn();
+const mockReplace = jest.fn();
+const pathnameRef = { current: '/does/not/exist' };
+
+jest.mock('expo-router', () => ({
+  usePathname: () => pathnameRef.current,
+}));
+
+jest.mock('@/shared/hooks/useGuardedRouter', () => ({
+  guardedRouter: { replace: (...a: unknown[]) => mockReplace(...a) },
+}));
+
+jest.mock('@/shared/lib/logger', () => ({
+  log: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: (...a: unknown[]) => mockWarn(...a),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('@/shared/hooks/useThemeColor', () => ({
+  useThemeColor: () => ['surface', 'foreground', 'muted'],
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+// Presentational primitives are mocked to trivial passthroughs so the test
+// isolates behaviour (logging + recovery action) from native rendering.
+jest.mock('assets/icons', () => ({ __esModule: true, default: () => null }));
+jest.mock('@/shared/ui/primitives/Button', () => ({
+  Button: (props: { testID?: string; onPress: () => void }) => {
+    void props;
+    return null;
+  },
+}));
+jest.mock('@/shared/ui/primitives/Text', () => ({ Text: () => null }));
+jest.mock('@/shared/ui/primitives/View/View', () => ({
+  View: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+jest.mock('@/shared/ui/primitives/View/VStack', () => ({
+  VStack: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+describe('NotFoundScreen', () => {
+  beforeEach(() => {
+    mockWarn.mockReset();
+    mockReplace.mockReset();
+    pathnameRef.current = '/does/not/exist';
+  });
+
+  it('logs the unresolved path once on mount', () => {
+    act(() => {
+      TestRenderer.create(<NotFoundScreen />);
+    });
+    expect(mockWarn).toHaveBeenCalledTimes(1);
+    expect(mockWarn).toHaveBeenCalledWith('nav.unknown_route', { path: '/does/not/exist' });
+  });
+
+  it('replaces to the wallet route when the recovery button is pressed', () => {
+    let renderer!: TestRenderer.ReactTestRenderer;
+    act(() => {
+      renderer = TestRenderer.create(<NotFoundScreen />);
+    });
+    const button = renderer.root.findByProps({ testID: 'not-found-go-wallet' });
+    act(() => {
+      (button.props as { onPress: () => void }).onPress();
+    });
+    expect(mockReplace).toHaveBeenCalledTimes(1);
+    expect(mockReplace).toHaveBeenCalledWith('/(drawer)/(tabs)/index');
+  });
+});

--- a/__tests__/walletRouteResolution.test.tsx
+++ b/__tests__/walletRouteResolution.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment node
+ *
+ * Regression guard for #212. The Wallet screen lives in the `(tabs)/index`
+ * folder, which expo-router collapses to an empty path segment. Its canonical
+ * route is therefore the app root `/` — navigating to `/(drawer)/(tabs)/index`
+ * (a path the typed-routes generator emits but the runtime never mounts)
+ * resolves to `+not-found`.
+ *
+ * This locks that behaviour against an in-memory mirror of the real tab
+ * structure, so reverting the drawer's Wallet target back to the `index` path
+ * (the original bug) fails here.
+ */
+import { inMemoryContext } from 'expo-router/build/testing-library/context-stubs';
+import { getRoutes } from 'expo-router/build/getRoutes';
+import { getReactNavigationConfig } from 'expo-router/build/getReactNavigationConfig';
+import { getStateFromPath } from 'expo-router/build/fork/getStateFromPath';
+
+const Stub = () => null;
+
+// Mirrors app/(drawer)/(tabs) with the wallet in an `index/` folder and a
+// sibling `feed/` folder, plus the root `+not-found` catch-all.
+const routeMap: Record<string, unknown> = {
+  './_layout.tsx': Stub,
+  './+not-found.tsx': Stub,
+  './(drawer)/_layout.tsx': Stub,
+  './(drawer)/(tabs)/_layout.tsx': {
+    default: Stub,
+    unstable_settings: { initialRouteName: 'index' },
+  },
+  './(drawer)/(tabs)/index/_layout.tsx': Stub,
+  './(drawer)/(tabs)/index/index.tsx': Stub,
+  './(drawer)/(tabs)/feed/_layout.tsx': Stub,
+  './(drawer)/(tabs)/feed/index.tsx': Stub,
+};
+
+/** Strip expo-router's `_route` extension that react-navigation's validator rejects. */
+function sanitize(node: unknown): unknown {
+  if (Array.isArray(node)) return node.map(sanitize);
+  if (node && typeof node === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
+      if (k === '_route') continue;
+      out[k] = sanitize(v);
+    }
+    return out;
+  }
+  return node;
+}
+
+type NavState = { routes?: { name: string; state?: unknown }[]; index?: number };
+
+/** Leaf route-name chain for a resolved navigation state. */
+function leafChain(state: unknown): string[] {
+  const chain: string[] = [];
+  let s: NavState | undefined = state as NavState;
+  while (s?.routes) {
+    const idx = s.index ?? s.routes.length - 1;
+    const r = s.routes[idx];
+    if (!r) break;
+    chain.push(r.name);
+    s = r.state as NavState | undefined;
+  }
+  return chain;
+}
+
+function resolve(path: string): string[] | undefined {
+  const ctx = inMemoryContext(routeMap as never);
+  const routeOptions = { internal_stripLoadRoute: true };
+  const tree = getRoutes(ctx as never, routeOptions as never);
+  const config = sanitize(getReactNavigationConfig(tree as never, false));
+  const emptySegments: string[] = [];
+  const state = getStateFromPath(path, config as never, emptySegments);
+  return state ? leafChain(state) : undefined;
+}
+
+describe('wallet route resolution (#212)', () => {
+  it('resolves the app root `/` to the wallet index screen', () => {
+    expect(resolve('/')).toEqual(['(drawer)', '(tabs)', 'index', 'index']);
+  });
+
+  it('resolves the old `/(drawer)/(tabs)/index` target to +not-found (the bug)', () => {
+    expect(resolve('/(drawer)/(tabs)/index')).toEqual(['+not-found']);
+  });
+
+  it('still resolves a normal sibling tab by its path', () => {
+    expect(resolve('/(drawer)/(tabs)/feed')).toEqual(['(drawer)', '(tabs)', 'feed', 'index']);
+  });
+});

--- a/app/(drawer)/_layout.tsx
+++ b/app/(drawer)/_layout.tsx
@@ -25,7 +25,10 @@ import { useNip46RequestsStore } from '@/features/nostrSigner';
 
 type MenuRoute =
   | '/(drawer)/(tabs)/feed'
-  | '/(drawer)/(tabs)/index'
+  // Wallet is the `(tabs)/index` folder, which expo-router collapses to an
+  // empty path segment — so its canonical route is the app root `/`, not
+  // `/(drawer)/(tabs)/index` (that path resolves to +not-found at runtime).
+  | '/'
   | '/(drawer)/(tabs)/contacts'
   | '/(drawer)/(tabs)/notifications'
   | '/(drawer)/(tabs)/ai'
@@ -64,7 +67,7 @@ const MENU_ITEMS: MenuItem[] = [
   {
     icon: { default: 'fluent:wallet-20-regular', selected: 'fluent:wallet-20-filled' },
     label: 'Wallet',
-    route: '/(drawer)/(tabs)/index',
+    route: '/',
     activeSegments: ['(drawer)', '(tabs)', 'index'],
   },
   {

--- a/app/+not-found.tsx
+++ b/app/+not-found.tsx
@@ -1,0 +1,1 @@
+export { NotFoundScreen as default } from '@/shared/blocks/NotFoundScreen';

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -393,6 +393,10 @@ function RootLayoutContent() {
           {/* Main drawer with tabs inside */}
           <Stack.Screen name="(drawer)" options={{ headerShown: false }} />
 
+          {/* Catch-all for unresolved routes — degrades gracefully instead of
+              leaving the user on a dead screen. */}
+          <Stack.Screen name="+not-found" options={{ headerShown: false }} />
+
           {/* All modal screens configured from MODAL_SCREENS */}
           {modalScreenElements}
         </Stack>

--- a/docs/adr/0001-graceful-unknown-route.md
+++ b/docs/adr/0001-graceful-unknown-route.md
@@ -1,0 +1,52 @@
+# 0001 — Graceful handling of unresolved routes
+
+- Status: Accepted
+- Date: 2026-06-20
+- Issue: #212 ("Wallet link resolves to a missing route and throws an error")
+
+## Context
+
+#212 reported that following a link to the Wallet screen navigated to a
+missing route and threw. Investigation of `main` found the opposite: the
+drawer Wallet item points at `/(drawer)/(tabs)/index`, which is a real,
+type-checked route, and an audit of all 100+ navigation call sites found **zero**
+targets that resolve to a missing route. The reported crash does not reproduce.
+
+What the app genuinely lacked was the issue's *Expected behavior* clause: "if
+the intended route no longer exists, the app should fail gracefully and keep the
+user in a usable state." There was no expo-router `+not-found` catch-all and no
+error boundary, so a future stale/renamed route would strand the user.
+
+Note: an early hypothesis that the broken link was a custom-scheme deep link
+(`sovran://wallet`) was disproved — the source Nostr note merely describes the
+repro in prose; no deep-link dispatch is involved.
+
+## Decision
+
+Add an expo-router `+not-found` catch-all (`app/+not-found.tsx` →
+`shared/blocks/NotFoundScreen`) that:
+
+- logs the unresolved path once via the canonical logger (`log.warn('nav.unknown_route', { path })`)
+  so a recurring broken link is observable rather than silent; and
+- renders a recoverable screen with a single **Go to Wallet** action that calls
+  `guardedRouter.replace('/(drawer)/(tabs)/index')` — `replace` (not `push`) so
+  the dead route never enters the back stack.
+
+We chose a **recoverable screen** over a silent auto-redirect because the issue
+emphasises keeping the user "in a usable state" — an unexplained bounce is more
+disorienting than a brief, actionable screen.
+
+This complements, and does not replace, the existing param-level seam: routes
+validate their params with `useRouteParams` (Zod → `router.back()`). Unknown
+*paths* and invalid *params* are handled by distinct, non-overlapping seams.
+
+We deliberately do **not** add custom URL-scheme dispatch — there is no evidence
+it is involved, and adding it would be speculative.
+
+## Consequences
+
+- Any unmatched route now degrades to an actionable screen instead of a dead end.
+- Reuses canonical owners only (`guardedRouter`, `log`, shared UI primitives) —
+  no new modules, shims, or re-exports.
+- If a real broken link is introduced later, `nav.unknown_route` in the logs
+  pinpoints the offending path.

--- a/docs/adr/0001-graceful-unknown-route.md
+++ b/docs/adr/0001-graceful-unknown-route.md
@@ -6,16 +6,26 @@
 
 ## Context
 
-#212 reported that following a link to the Wallet screen navigated to a
-missing route and threw. Investigation of `main` found the opposite: the
-drawer Wallet item points at `/(drawer)/(tabs)/index`, which is a real,
-type-checked route, and an audit of all 100+ navigation call sites found **zero**
-targets that resolve to a missing route. The reported crash does not reproduce.
+#212 reported that clicking **Wallet** in the drawer ("drop down") menu
+navigated to a missing route and threw.
 
-What the app genuinely lacked was the issue's *Expected behavior* clause: "if
-the intended route no longer exists, the app should fail gracefully and keep the
-user in a usable state." There was no expo-router `+not-found` catch-all and no
-error boundary, so a future stale/renamed route would strand the user.
+The drawer's Wallet item targeted `/(drawer)/(tabs)/index`. The wallet screen
+lives in the `app/(drawer)/(tabs)/index/` folder, and **expo-router collapses an
+`index` folder to an empty path segment** — so the wallet's real, mounted route
+is the group root `/`, and *no route is mounted at `/(drawer)/(tabs)/index`*.
+The typed-routes generator nonetheless emits both `/(drawer)/(tabs)/index` and
+the shorthand `/index` as "valid" hrefs, which is why this passed type-check
+while failing at runtime: both resolve to `+not-found`. (Verified by resolving
+each path against the route tree via `getStateFromPath` — see
+`__tests__/walletRouteResolution.test.tsx`.)
+
+Two gaps, fixed together:
+
+1. **The actual bug** — the Wallet link pointed at a path that does not resolve.
+2. **Missing graceful degradation** — the issue's *Expected behavior* clause
+   ("if the intended route no longer exists, the app should fail gracefully and
+   keep the user in a usable state"). There was no expo-router `+not-found`
+   catch-all, so the broken link (and any future stale route) stranded the user.
 
 Note: an early hypothesis that the broken link was a custom-scheme deep link
 (`sovran://wallet`) was disproved — the source Nostr note merely describes the
@@ -23,8 +33,14 @@ repro in prose; no deep-link dispatch is involved.
 
 ## Decision
 
-Add an expo-router `+not-found` catch-all (`app/+not-found.tsx` →
-`shared/blocks/NotFoundScreen`) that:
+**Fix the link:** point the drawer's Wallet item (and the not-found recovery
+button) at `/`, the canonical route that resolves to the wallet via the
+`initialRouteName` chain (root → `(drawer)` → `(tabs)` → `index`). `/` is in the
+typed `Href` union; the runtime-correct `/(drawer)/(tabs)` is not, so `/` is
+preferred over a cast.
+
+**Add the safety net:** an expo-router `+not-found` catch-all (`app/+not-found.tsx`
+→ `shared/blocks/NotFoundScreen`) that:
 
 - logs the unresolved path once via the canonical logger (`log.warn('nav.unknown_route', { path })`)
   so a recurring broken link is observable rather than silent; and

--- a/shared/blocks/NotFoundScreen.tsx
+++ b/shared/blocks/NotFoundScreen.tsx
@@ -28,8 +28,12 @@ import { Text } from '@/shared/ui/primitives/Text';
 import { View } from '@/shared/ui/primitives/View/View';
 import { VStack } from '@/shared/ui/primitives/View/VStack';
 
-/** Canonical wallet route — the app's initial tab and natural landing point. */
-const WALLET_ROUTE = '/(drawer)/(tabs)/index' as const;
+/**
+ * Canonical wallet route. The wallet lives in the `(tabs)/index` folder, which
+ * expo-router collapses to an empty path segment, so the app root `/` is what
+ * resolves to it (`/(drawer)/(tabs)/index` resolves to +not-found at runtime).
+ */
+const WALLET_ROUTE = '/' as const;
 
 export function NotFoundScreen() {
   const pathname = usePathname();

--- a/shared/blocks/NotFoundScreen.tsx
+++ b/shared/blocks/NotFoundScreen.tsx
@@ -1,0 +1,80 @@
+/**
+ * @fileoverview Catch-all screen for unresolved routes.
+ *
+ * Rendered by the expo-router `+not-found` route whenever navigation lands on
+ * a path that matches no route file (e.g. a stale link, a renamed screen, or a
+ * malformed deep link). Instead of leaving the user on a dead screen, it logs
+ * the attempted path for observability and offers a one-tap return into the
+ * app. Recovery uses `guardedRouter.replace` so the unresolved route never
+ * sits in the back stack.
+ *
+ * Param-level failures are handled separately at the route boundary by
+ * `useRouteParams` (Zod validate → `router.back()`); this screen covers the
+ * orthogonal case of an unknown *path*.
+ */
+
+import { useEffect } from 'react';
+import { StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { usePathname } from 'expo-router';
+
+import Icon from 'assets/icons';
+import { guardedRouter } from '@/shared/hooks/useGuardedRouter';
+import { useThemeColor } from '@/shared/hooks/useThemeColor';
+import { log } from '@/shared/lib/logger';
+import { iconSize, spacing } from '@/shared/styles/tokens';
+import { Button } from '@/shared/ui/primitives/Button';
+import { Text } from '@/shared/ui/primitives/Text';
+import { View } from '@/shared/ui/primitives/View/View';
+import { VStack } from '@/shared/ui/primitives/View/VStack';
+
+/** Canonical wallet route — the app's initial tab and natural landing point. */
+const WALLET_ROUTE = '/(drawer)/(tabs)/index' as const;
+
+export function NotFoundScreen() {
+  const pathname = usePathname();
+  const insets = useSafeAreaInsets();
+  const [surface, foreground, muted] = useThemeColor(['surface', 'foreground', 'muted'] as const);
+
+  // Log the unresolved path once per mount so a recurring broken link surfaces
+  // in diagnostics rather than failing silently.
+  useEffect(() => {
+    log.warn('nav.unknown_route', { path: pathname });
+  }, [pathname]);
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { backgroundColor: surface, paddingTop: insets.top, paddingBottom: insets.bottom },
+      ]}>
+      <VStack align="center" justify="center" spacing={spacing.xl} style={styles.content}>
+        <Icon name="mdi:alert-circle-outline" color={muted} size={iconSize['3xl']} />
+        <VStack align="center" spacing={spacing.xs}>
+          <Text size={20} bold style={{ color: foreground, textAlign: 'center' }}>
+            This screen isn’t available
+          </Text>
+          <Text size={15} style={{ color: muted, textAlign: 'center' }}>
+            The link you followed points somewhere that no longer exists.
+          </Text>
+        </VStack>
+        <Button
+          testID="not-found-go-wallet"
+          text="Go to Wallet"
+          variant="primary"
+          onPress={() => guardedRouter.replace(WALLET_ROUTE)}
+        />
+      </VStack>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: spacing['2xl'],
+  },
+});


### PR DESCRIPTION
Closes #212.

## Root cause (corrected)
Clicking **Wallet** in the drawer menu navigated to `/(drawer)/(tabs)/index`, which **does not resolve at runtime**:

- The wallet screen lives in the `app/(drawer)/(tabs)/index/` folder.
- expo-router **collapses an `index` folder to an empty path segment**, so the wallet's real mounted route is the group root `/`, and **no route exists at `/(drawer)/(tabs)/index`** — it resolves to `+not-found`.
- The typed-routes generator nonetheless emits `/(drawer)/(tabs)/index` *and* the shorthand `/index` as valid hrefs, so the bug passed type-check while failing at runtime.

Verified by resolving each path against the route tree with `getStateFromPath` (see `__tests__/walletRouteResolution.test.tsx`):

| Target | Resolves to |
|---|---|
| `/(drawer)/(tabs)/index` (old target) | `+not-found` ❌ |
| `/index` (typed shorthand) | `+not-found` ❌ |
| `/` | wallet ✅ |
| `/(drawer)/(tabs)/feed` | feed ✅ |

## Fix
1. **The link** — retarget the drawer Wallet item (and the not-found recovery button) at `/`, which resolves to the wallet via the `initialRouteName` chain (root → `(drawer)` → `(tabs)` → `index`). `/` is in the typed `Href` union; the also-correct `/(drawer)/(tabs)` is not, so `/` is preferred over a cast.
2. **The safety net** — an expo-router `+not-found` catch-all (`app/+not-found.tsx` → `shared/blocks/NotFoundScreen`) that logs the unresolved path (`log.warn('nav.unknown_route', { path })`) and renders a recoverable screen with a **Go to Wallet** action (`guardedRouter.replace('/')`). This satisfies the issue's *Expected behavior* ("fail gracefully and keep the user in a usable state") and hardens against future stale routes.

## Tests
- `__tests__/walletRouteResolution.test.tsx` — locks the resolution contract (`/` → wallet, `/(drawer)/(tabs)/index` → `+not-found`); fails if the buggy target returns.
- `__tests__/notFoundScreen.test.tsx` — logs `nav.unknown_route` + recovers to `/`.

## Design
Reuses canonical owners only — `guardedRouter` (nav), `log` (logging), shared UI primitives + theme tokens. No new modules, shims, or re-exports. Complements the existing param-level seam `useRouteParams` (Zod → `router.back()`): unknown **paths** and invalid **params** are handled by distinct seams. Decision recorded in `docs/adr/0001-graceful-unknown-route.md`.

## Verification
- `tsc --noEmit`: clean
- `eslint` (changed files): 0 errors
- `knip`: no new findings
- `jest`: 5 new tests pass; full suite at the known 8-failure `naggFeedClient` baseline (no new failures)