### PR TITLE
fix(media): append a renderable extension to Blossom image URLs

### DIFF
--- a/__tests__/mediaType.test.ts
+++ b/__tests__/mediaType.test.ts
@@ -56,6 +56,10 @@ describe('extensionForMime', () => {
     expect(extensionForMime('application/octet-stream')).toBeUndefined();
     expect(extensionForMime(undefined)).toBeUndefined();
   });
+
+  it('prefers jpg over jpeg for image/jpeg', () => {
+    expect(extensionForMime('image/jpeg')).toBe('jpg');
+  });
 });
 
 describe('ensureUrlExtension', () => {

--- a/__tests__/mediaType.test.ts
+++ b/__tests__/mediaType.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Media MIME ↔ extension resolution and the renderable-URL guarantee that fixes
+ * bare-hash Blossom URLs failing to inline-render in Nostr clients.
+ */
+import {
+  ensureUrlExtension,
+  extensionForMime,
+  resolveMediaType,
+} from '@/shared/lib/nostr/media/mediaType';
+
+const PRIMAL = 'https://blossom.primal.net';
+const HASH = '42caeea8a44aa9a57f6e68ce7752dba858de463dc79c53f6adf0e9b120fccd5e';
+
+describe('resolveMediaType', () => {
+  it('prefers the file name over a wrong picker mime', () => {
+    // A PNG screenshot the picker mislabels as JPEG: the name wins, both agree.
+    expect(resolveMediaType({ fileName: 'IMG_001.png', mimeType: 'image/jpeg' })).toEqual({
+      extension: 'png',
+      mimeType: 'image/png',
+    });
+  });
+
+  it('falls back to the uri extension when there is no file name', () => {
+    expect(resolveMediaType({ uri: 'file:///tmp/ImagePicker/abc.heic' })).toEqual({
+      extension: 'heic',
+      mimeType: 'image/heic',
+    });
+  });
+
+  it('derives the extension from the mime when name and uri are extensionless', () => {
+    expect(resolveMediaType({ uri: 'file:///tmp/ph-asset', mimeType: 'video/quicktime' })).toEqual({
+      extension: 'mov',
+      mimeType: 'video/quicktime',
+    });
+  });
+
+  it('falls back by kind when nothing else resolves a type', () => {
+    expect(resolveMediaType({ uri: 'ph://no-extension', kind: 'image' })).toEqual({
+      extension: 'jpg',
+      mimeType: 'image/jpeg',
+    });
+    expect(resolveMediaType({ uri: 'ph://no-extension', kind: 'video' })).toEqual({
+      extension: 'mp4',
+      mimeType: 'video/mp4',
+    });
+  });
+
+  it('ignores a query string when reading the uri extension', () => {
+    expect(resolveMediaType({ uri: 'https://x/y.webp?dl=1' }).extension).toBe('webp');
+  });
+});
+
+describe('extensionForMime', () => {
+  it('maps known mimes and ignores unknown ones', () => {
+    expect(extensionForMime('image/gif')).toBe('gif');
+    expect(extensionForMime('application/octet-stream')).toBeUndefined();
+    expect(extensionForMime(undefined)).toBeUndefined();
+  });
+});
+
+describe('ensureUrlExtension', () => {
+  it('appends the extension to a bare-hash Blossom url (the bug)', () => {
+    expect(ensureUrlExtension(`${PRIMAL}/${HASH}`, 'png')).toBe(`${PRIMAL}/${HASH}.png`);
+  });
+
+  it('leaves a url that already has a known media extension untouched', () => {
+    const withExt = `${PRIMAL}/${HASH}.jpg`;
+    expect(ensureUrlExtension(withExt, 'jpg')).toBe(withExt);
+  });
+});

--- a/features/composer/ui/PostComposer.tsx
+++ b/features/composer/ui/PostComposer.tsx
@@ -228,7 +228,6 @@ export function PostComposer() {
     if (result.canceled || !result.assets[0]) return;
     const asset = result.assets[0];
     const mediaKind = asset.type === 'video' ? 'video' : 'image';
-    const mimeType = asset.mimeType ?? (mediaKind === 'video' ? 'video/mp4' : 'image/jpeg');
 
     const id = addMediaBlock({
       kind: 'media',
@@ -239,7 +238,14 @@ export function PostComposer() {
 
     const upload = await uploadMedia({
       ndk,
-      asset: { uri: asset.uri, mimeType, width: asset.width, height: asset.height },
+      asset: {
+        uri: asset.uri,
+        mimeType: asset.mimeType,
+        fileName: asset.fileName ?? undefined,
+        kind: mediaKind,
+        width: asset.width,
+        height: asset.height,
+      },
     });
     if (upload.isOk()) {
       updateBlock(id, { descriptor: upload.value, uploadProgress: undefined });

--- a/features/feed/components/ThreadReplyBar.tsx
+++ b/features/feed/components/ThreadReplyBar.tsx
@@ -191,7 +191,6 @@ export function ThreadReplyBar({
     if (result.canceled || !result.assets[0]) return;
     const asset = result.assets[0];
     const mediaKind = asset.type === 'video' ? 'video' : 'image';
-    const mimeType = asset.mimeType ?? (mediaKind === 'video' ? 'video/mp4' : 'image/jpeg');
     const id = `m${(mediaSeq += 1)}`;
     setMediaBlocks((prev) => [
       ...prev,
@@ -200,7 +199,14 @@ export function ThreadReplyBar({
 
     const upload = await uploadMedia({
       ndk,
-      asset: { uri: asset.uri, mimeType, width: asset.width, height: asset.height },
+      asset: {
+        uri: asset.uri,
+        mimeType: asset.mimeType,
+        fileName: asset.fileName ?? undefined,
+        kind: mediaKind,
+        width: asset.width,
+        height: asset.height,
+      },
     });
     setMediaBlocks((prev) => {
       if (upload.isErr()) return prev.filter((b) => b.id !== id);

--- a/shared/lib/nostr/media/mediaType.ts
+++ b/shared/lib/nostr/media/mediaType.ts
@@ -27,18 +27,16 @@ const EXTENSION_TO_MIME = {
 
 type KnownExtension = keyof typeof EXTENSION_TO_MIME;
 
-/** Canonical MIME type → preferred extension (the reverse of the table above). */
-const MIME_TO_EXTENSION: Record<string, KnownExtension> = {
-  'image/jpeg': 'jpg',
-  'image/png': 'png',
-  'image/gif': 'gif',
-  'image/webp': 'webp',
-  'image/heic': 'heic',
-  'image/heif': 'heif',
-  'video/mp4': 'mp4',
-  'video/quicktime': 'mov',
-  'video/webm': 'webm',
-};
+/**
+ * Canonical MIME type → preferred extension, derived from the table above so the
+ * two never drift. The first extension listed for a mime wins (e.g. `jpg`, not
+ * `jpeg`), so order entries in `EXTENSION_TO_MIME` preference-first.
+ */
+const MIME_TO_EXTENSION: Record<string, KnownExtension> = Object.fromEntries(
+  (Object.entries(EXTENSION_TO_MIME) as [KnownExtension, string][])
+    .reverse()
+    .map(([ext, mime]) => [mime, ext])
+);
 
 /** The known media extension at the end of a filename or URL path, if any. */
 function extensionOf(nameOrUri: string | undefined): KnownExtension | undefined {
@@ -79,6 +77,7 @@ export function resolveMediaType(hints: PickedMediaHints): ResolvedMediaType {
   if (fromName) return { extension: fromName, mimeType: EXTENSION_TO_MIME[fromName] };
 
   const fromMime = extensionForMime(hints.mimeType);
+  // `&& hints.mimeType` narrows it to a non-undefined string for the return type.
   if (fromMime && hints.mimeType) return { extension: fromMime, mimeType: hints.mimeType };
 
   const extension: KnownExtension = hints.kind === 'video' ? 'mp4' : 'jpg';

--- a/shared/lib/nostr/media/mediaType.ts
+++ b/shared/lib/nostr/media/mediaType.ts
@@ -1,0 +1,96 @@
+/**
+ * @fileoverview Media MIME ↔ file-extension resolution — the canonical owner.
+ *
+ * Blossom addresses blobs by their sha256, so an upload response URL can arrive
+ * with no file extension. Nostr clients inline-render media by the extension in
+ * the note's URL, so a bare-hash URL renders as a plain link, not an image.
+ *
+ * This module resolves a consistent `{ mimeType, extension }` from a picked
+ * asset — trusting the file's own name over a picker-supplied mime, which is
+ * often wrong (e.g. a PNG screenshot reported as `image/jpeg`) — and guarantees
+ * the final URL carries a renderable suffix.
+ */
+
+/** Known media extensions → canonical MIME type. */
+const EXTENSION_TO_MIME = {
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  heic: 'image/heic',
+  heif: 'image/heif',
+  mp4: 'video/mp4',
+  mov: 'video/quicktime',
+  webm: 'video/webm',
+} as const;
+
+type KnownExtension = keyof typeof EXTENSION_TO_MIME;
+
+/** Canonical MIME type → preferred extension (the reverse of the table above). */
+const MIME_TO_EXTENSION: Record<string, KnownExtension> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+  'image/heic': 'heic',
+  'image/heif': 'heif',
+  'video/mp4': 'mp4',
+  'video/quicktime': 'mov',
+  'video/webm': 'webm',
+};
+
+/** The known media extension at the end of a filename or URL path, if any. */
+function extensionOf(nameOrUri: string | undefined): KnownExtension | undefined {
+  if (!nameOrUri) return undefined;
+  const path = nameOrUri.split(/[?#]/, 1)[0];
+  const dot = path.lastIndexOf('.');
+  if (dot === -1) return undefined;
+  const ext = path.slice(dot + 1).toLowerCase();
+  return ext in EXTENSION_TO_MIME ? (ext as KnownExtension) : undefined;
+}
+
+/** The preferred extension for a MIME type, if recognized. */
+export function extensionForMime(mimeType: string | undefined): KnownExtension | undefined {
+  if (!mimeType) return undefined;
+  return MIME_TO_EXTENSION[mimeType.toLowerCase()];
+}
+
+interface PickedMediaHints {
+  fileName?: string;
+  uri?: string;
+  mimeType?: string;
+  /** Last-resort family when no name/uri/mime resolves a type. */
+  kind?: 'image' | 'video';
+}
+
+interface ResolvedMediaType {
+  mimeType: string;
+  extension: KnownExtension;
+}
+
+/**
+ * Resolve a consistent mime + extension from a picked asset, preferring the
+ * most trustworthy source and deriving BOTH fields from it (so they never
+ * disagree): file name → uri → supplied mime → kind fallback.
+ */
+export function resolveMediaType(hints: PickedMediaHints): ResolvedMediaType {
+  const fromName = extensionOf(hints.fileName) ?? extensionOf(hints.uri);
+  if (fromName) return { extension: fromName, mimeType: EXTENSION_TO_MIME[fromName] };
+
+  const fromMime = extensionForMime(hints.mimeType);
+  if (fromMime && hints.mimeType) return { extension: fromMime, mimeType: hints.mimeType };
+
+  const extension: KnownExtension = hints.kind === 'video' ? 'mp4' : 'jpg';
+  return { extension, mimeType: EXTENSION_TO_MIME[extension] };
+}
+
+/**
+ * Append `.extension` to a URL that lacks a renderable media suffix. Idempotent:
+ * a URL that already ends in a known media extension is returned untouched.
+ * Blossom blob URLs are clean content-address paths, so a bare append is safe.
+ */
+export function ensureUrlExtension(url: string, extension: string): string {
+  if (extensionOf(url)) return url;
+  return `${url}.${extension}`;
+}

--- a/shared/lib/nostr/media/mediaUpload.ts
+++ b/shared/lib/nostr/media/mediaUpload.ts
@@ -9,12 +9,18 @@ import type NDK from '@nostr-dev-kit/ndk-mobile';
 import type { ResultAsync } from 'neverthrow';
 
 import { uploadToBlossom, type BlossomError } from '@/shared/lib/nostr/media/blossomClient';
+import { ensureUrlExtension, resolveMediaType } from '@/shared/lib/nostr/media/mediaType';
 import { getMediaServer } from '@/shared/lib/nostr/media/mediaServerStore';
 import type { MediaDescriptor } from '@/shared/lib/nostr/media/types';
 
 export interface PickedAsset {
   uri: string;
-  mimeType: string;
+  /** Picker-supplied mime; may be absent or wrong — resolved against the name. */
+  mimeType?: string;
+  /** The asset's own file name, the most trustworthy type signal. */
+  fileName?: string;
+  /** Media family, the last-resort hint when name/uri/mime resolve nothing. */
+  kind?: 'image' | 'video';
   width?: number;
   height?: number;
 }
@@ -30,15 +36,22 @@ export interface UploadMediaOptions {
 
 /** Uploads a picked asset and returns a ready-to-serialize media descriptor. */
 export function uploadMedia(opts: UploadMediaOptions): ResultAsync<MediaDescriptor, BlossomError> {
+  const { mimeType, extension } = resolveMediaType({
+    fileName: opts.asset.fileName,
+    uri: opts.asset.uri,
+    mimeType: opts.asset.mimeType,
+    kind: opts.asset.kind,
+  });
   return uploadToBlossom({
     ndk: opts.ndk,
     server: opts.server ?? getMediaServer(),
     fileUri: opts.asset.uri,
-    mimeType: opts.asset.mimeType,
+    mimeType,
   }).map((descriptor) => ({
-    url: descriptor.url,
+    // Guarantee a renderable suffix; Blossom may return a bare-hash URL.
+    url: ensureUrlExtension(descriptor.url, extension),
     sha256: descriptor.sha256,
-    mimeType: opts.asset.mimeType,
+    mimeType,
     sizeBytes: descriptor.size,
     width: opts.asset.width,
     height: opts.asset.height,


### PR DESCRIPTION
## Problem

Image uploads "sometimes work, sometimes don't" — the same kind of photo would inline-render on one upload and show as a plain link on the next.

**Root cause:** Blossom addresses blobs by sha256, so its upload response URL can come back as a *bare hash with no file extension*. Nostr clients (njump and others) decide whether to inline-render a URL by the **extension in the note content**, not the `imeta` tag. We passed Primal's returned `descriptor.url` through verbatim (`mediaUpload.ts`), so when Primal didn't append a suffix server-side, the inline link had no extension and rendered as plain text. The screenshot-vs-camera correlation is real: it changes the type Primal sees, which changes whether it appends a suffix.

Example (both from one note): `…/42caeea8…` (bare → didn't render) vs `…/9df61c3b….jpg` (rendered).

## Fix

Stop depending on the server to make the URL renderable.

- **New `shared/lib/nostr/media/mediaType.ts`** — the canonical owner of MIME ↔ extension (the capability audit found none). `resolveMediaType` derives a *consistent* `{ mimeType, extension }`, trusting the file's own name over a picker-supplied mime (a PNG screenshot is often mislabelled `image/jpeg`). `ensureUrlExtension` appends a suffix only when one is missing (idempotent — the already-`.jpg` case is untouched).
- **`mediaUpload.ts`** resolves the type once and stamps both the Blossom `Content-Type` and the `imeta` mime from it, then guarantees the URL suffix. One seam, so both composers inherit it.
- **Dedup:** the identical `?? 'image/jpeg'` mime fallback that lived in both `PostComposer` and `ThreadReplyBar` is removed; both now pass the raw asset.

## Tests

New `__tests__/mediaType.test.ts` covers the precedence chain (name → uri → mime → kind), the mislabel correction (PNG screenshot → `.png`/`image/png`), and idempotent suffixing (bare hash → `.png`; already-`.jpg` unchanged).

## Gates

type-check ✅ · lint ✅ (0 errors) · jest ✅ (media + composer suites) · knip ✅ (no new issues)

## Notes / risks

- Blossom serving suffixed paths is BUD-01 *SHOULD*; Primal already serves them.
- HEIC camera files now get an honest `.heic` some clients can't decode — a format limitation, not a regression; we represent the type truthfully rather than mislabelling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)