### PR TITLE
feat(composer): optimistic posting + local own-content store with instant View

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -31,3 +31,45 @@ larger than the spendable balance. Needed because an over-balance ecash send
 still resolves (it rounds down to the balance) and so produces no blocking
 Notice — only lightning, which can't round down, would otherwise reveal the
 shortfall. Drives the red Amount tint independently of a Notice.
+
+## Publishing & own content
+
+**Publish seam** — `shared/lib/nostr/publish/publishEvent.ts`, the single path
+every Nostr write routes through. One engine (`fanOut` over `publishRound`),
+three `resolveOn` modes.
+
+**resolveOn modes** — `first-ok` (resolve once any relay accepts, then stop),
+`all-settled` (run the full retry budget for widest reach; replaceable lists),
+`optimistic` (resolve on the first accept, finish fan-out + retries in the
+background).
+
+**Assured vs settled** — _assured_ = delivery is guaranteed (first relay
+accepted) and the UI may proceed; _settled_ = the full background fan-out
+(retries + recipient relays) has finished. Optimistic publishing resolves the
+caller at _assured_ and continues to _settled_ in the background.
+
+**Background / recipient (outbox) relays** — a mentioned user's NIP-65 read
+relays. They need a network lookup, so they're resolved off the critical path
+and folded into the background fan-out via `PublishOptions.backgroundRelays`.
+
+**Own content** — notes/replies/quotes (kind:1) authored by the active profile,
+held in `ownContentStore` (`shared/stores/profile/ownContentStore.ts`): a
+per-profile, persisted, id-keyed local cache. Serves instant "View" of a
+just-posted note and a note-by-id fallback for the thread reader.
+
+**Status (pending → local → confirmed)** — `pending`: publish in flight;
+`local`: delivery assured but not yet echoed back by a relay/app-view;
+`confirmed`: seen from a relay/app-view. A failed publish is removed (no phantom).
+
+**Settle-by-id** — own content reconciles by exact `event.id` (a signed note
+already knows its id), so a relay echo is the same key — no timestamp/content
+heuristics, unlike engagement state.
+
+**Passive ingest** — recording own kind:1 notes the app already encounters
+(feed/thread reads) into `ownContentStore`, giving cross-client convergence
+without a dedicated always-on subscription. Seam: `ingestOwnContent`.
+
+**Viewer-state** — a viewer's relation to a post (did _I_ like / repost / quote /
+reply; do I follow this profile). Today derived client-side from relay
+subscriptions; the authoritative source is planned to be nagg app-view payloads
+(see ADR 0001).

--- a/__tests__/ownContentStore.test.ts
+++ b/__tests__/ownContentStore.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Unit tests for ownContentStore — the per-profile local cache of our own
+ * authored notes. Covers the lifecycle (record/confirm/remove/ingest),
+ * read scoping (profile isolation), and retention (FIFO cap + local age-out).
+ */
+/* eslint-disable import/first */
+
+jest.mock('@/shared/lib/logger', () => ({
+  storeLog: { info: jest.fn(), debug: jest.fn(), warn: jest.fn(), error: jest.fn() },
+  log: { info: jest.fn(), debug: jest.fn(), warn: jest.fn(), error: jest.fn() },
+  redactError: (e: unknown) => e,
+}));
+
+jest.mock('@/shared/lib/cashu/profileScopedStorage', () => ({
+  createProfileScopedStorage: () => ({
+    getItem: async () => null,
+    setItem: async () => {},
+    removeItem: async () => {},
+  }),
+}));
+
+import type { FeedEvent } from '@/features/feed/components/nostr/feedTypes';
+import {
+  ingestOwnContent,
+  LOCAL_GRACE_MS,
+  MAX_CONFIRMED,
+  useOwnContentStore,
+} from '@/shared/stores/profile/ownContentStore';
+
+const ME = 'a'.repeat(64);
+const OTHER = 'b'.repeat(64);
+
+function note(id: string, pubkey = ME): FeedEvent {
+  return { id, kind: 1, pubkey, content: `hi ${id}`, tags: [], created_at: 1000 };
+}
+
+beforeEach(() => {
+  useOwnContentStore.setState({ byId: {} });
+  jest.restoreAllMocks();
+});
+
+describe('ownContentStore lifecycle', () => {
+  it('records a note and reads it back, scoped to the active author', () => {
+    const store = useOwnContentStore.getState();
+    store.recordOwn(note('n1'), 'pending');
+
+    expect(store.getOwn('n1')?.status).toBe('pending');
+    expect(store.getOwn('n1', ME)?.event.content).toBe('hi n1');
+    // Profile isolation: a different active author cannot read it.
+    expect(store.getOwn('n1', OTHER)).toBeUndefined();
+  });
+
+  it('confirms a pending note to local; no-op once not pending', () => {
+    const store = useOwnContentStore.getState();
+    store.recordOwn(note('n1'), 'pending');
+    store.confirmOwn('n1');
+    expect(useOwnContentStore.getState().getOwn('n1')?.status).toBe('local');
+
+    // confirmOwn only promotes pending → local.
+    store.confirmOwn('n1');
+    expect(useOwnContentStore.getState().getOwn('n1')?.status).toBe('local');
+  });
+
+  it('removes a note (failed publish leaves no phantom)', () => {
+    const store = useOwnContentStore.getState();
+    store.recordOwn(note('n1'), 'pending');
+    store.removeOwn('n1');
+    expect(useOwnContentStore.getState().getOwn('n1')).toBeUndefined();
+  });
+
+  it('ingestSeen settles a note as confirmed and is idempotent', () => {
+    const store = useOwnContentStore.getState();
+    store.recordOwn(note('n1'), 'pending');
+    store.ingestSeen(note('n1'));
+    expect(useOwnContentStore.getState().getOwn('n1')?.status).toBe('confirmed');
+
+    const before = useOwnContentStore.getState().getOwn('n1')?.updatedAt;
+    store.ingestSeen(note('n1')); // already confirmed → no-op
+    expect(useOwnContentStore.getState().getOwn('n1')?.updatedAt).toBe(before);
+  });
+});
+
+describe('ingestOwnContent passive seam', () => {
+  it('records only our own kind:1 notes', () => {
+    ingestOwnContent([note('mine'), note('theirs', OTHER), { ...note('repost'), kind: 6 }], ME);
+    const store = useOwnContentStore.getState();
+    expect(store.getOwn('mine')?.status).toBe('confirmed');
+    expect(store.getOwn('theirs')).toBeUndefined(); // not ours
+    expect(store.getOwn('repost')).toBeUndefined(); // not kind:1
+  });
+
+  it('no-ops without a viewer pubkey', () => {
+    ingestOwnContent([note('mine')], undefined);
+    expect(useOwnContentStore.getState().getOwn('mine')).toBeUndefined();
+  });
+});
+
+describe('ownContentStore retention', () => {
+  it('FIFO-caps confirmed entries, evicting the oldest', () => {
+    const store = useOwnContentStore.getState();
+    let t = 1_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => (t += 1000));
+
+    for (let i = 0; i < MAX_CONFIRMED + 5; i += 1) {
+      store.ingestSeen(note(`c${i}`));
+    }
+
+    const byId = useOwnContentStore.getState().byId;
+    expect(Object.keys(byId)).toHaveLength(MAX_CONFIRMED);
+    // The five oldest were evicted.
+    expect(byId['c0']).toBeUndefined();
+    expect(byId['c4']).toBeUndefined();
+    expect(byId[`c${MAX_CONFIRMED + 4}`]).toBeDefined();
+  });
+
+  it('ages out a local note relays never echo back, but keeps recent ones', () => {
+    const store = useOwnContentStore.getState();
+    let now = 1_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
+
+    store.recordOwn(note('old'), 'pending');
+    store.confirmOwn('old'); // → local at `now`
+
+    now += LOCAL_GRACE_MS + 1; // advance past the grace window
+    store.recordOwn(note('fresh'), 'pending'); // triggers prune
+
+    const byId = useOwnContentStore.getState().byId;
+    expect(byId['old']).toBeUndefined(); // aged out
+    expect(byId['fresh']).toBeDefined();
+  });
+});

--- a/__tests__/publishComposed.test.ts
+++ b/__tests__/publishComposed.test.ts
@@ -16,6 +16,7 @@ jest.mock(
       created_at = 0;
       tags: string[][] = [];
     },
+    normalizeRelayUrl: (url: string) => url,
     useNDK: () => ({ ndk: null }),
   }),
   { virtual: true }
@@ -39,16 +40,19 @@ import { okAsync, errAsync } from 'neverthrow';
 import type NDK from '@nostr-dev-kit/ndk-mobile';
 
 import { publishEvent } from '@/shared/lib/nostr/publish';
+import { resolveOutboxRelays } from '@/shared/lib/nostr/outbox/recipientRelays';
 import { publishComposed } from '@/features/composer/publish/useComposerActions';
 import type { ComposerBlock } from '@/features/composer/config/types';
 
 const mockPublishEvent = publishEvent as unknown as jest.Mock;
+const mockResolveOutbox = resolveOutboxRelays as unknown as jest.Mock;
 const signerNdk = { signer: {} } as unknown as NDK;
 const text = (t: string): ComposerBlock => ({ id: 'x', kind: 'text', text: t });
 
 beforeEach(() => {
   mockPublishEvent.mockReset();
   mockPublishEvent.mockReturnValue(okAsync({ accepted: [{ url: 'wss://write.example' }] }));
+  mockResolveOutbox.mockClear();
 });
 
 describe('publishComposed', () => {
@@ -84,16 +88,33 @@ describe('publishComposed', () => {
     });
     expect(out).toBe('ok');
     expect(mockPublishEvent).toHaveBeenCalledTimes(1);
-    const event = mockPublishEvent.mock.calls[0][0].event;
-    expect(event.kind).toBe(1);
-    expect(event.content).toBe('nice post');
-    expect(event.tags).toEqual(
+    const call = mockPublishEvent.mock.calls[0][0];
+    expect(call.event.kind).toBe(1);
+    expect(call.event.content).toBe('nice post');
+    expect(call.event.tags).toEqual(
       expect.arrayContaining([
         ['e', 'root1', '', 'root'],
         ['e', 'p1', '', 'reply'],
         ['p', 'pub1'],
       ])
     );
+    // Optimistic publish; the reply's mention is resolved off the critical path.
+    expect(call.resolveOn).toBe('optimistic');
+    expect(call.backgroundRelays).toBeInstanceOf(Promise);
+    expect(mockResolveOutbox).toHaveBeenCalledTimes(1);
+  });
+
+  it('publishes a top-level note to own relays without fetching recipient relays', async () => {
+    const out = await publishComposed(signerNdk, {
+      blocks: [text('gm')],
+      target: { mode: 'new' },
+    });
+    expect(out).toBe('ok');
+    const call = mockPublishEvent.mock.calls[0][0];
+    expect(call.resolveOn).toBe('optimistic');
+    expect(call.backgroundRelays).toBeUndefined();
+    expect(call.relays).toEqual(['wss://write.example']); // own write relays, resolved synchronously
+    expect(mockResolveOutbox).not.toHaveBeenCalled(); // no mentions → no network fetch
   });
 
   it('returns failed when the publish seam errors', async () => {

--- a/__tests__/publishComposed.test.ts
+++ b/__tests__/publishComposed.test.ts
@@ -15,6 +15,9 @@ jest.mock(
       content = '';
       created_at = 0;
       tags: string[][] = [];
+      id = 'signed-evt-id';
+      pubkey = 'me-pubkey';
+      sign = jest.fn(async () => {});
     },
     normalizeRelayUrl: (url: string) => url,
     useNDK: () => ({ ndk: null }),
@@ -24,6 +27,19 @@ jest.mock(
 
 jest.mock('@/shared/lib/logger', () => ({
   nostrLog: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const mockOwnContent = {
+  recordOwn: jest.fn(),
+  confirmOwn: jest.fn(),
+  removeOwn: jest.fn(),
+};
+jest.mock('@/shared/stores/profile/ownContentStore', () => ({
+  useOwnContentStore: { getState: () => mockOwnContent },
+}));
+
+jest.mock('@/shared/lib/popup/popups/notePublished', () => ({
+  notePublishedPopup: jest.fn(),
 }));
 
 jest.mock('@/shared/lib/nostr/outbox/relayListStore', () => ({
@@ -41,11 +57,13 @@ import type NDK from '@nostr-dev-kit/ndk-mobile';
 
 import { publishEvent } from '@/shared/lib/nostr/publish';
 import { resolveOutboxRelays } from '@/shared/lib/nostr/outbox/recipientRelays';
+import { notePublishedPopup } from '@/shared/lib/popup/popups/notePublished';
 import { publishComposed } from '@/features/composer/publish/useComposerActions';
 import type { ComposerBlock } from '@/features/composer/config/types';
 
 const mockPublishEvent = publishEvent as unknown as jest.Mock;
 const mockResolveOutbox = resolveOutboxRelays as unknown as jest.Mock;
+const mockNotePublished = notePublishedPopup as unknown as jest.Mock;
 const signerNdk = { signer: {} } as unknown as NDK;
 const text = (t: string): ComposerBlock => ({ id: 'x', kind: 'text', text: t });
 
@@ -53,6 +71,10 @@ beforeEach(() => {
   mockPublishEvent.mockReset();
   mockPublishEvent.mockReturnValue(okAsync({ accepted: [{ url: 'wss://write.example' }] }));
   mockResolveOutbox.mockClear();
+  mockOwnContent.recordOwn.mockClear();
+  mockOwnContent.confirmOwn.mockClear();
+  mockOwnContent.removeOwn.mockClear();
+  mockNotePublished.mockClear();
 });
 
 describe('publishComposed', () => {
@@ -102,6 +124,14 @@ describe('publishComposed', () => {
     expect(call.resolveOn).toBe('optimistic');
     expect(call.backgroundRelays).toBeInstanceOf(Promise);
     expect(mockResolveOutbox).toHaveBeenCalledTimes(1);
+    // Records optimistically, confirms on success, and offers a "View" toast.
+    expect(mockOwnContent.recordOwn).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'signed-evt-id', kind: 1 }),
+      'pending'
+    );
+    expect(mockOwnContent.confirmOwn).toHaveBeenCalledWith('signed-evt-id');
+    expect(mockOwnContent.removeOwn).not.toHaveBeenCalled();
+    expect(mockNotePublished).toHaveBeenCalledWith({ eventId: 'signed-evt-id' });
   });
 
   it('publishes a top-level note to own relays without fetching recipient relays', async () => {
@@ -117,12 +147,20 @@ describe('publishComposed', () => {
     expect(mockResolveOutbox).not.toHaveBeenCalled(); // no mentions → no network fetch
   });
 
-  it('returns failed when the publish seam errors', async () => {
+  it('returns failed when the publish seam errors and drops the optimistic note', async () => {
     mockPublishEvent.mockReturnValue(errAsync({ type: 'all-failed', relayResults: [] }));
     const out = await publishComposed(signerNdk, {
       blocks: [text('hi')],
       target: { mode: 'new' },
     });
     expect(out).toBe('failed');
+    // No phantom: a failed publish removes the optimistic entry and shows no toast.
+    expect(mockOwnContent.recordOwn).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'signed-evt-id' }),
+      'pending'
+    );
+    expect(mockOwnContent.removeOwn).toHaveBeenCalledWith('signed-evt-id');
+    expect(mockOwnContent.confirmOwn).not.toHaveBeenCalled();
+    expect(mockNotePublished).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/publishEvent.test.ts
+++ b/__tests__/publishEvent.test.ts
@@ -12,7 +12,12 @@ jest.mock(
     __esModule: true,
     default: class NDK {},
     NDKEvent: class NDKEvent {},
-    NDKRelaySet: { fromRelayUrls: jest.fn() },
+    NDKRelaySet: {
+      // Resolve an explicit url set against the fake pool (mirrors NDK).
+      fromRelayUrls: jest.fn((urls: string[], ndk: { pool: { relays: Map<string, unknown> } }) => ({
+        relays: urls.map((u) => ndk.pool.relays.get(u)).filter(Boolean),
+      })),
+    },
     normalizeRelayUrl: (url: string) => url,
   }),
   { virtual: true }
@@ -180,5 +185,99 @@ describe('publishEvent', () => {
     });
 
     expect(seen).toEqual(expect.arrayContaining(['wss://a:true', 'wss://b:false']));
+  });
+});
+
+/** Drains background fan-out work (microtasks + zero-delay backoff timers). */
+const flushBackground = async (): Promise<void> => {
+  for (let i = 0; i < 20; i += 1) {
+    await Promise.resolve();
+    await new Promise((r) => setTimeout(r, 0));
+  }
+};
+
+describe('publishEvent optimistic mode', () => {
+  it('resolves ok on the first accept, then retries failed base relays in the background', async () => {
+    let badCalls = 0;
+    const good = relay('wss://good', accept);
+    const bad = relay('wss://bad', () => {
+      badCalls += 1;
+      return badCalls >= 2 ? Promise.resolve(true) : Promise.reject(new Error('temp'));
+    });
+    const ndk = fakeNdk([good, bad]);
+
+    const res = await publishEvent({
+      ndk,
+      event: signedEvent('opt1'),
+      relays: ['wss://good', 'wss://bad'],
+      resolveOn: 'optimistic',
+      retry: fastRetry,
+    });
+
+    expect(res.isOk()).toBe(true);
+    expect(res._unsafeUnwrap().anyAccepted).toBe(true);
+
+    await flushBackground();
+    expect(bad.publish).toHaveBeenCalledTimes(2); // failed round retried in the background
+  });
+
+  it('fails fast with no background retries when the first round accepts nowhere', async () => {
+    const bad = relay('wss://bad', reject('down'));
+    const ndk = fakeNdk([bad]);
+
+    const res = await publishEvent({
+      ndk,
+      event: signedEvent('opt2'),
+      relays: ['wss://bad'],
+      resolveOn: 'optimistic',
+      retry: fastRetry,
+    });
+
+    expect(res.isErr()).toBe(true);
+    expect(res._unsafeUnwrapErr().type).toBe('all-failed');
+
+    await flushBackground();
+    // No zombie retries: the user keeps the draft and may resubmit.
+    expect(bad.publish).toHaveBeenCalledTimes(1);
+  });
+
+  it('fans out to background recipient relays once the post is assured', async () => {
+    const own = relay('wss://own', accept);
+    const recipient = relay('wss://recipient', accept);
+    const ndk = fakeNdk([own, recipient]);
+
+    const res = await publishEvent({
+      ndk,
+      event: signedEvent('opt3'),
+      relays: ['wss://own'],
+      backgroundRelays: Promise.resolve(['wss://recipient']),
+      resolveOn: 'optimistic',
+      retry: fastRetry,
+    });
+
+    expect(res.isOk()).toBe(true);
+    expect(own.publish).toHaveBeenCalledTimes(1);
+
+    await flushBackground();
+    expect(recipient.publish).toHaveBeenCalledTimes(1); // reached off the critical path
+  });
+
+  it('skips background recipient relays when the post failed', async () => {
+    const own = relay('wss://own', reject('down'));
+    const recipient = relay('wss://recipient', accept);
+    const ndk = fakeNdk([own, recipient]);
+
+    const res = await publishEvent({
+      ndk,
+      event: signedEvent('opt4'),
+      relays: ['wss://own'],
+      backgroundRelays: Promise.resolve(['wss://recipient']),
+      resolveOn: 'optimistic',
+      retry: fastRetry,
+    });
+
+    expect(res.isErr()).toBe(true);
+    await flushBackground();
+    expect(recipient.publish).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/publishEvent.test.ts
+++ b/__tests__/publishEvent.test.ts
@@ -28,7 +28,7 @@ jest.mock('@/shared/lib/logger', () => ({
 }));
 
 import type NDK from '@nostr-dev-kit/ndk-mobile';
-import type { NDKEvent } from '@nostr-dev-kit/ndk-mobile';
+import { NDKRelaySet, type NDKEvent } from '@nostr-dev-kit/ndk-mobile';
 
 import { publishEvent } from '@/shared/lib/nostr/publish';
 
@@ -260,6 +260,25 @@ describe('publishEvent optimistic mode', () => {
 
     await flushBackground();
     expect(recipient.publish).toHaveBeenCalledTimes(1); // reached off the critical path
+  });
+
+  it('settles with an error (never hangs) when relay resolution throws', async () => {
+    const ndk = fakeNdk([relay('wss://x', accept)]);
+    (NDKRelaySet.fromRelayUrls as jest.Mock).mockImplementationOnce(() => {
+      throw new Error('relay set boom');
+    });
+
+    // If `assured` failed to settle this `await` would hang and time out.
+    const res = await publishEvent({
+      ndk,
+      event: signedEvent('throw1'),
+      relays: ['wss://x'],
+      resolveOn: 'optimistic',
+      retry: fastRetry,
+    });
+
+    expect(res.isErr()).toBe(true);
+    expect(res._unsafeUnwrapErr().type).toBe('all-failed');
   });
 
   it('skips background recipient relays when the post failed', async () => {

--- a/docs/adr/0001-optimistic-publish-and-own-content-store.md
+++ b/docs/adr/0001-optimistic-publish-and-own-content-store.md
@@ -1,0 +1,66 @@
+# 1. Optimistic publishing, a local own-content store, and viewer-state ownership
+
+Date: 2026-06-20
+Status: Accepted
+
+## Context
+
+Posting felt slow. The composer awaited `resolveOn: 'all-settled'` and kept the
+UI blocked until the *slowest* relay either acknowledged or exhausted the full
+retry budget (10s/relay × up to 3 rounds). Publishing was already parallel with
+warm connections — the cost was waiting for everyone, not serial writes.
+
+Separately, the app had no local record of the notes we authored. A just-posted
+note wasn't readable until it round-tripped through relays/nagg, so a thread
+opened to it could show "Post not found", and there was no fast "View" affordance
+after posting. Cross-cutting viewer-state (did *I* like/repost/quote/reply; do I
+follow this profile) was computed entirely client-side from relay subscriptions.
+
+## Decisions
+
+1. **Optimistic publishing.** Add a third publish-seam mode, `optimistic`:
+   resolve the caller the instant the first relay accepts (so the composer can
+   dismiss), and finish the fan-out + retries in the background. If the first
+   round accepts nowhere, resolve `all-failed` immediately so the composer stays
+   open with the draft intact — and abandon the background work (no zombie
+   publish for a post the user will retry). The seam guarantees its returned
+   promise always settles (a throw in the background resolves `all-failed`).
+   `first-ok`/`all-settled` behavior is unchanged; replaceable lists (kind:3,
+   kind:10002) and polls keep `all-settled`.
+
+2. **Local own-content store.** Introduce `ownContentStore`, a per-profile,
+   persisted, `event.id`-keyed cache of own kind:1 notes. It is recorded
+   optimistically on publish, reconciled by exact id (a signed note already
+   knows its id), and read as a note-by-id fallback by the thread reader so
+   "View" opens instantly and "Post not found" is fixed for own content.
+   Cross-client convergence is **passive**: own notes the app already encounters
+   (feed/thread reads) are ingested — no dedicated always-on subscription.
+
+3. **Viewer-state belongs in nagg (future).** The authoritative source for
+   per-viewer engagement/follow state should be nagg app-view payloads across
+   feed/thread/profile endpoints (the viewer pubkey is already passed), reducing
+   reliance on client relay subscriptions. This is scoped as a separate nagg
+   repo change, not part of this app-side work.
+
+## Consequences
+
+- Posting feels instant; a slow/dead relay no longer blocks the UI.
+- A just-posted note is locally viewable; the post toast's "View" opens its
+  thread with no relay round-trip.
+- A failed publish leaves no phantom (the optimistic entry is removed).
+- The store is bounded (FIFO cap on `confirmed`, grace age-out for `local`) and
+  profile-isolated (scoped storage + per-entry author filter).
+- Viewer-state still comes from relay subscriptions until the nagg work lands;
+  this ADR records the intended direction so the two don't diverge.
+
+## Alternatives considered
+
+- **Switch the composer to `first-ok`** — fast, but drops the wide fan-out notes
+  need; rejected in favor of `optimistic` (first-ok responsiveness *with*
+  background reach).
+- **Generic note-by-id cache for all notes** — larger, riskier feed-wide
+  refactor; deferred. The store is scoped to own content, where the value
+  (instant View, no relay dependency) is highest.
+- **Dedicated own-notes subscription** — eager convergence at the cost of an
+  always-on subscription; rejected for passive ingest, which matches "store what
+  we already see".

--- a/features/composer/publish/useComposerActions.ts
+++ b/features/composer/publish/useComposerActions.ts
@@ -15,6 +15,7 @@ import { router } from 'expo-router';
 import { nostrLog } from '@/shared/lib/logger';
 import { getOwnWriteRelays } from '@/shared/lib/nostr/outbox/relayListStore';
 import { resolveOutboxRelays } from '@/shared/lib/nostr/outbox/recipientRelays';
+import { resolveWriteRelays } from '@/shared/lib/nostr/outbox/resolveWriteRelays';
 import { publishEvent } from '@/shared/lib/nostr/publish';
 import { buildPollEvent } from '@/features/feed/components/nostr/poll/buildPollEvents';
 import {
@@ -115,13 +116,20 @@ export async function publishComposed(ndk: NDK, draft: ComposedDraft): Promise<P
     return 'empty';
   }
 
-  const relayHint = getOwnWriteRelays()[0];
+  const ownWriteRelays = getOwnWriteRelays();
+  const relayHint = ownWriteRelays[0];
+  const hintRelays = relayHint ? [relayHint] : undefined;
   const mentionPubkeys = note.tags.filter((t) => t[0] === 'p').map((t) => t[1]);
-  const relays = await resolveOutboxRelays(ndk, {
-    ownWriteRelays: getOwnWriteRelays(),
-    mentionPubkeys,
-    hintRelays: relayHint ? [relayHint] : undefined,
-  });
+
+  // Base set = the author's own write relays, resolved synchronously (no
+  // network) so the optimistic publish can fire immediately.
+  const baseRelays = resolveWriteRelays({ ownWriteRelays, hintRelays });
+  // Recipient inbox relays need a network fetch (their NIP-65 lists); resolve
+  // them off the critical path and fold them into the background fan-out so
+  // mentions still reach their inboxes without the user waiting on the fetch.
+  const backgroundRelays = mentionPubkeys.length
+    ? resolveOutboxRelays(ndk, { ownWriteRelays, mentionPubkeys, hintRelays })
+    : undefined;
 
   const event = new NDKEvent(ndk);
   event.kind = note.kind;
@@ -129,7 +137,13 @@ export async function publishComposed(ndk: NDK, draft: ComposedDraft): Promise<P
   event.created_at = note.created_at;
   event.tags = note.tags;
 
-  const result = await publishEvent({ ndk, event, relays, resolveOn: 'all-settled' });
+  const result = await publishEvent({
+    ndk,
+    event,
+    relays: baseRelays,
+    backgroundRelays,
+    resolveOn: 'optimistic',
+  });
   if (result.isErr()) {
     nostrLog.warn('composer.publish_failed', { reason: result.error.type });
     return 'failed';

--- a/features/composer/publish/useComposerActions.ts
+++ b/features/composer/publish/useComposerActions.ts
@@ -17,6 +17,9 @@ import { getOwnWriteRelays } from '@/shared/lib/nostr/outbox/relayListStore';
 import { resolveOutboxRelays } from '@/shared/lib/nostr/outbox/recipientRelays';
 import { resolveWriteRelays } from '@/shared/lib/nostr/outbox/resolveWriteRelays';
 import { publishEvent } from '@/shared/lib/nostr/publish';
+import { notePublishedPopup } from '@/shared/lib/popup/popups/notePublished';
+import { useOwnContentStore } from '@/shared/stores/profile/ownContentStore';
+import type { FeedEvent } from '@/features/feed/components/nostr/feedTypes';
 import { buildPollEvent } from '@/features/feed/components/nostr/poll/buildPollEvents';
 import {
   useComposerStore,
@@ -137,6 +140,28 @@ export async function publishComposed(ndk: NDK, draft: ComposedDraft): Promise<P
   event.created_at = note.created_at;
   event.tags = note.tags;
 
+  // Sign now so we have the final event id before publishing: it lets us record
+  // the note locally (optimistic) and point the "View" toast at its thread.
+  try {
+    await event.sign();
+  } catch (error) {
+    nostrLog.warn('composer.sign_failed', {
+      reason: error instanceof Error ? error.message : 'unknown',
+    });
+    return 'failed';
+  }
+
+  const ownNote: FeedEvent = {
+    id: event.id,
+    kind: note.kind,
+    pubkey: event.pubkey,
+    content: note.content,
+    tags: note.tags,
+    created_at: note.created_at,
+  };
+  const ownContent = useOwnContentStore.getState();
+  ownContent.recordOwn(ownNote, 'pending');
+
   const result = await publishEvent({
     ndk,
     event,
@@ -145,9 +170,12 @@ export async function publishComposed(ndk: NDK, draft: ComposedDraft): Promise<P
     resolveOn: 'optimistic',
   });
   if (result.isErr()) {
+    ownContent.removeOwn(ownNote.id); // no phantom: a failed post never lingers
     nostrLog.warn('composer.publish_failed', { reason: result.error.type });
     return 'failed';
   }
+  ownContent.confirmOwn(ownNote.id);
+  notePublishedPopup({ eventId: ownNote.id });
   nostrLog.info('composer.published', {
     mode: draft.target.mode,
     accepted: result.value.accepted.length,

--- a/features/feed/data/naggFeedClient.ts
+++ b/features/feed/data/naggFeedClient.ts
@@ -62,6 +62,7 @@ import type {
   PostsByPubkeysRequest,
 } from './feedClient';
 import { emptyFeedParseResult } from './feedClient';
+import { ingestOwnContent } from '@/shared/stores/profile/ownContentStore';
 import { hasEmptyExplicitPubkeys, hydrateSpecWithPubkey } from './feedSpec';
 import { parseJson } from '../components/nostr/feedParse';
 import type { FeedEvent, NoteMetrics, ProfileInfo } from '../components/nostr/feedTypes';
@@ -1465,6 +1466,24 @@ function collectHydrationFromGraphqlNodes(nodes: GraphqlEventNode[]): {
   };
 }
 
+/**
+ * Own-note candidates from a feed page — note events, their roots, and reposted
+ * originals. `ingestOwnContent` filters these to our own kind:1, so passing the
+ * superset here is safe and keeps the choke-point in one place.
+ */
+function ownNoteCandidatesFromFeed(result: FeedParseResult): FeedEvent[] {
+  const events: FeedEvent[] = [];
+  for (const item of result.orderedFeedItems) {
+    if (item.type === 'note') {
+      events.push(item.event);
+      if (item.rootEvent) events.push(item.rootEvent);
+    } else if (item.originalEvent) {
+      events.push(item.originalEvent);
+    }
+  }
+  return events;
+}
+
 function compareNotificationsNewestFirst(
   left: FeedNotificationsResult['notifications'][number],
   right: FeedNotificationsResult['notifications'][number]
@@ -1681,8 +1700,10 @@ export function createNaggFeedClient(): FeedClient {
       timeoutMs,
     }: FeedPageRequest) {
       const startedAt = Date.now();
-      const logResult = (source: string, result: FeedParseResult): FeedParseResult =>
-        logFeedPageResult(source, result, {
+      const logResult = (source: string, result: FeedParseResult): FeedParseResult => {
+        // Passive convergence: settle any of our own notes this page surfaced.
+        ingestOwnContent(ownNoteCandidatesFromFeed(result), userPubkey);
+        return logFeedPageResult(source, result, {
           limit,
           until,
           offset,
@@ -1690,6 +1711,7 @@ export function createNaggFeedClient(): FeedClient {
           viewerPubkey: !!userPubkey,
           durationMs: Date.now() - startedAt,
         });
+      };
       const hydratedSpec = hydrateSpecWithPubkey(spec, userPubkey);
       if (hasEmptyExplicitPubkeys(hydratedSpec)) {
         return logResult('empty-explicit-pubkeys', emptyFeedParseResult());

--- a/features/feed/hooks/useThread.ts
+++ b/features/feed/hooks/useThread.ts
@@ -12,7 +12,7 @@ import type {
   ThreadSeedBuckets,
 } from '@/features/feed/data/feedClient';
 import { getFeedClient } from '@/features/feed/data/useFeedClient';
-import { consumeThreadSeed } from '@/features/feed/lib/threadSeedCache';
+import { consumeThreadSeed, type ThreadSeed } from '@/features/feed/lib/threadSeedCache';
 import {
   bucketsFromThreadResult,
   buildThreadItemsFromResult,
@@ -23,6 +23,23 @@ import {
 } from '@/features/feed/lib/threadItems';
 import { feedLog } from '@/shared/lib/logger';
 import { useNostrKeysContext } from '@/shared/providers/NostrKeysProvider';
+import { ingestOwnContent, useOwnContentStore } from '@/shared/stores/profile/ownContentStore';
+
+/**
+ * Build a single-note thread seed from a locally-stored own note, so a just-
+ * posted (or other-client) note opens its thread instantly even before it has
+ * round-tripped through relays/nagg. Scoped to the active viewer.
+ */
+function ownContentSeed(eventId: string, viewerPubkey: string | undefined): ThreadSeed | undefined {
+  const entry = useOwnContentStore.getState().getOwn(eventId, viewerPubkey);
+  if (!entry) return undefined;
+  return {
+    allEvents: new Map([[eventId, entry.event]]),
+    profiles: new Map(),
+    metrics: new Map(),
+    quotedEvents: new Map(),
+  };
+}
 
 export type { ThreadItem } from '@/features/feed/lib/threadItems';
 
@@ -84,6 +101,8 @@ export function useThread(eventId: string): UseThreadResult {
         .filter((item): item is Extract<ThreadItem, { type: 'reply' }> => item.type === 'reply')
         .map((item) => item.event.id);
       threadSeedRef.current = bucketsFromThreadResult(result);
+      // Passive convergence: settle any own notes this thread surfaced.
+      ingestOwnContent(threadSeedRef.current.allEvents.values(), viewerPubkey);
       profilesRef.current = result.profiles;
       metricsRef.current = result.metrics;
       quotedEventsRef.current = result.quotedEvents;
@@ -109,7 +128,7 @@ export function useThread(eventId: string): UseThreadResult {
 
       return built;
     },
-    [eventId, replySort]
+    [eventId, replySort, viewerPubkey]
   );
 
   const loadMoreReplies = useCallback(async () => {
@@ -207,9 +226,9 @@ export function useThread(eventId: string): UseThreadResult {
     setIsLoadingMoreReplies(false);
     setHasMoreReplies(false);
 
-    const seed = eventChanged
-      ? consumeThreadSeed(eventId)
-      : (preservedSeed ?? consumeThreadSeed(eventId));
+    const seed =
+      (eventChanged ? consumeThreadSeed(eventId) : (preservedSeed ?? consumeThreadSeed(eventId))) ??
+      ownContentSeed(eventId, viewerPubkey);
     if (seed) {
       threadSeedRef.current = seed;
       const seeded = buildThreadItemsFromSeed(eventId, seed);
@@ -270,7 +289,9 @@ export function useThread(eventId: string): UseThreadResult {
         replyOffsetRef.current = result.loadedReplyCount;
 
         if (!applyThreadResult(result, 'initial')) {
-          setError('Post not found');
+          // A locally-seeded own note may not be on nagg yet — keep the seeded
+          // render instead of clobbering it with a not-found error.
+          if (!seed) setError('Post not found');
           setIsLoading(false);
           setIsFetching(false);
           return;

--- a/shared/lib/cashu/profileScopedStorage.ts
+++ b/shared/lib/cashu/profileScopedStorage.ts
@@ -129,6 +129,7 @@ export const PROFILE_SCOPED_STORE_KEYS = [
   'transaction-location-store',
   'transaction-distribution-store',
   'nostr-social-store',
+  'own-content-store',
   'nostr-relay-list-store',
   'nostr-media-server-store',
   'nostr-metadata-cache',
@@ -174,6 +175,7 @@ async function rehydrateProfileStores(): Promise<void> {
   const { useTransactionDistributionStore } =
     await import('@/shared/stores/profile/transactionDistributionStore');
   const { useNostrSocialStore } = await import('@/shared/stores/profile/nostrSocialStore');
+  const { useOwnContentStore } = await import('@/shared/stores/profile/ownContentStore');
   const { useNpcMintStore } = await import('@/shared/stores/profile/npcMintStore');
   const { useThemeStore } = await import('@/shared/stores/profile/themeStore');
   const { useBitchatDmMessagesStore } = await import('@/features/bitchat/stores/bitchatDmMessages');
@@ -222,6 +224,7 @@ async function rehydrateProfileStores(): Promise<void> {
         optimisticLikesByEventId: {},
         optimisticRepostsByEventId: {},
       });
+      useOwnContentStore.setState({ byId: {} });
       useThemeStore.setState({
         _hasHydrated: false,
         activeAlbumSlug: null,
@@ -248,6 +251,7 @@ async function rehydrateProfileStores(): Promise<void> {
     useTransactionDistributionStore.persist.rehydrate(),
     useNpcMintStore.persist.rehydrate(),
     useNostrSocialStore.persist.rehydrate(),
+    useOwnContentStore.persist.rehydrate(),
     useThemeStore.persist.rehydrate(),
     useBitchatDmMessagesStore.persist.rehydrate(),
     useFeedIgnoreStore.persist.rehydrate(),

--- a/shared/lib/nostr/publish/publishEvent.ts
+++ b/shared/lib/nostr/publish/publishEvent.ts
@@ -12,6 +12,11 @@
  * `relay.publish(event, timeoutMs)` resolves on the relay's OK frame and
  * rejects on error/timeout. Unlike `NDKRelaySet.publish`, this gives genuine
  * per-relay outcomes and resolve-on-first-accept.
+ *
+ * Three resolve modes, one engine: `first-ok` and `all-settled` resolve only
+ * once the fan-out is done; `optimistic` resolves the instant the first relay
+ * accepts and finishes the fan-out (plus recipient/outbox relays) in the
+ * background — see {@link runOptimistic}.
  */
 import NDK, { NDKEvent, NDKRelaySet, normalizeRelayUrl } from '@nostr-dev-kit/ndk-mobile';
 import type { NDKRelay } from '@nostr-dev-kit/ndk-mobile';
@@ -31,10 +36,24 @@ import type {
   RetryPolicy,
 } from '@/shared/lib/nostr/publish/types';
 
-/** In-flight publishes keyed by signed event id — joins duplicate calls. */
+/**
+ * In-flight publishes keyed by signed event id — joins duplicate calls. For
+ * `optimistic` publishes the entry is held until the BACKGROUND fan-out
+ * finishes (not just first-accept), so a duplicate during the background window
+ * still joins instead of starting a second fan-out.
+ */
 const inFlight = new Map<string, Promise<Result<PublishResult, PublishError>>>();
 
 const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+type AcceptResult = Extract<PublishRelayResult, { ok: true }>;
+
+/** Assembles the structured result from a set of per-relay outcomes. */
+function buildPublishResult(eventId: string, relayResults: PublishRelayResult[]): PublishResult {
+  const accepted = relayResults.filter((r): r is AcceptResult => r.ok);
+  const failed = relayResults.filter((r): r is Extract<PublishRelayResult, { ok: false }> => !r.ok);
+  return { eventId, relayResults, accepted, failed, anyAccepted: accepted.length > 0 };
+}
 
 /**
  * Resolves the target {@link NDKRelay} objects. With an explicit url set, builds
@@ -75,48 +94,205 @@ async function publishOne(
 }
 
 /**
- * Publishes to every relay, retrying only the failed ones with exponential
- * backoff. `first-ok` short-circuits the retry loop once any relay accepts.
+ * Publishes to every relay concurrently, once. `onAccept` fires the instant any
+ * relay accepts (before the round settles) — the hook the optimistic mode uses
+ * to resolve on the genuine first accept rather than the slowest relay.
  */
-async function publishToRelays(
+async function publishRound(
+  relays: NDKRelay[],
+  event: NDKEvent,
+  timeoutMs: number,
+  onAccept?: (result: AcceptResult) => void
+): Promise<{ results: PublishRelayResult[]; failed: NDKRelay[] }> {
+  const settled = await Promise.all(
+    relays.map(async (relay) => {
+      const result = await publishOne(relay, event, timeoutMs);
+      if (result.ok) onAccept?.(result);
+      return { result, relay };
+    })
+  );
+  return {
+    results: settled.map((s) => s.result),
+    failed: settled.filter((s) => !s.result.ok).map((s) => s.relay),
+  };
+}
+
+interface FanOutHooks {
+  resolveOn: 'first-ok' | 'all-settled';
+  onAccept?: (result: AcceptResult) => void;
+  onRelayResult?: (result: PublishRelayResult) => void;
+  /**
+   * Called after each round settles with the 0-based attempt index and whether
+   * any relay has accepted so far. Return `true` to stop the fan-out early
+   * (the optimistic mode uses this to bail after a fully-failed first round).
+   */
+  onRoundSettled?: (attempt: number, anyAccepted: boolean) => boolean;
+}
+
+/**
+ * Runs the full retry budget over `relays`, retrying only the relays that
+ * failed, accumulating terminal outcomes into `finalByUrl`. The single engine
+ * behind all resolve modes.
+ */
+async function fanOut(
   relays: NDKRelay[],
   event: NDKEvent,
   timeoutMs: number,
   policy: RetryPolicy,
-  resolveOn: 'first-ok' | 'all-settled',
-  onRelayResult?: (result: PublishRelayResult) => void
-): Promise<PublishRelayResult[]> {
-  const finalByUrl = new Map<string, PublishRelayResult>();
+  finalByUrl: Map<string, PublishRelayResult>,
+  hooks: FanOutHooks
+): Promise<void> {
   let pending = relays;
-
   for (let attempt = 0; attempt <= policy.attempts; attempt += 1) {
     if (pending.length === 0) break;
 
-    const settled = await Promise.all(pending.map((relay) => publishOne(relay, event, timeoutMs)));
-    const nextPending: NDKRelay[] = [];
-
-    settled.forEach((result, i) => {
-      if (result.ok) {
-        finalByUrl.set(result.url, result);
-        onRelayResult?.(result);
-        return;
-      }
-      // Record the latest failure; retry unless this was the last round.
+    const { results, failed } = await publishRound(pending, event, timeoutMs, hooks.onAccept);
+    const isLast = attempt === policy.attempts;
+    for (const result of results) {
       finalByUrl.set(result.url, result);
-      if (attempt < policy.attempts) {
-        nextPending.push(pending[i]);
-      } else {
-        onRelayResult?.(result);
-      }
-    });
+      // Accepts stream immediately; failures only once they're terminal (last round).
+      if (result.ok || isLast) hooks.onRelayResult?.(result);
+    }
 
-    if (resolveOn === 'first-ok' && [...finalByUrl.values()].some((r) => r.ok)) break;
+    const anyAccepted = [...finalByUrl.values()].some((r) => r.ok);
+    if (hooks.onRoundSettled?.(attempt, anyAccepted)) return;
+    if (hooks.resolveOn === 'first-ok' && anyAccepted) return;
 
-    pending = nextPending;
+    pending = isLast ? [] : failed;
     if (pending.length > 0) await delay(backoffDelayMs(attempt, policy));
   }
+}
 
-  return [...finalByUrl.values()];
+interface PublishRun {
+  /** Resolves when delivery is assured (or has definitively failed). */
+  assured: Promise<Result<PublishResult, PublishError>>;
+  /** Resolves when ALL work — including background fan-out — has finished. */
+  done: Promise<void>;
+}
+
+/**
+ * Optimistic publish: resolve `assured` the instant the first relay accepts so
+ * the UI can dismiss, then finish the fan-out and the recipient/outbox relays
+ * in the background. If the first round over the base relays accepts nowhere,
+ * resolve `all-failed` immediately and abandon the rest (the caller keeps the
+ * composer open with the draft intact).
+ */
+function runOptimistic(
+  ndk: NDK,
+  event: NDKEvent,
+  eventId: string,
+  timeoutMs: number,
+  policy: RetryPolicy,
+  opts: PublishOptions
+): PublishRun {
+  let settle!: (result: Result<PublishResult, PublishError>) => void;
+  const assured = new Promise<Result<PublishResult, PublishError>>((resolve) => {
+    settle = resolve;
+  });
+  // Held on an object so TS doesn't narrow it away across the `await` below
+  // (it's only ever mutated inside the fan-out callbacks).
+  const status = { resolved: false, ok: false };
+  const resolveAssured = (result: Result<PublishResult, PublishError>): void => {
+    if (status.resolved) return;
+    status.resolved = true;
+    status.ok = result.isOk();
+    settle(result);
+  };
+
+  const finalByUrl = new Map<string, PublishRelayResult>();
+  const onAccept = (result: AcceptResult): void =>
+    resolveAssured(ok(buildPublishResult(eventId, [result])));
+
+  const done = (async (): Promise<void> => {
+    const base = targetRelays(ndk, opts.relays);
+    if (base.length === 0) {
+      nostrLog.warn('nostr.publish.no_relays', { kind: event.kind });
+      resolveAssured(err({ type: 'no-relays' }));
+      return;
+    }
+
+    await fanOut(base, event, timeoutMs, policy, finalByUrl, {
+      resolveOn: 'all-settled',
+      onAccept,
+      onRelayResult: opts.onRelayResult,
+      onRoundSettled: (attempt, anyAccepted) => {
+        if (attempt === 0 && !anyAccepted) {
+          // Nothing accepted on the first attempt: surface the failure now so
+          // the user keeps their draft, and don't leave a zombie background
+          // publish running for a post they'll likely retry.
+          nostrLog.error('nostr.publish.all_failed', {
+            kind: event.kind,
+            relayCount: finalByUrl.size,
+          });
+          resolveAssured(err({ type: 'all-failed', relayResults: [...finalByUrl.values()] }));
+          return true;
+        }
+        return false;
+      },
+    });
+
+    if (!status.ok) return;
+
+    // Recipient (outbox) relays: best-effort reach, off the user's critical
+    // path. Failures here never surface — the note is already on the network.
+    if (opts.backgroundRelays) {
+      const extraUrls = await opts.backgroundRelays.catch(() => [] as readonly string[]);
+      const extra = targetRelays(ndk, extraUrls).filter((relay) => !finalByUrl.has(relay.url));
+      if (extra.length > 0) {
+        await fanOut(extra, event, timeoutMs, policy, finalByUrl, {
+          resolveOn: 'all-settled',
+          onRelayResult: opts.onRelayResult,
+        });
+      }
+    }
+
+    const accepted = [...finalByUrl.values()].filter((r) => r.ok).length;
+    nostrLog.info('nostr.publish.optimistic_settled', {
+      kind: event.kind,
+      accepted,
+      relayCount: finalByUrl.size,
+    });
+  })();
+
+  return { assured, done };
+}
+
+/** Runs `first-ok` / `all-settled`: a single fan-out, resolved once it's done. */
+async function runBlocking(
+  ndk: NDK,
+  event: NDKEvent,
+  eventId: string,
+  timeoutMs: number,
+  policy: RetryPolicy,
+  opts: PublishOptions
+): Promise<Result<PublishResult, PublishError>> {
+  const relays = targetRelays(ndk, opts.relays);
+  if (relays.length === 0) {
+    nostrLog.warn('nostr.publish.no_relays', { kind: event.kind });
+    return err({ type: 'no-relays' });
+  }
+
+  const finalByUrl = new Map<string, PublishRelayResult>();
+  await fanOut(relays, event, timeoutMs, policy, finalByUrl, {
+    resolveOn: opts.resolveOn === 'first-ok' ? 'first-ok' : 'all-settled',
+    onRelayResult: opts.onRelayResult,
+  });
+
+  const result = buildPublishResult(eventId, [...finalByUrl.values()]);
+  if (!result.anyAccepted) {
+    nostrLog.error('nostr.publish.all_failed', {
+      kind: event.kind,
+      relayCount: result.relayResults.length,
+    });
+    return err({ type: 'all-failed', relayResults: result.relayResults });
+  }
+
+  nostrLog.info('nostr.publish.ok', {
+    kind: event.kind,
+    accepted: result.accepted.length,
+    failed: result.failed.length,
+  });
+  return ok(result);
 }
 
 async function runPublish(opts: PublishOptions): Promise<Result<PublishResult, PublishError>> {
@@ -143,44 +319,21 @@ async function runPublish(opts: PublishOptions): Promise<Result<PublishResult, P
   const existing = inFlight.get(eventId);
   if (existing) return existing;
 
-  const run = (async (): Promise<Result<PublishResult, PublishError>> => {
-    const relays = targetRelays(ndk, opts.relays);
-    if (relays.length === 0) {
-      nostrLog.warn('nostr.publish.no_relays', { kind: event.kind });
-      return err({ type: 'no-relays' });
-    }
+  if (resolveOn === 'optimistic') {
+    const { assured, done } = runOptimistic(ndk, event, eventId, timeoutMs, policy, opts);
+    inFlight.set(eventId, assured);
+    void done
+      .catch((error: unknown) =>
+        nostrLog.error('nostr.publish.background_failed', {
+          kind: event.kind,
+          message: error instanceof Error ? error.message : String(error),
+        })
+      )
+      .finally(() => inFlight.delete(eventId));
+    return assured;
+  }
 
-    const relayResults = await publishToRelays(
-      relays,
-      event,
-      timeoutMs,
-      policy,
-      resolveOn,
-      opts.onRelayResult
-    );
-    const accepted = relayResults.filter(
-      (r): r is Extract<PublishRelayResult, { ok: true }> => r.ok
-    );
-    const failed = relayResults.filter(
-      (r): r is Extract<PublishRelayResult, { ok: false }> => !r.ok
-    );
-
-    if (accepted.length === 0) {
-      nostrLog.error('nostr.publish.all_failed', {
-        kind: event.kind,
-        relayCount: relayResults.length,
-      });
-      return err({ type: 'all-failed', relayResults });
-    }
-
-    nostrLog.info('nostr.publish.ok', {
-      kind: event.kind,
-      accepted: accepted.length,
-      failed: failed.length,
-    });
-    return ok({ eventId, relayResults, accepted, failed, anyAccepted: true });
-  })();
-
+  const run = runBlocking(ndk, event, eventId, timeoutMs, policy, opts);
   inFlight.set(eventId, run);
   try {
     return await run;

--- a/shared/lib/nostr/publish/publishEvent.ts
+++ b/shared/lib/nostr/publish/publishEvent.ts
@@ -204,54 +204,71 @@ function runOptimistic(
     resolveAssured(ok(buildPublishResult(eventId, [result])));
 
   const done = (async (): Promise<void> => {
-    const base = targetRelays(ndk, opts.relays);
-    if (base.length === 0) {
-      nostrLog.warn('nostr.publish.no_relays', { kind: event.kind });
-      resolveAssured(err({ type: 'no-relays' }));
-      return;
-    }
-
-    await fanOut(base, event, timeoutMs, policy, finalByUrl, {
-      resolveOn: 'all-settled',
-      onAccept,
-      onRelayResult: opts.onRelayResult,
-      onRoundSettled: (attempt, anyAccepted) => {
-        if (attempt === 0 && !anyAccepted) {
-          // Nothing accepted on the first attempt: surface the failure now so
-          // the user keeps their draft, and don't leave a zombie background
-          // publish running for a post they'll likely retry.
-          nostrLog.error('nostr.publish.all_failed', {
-            kind: event.kind,
-            relayCount: finalByUrl.size,
-          });
-          resolveAssured(err({ type: 'all-failed', relayResults: [...finalByUrl.values()] }));
-          return true;
-        }
-        return false;
-      },
-    });
-
-    if (!status.ok) return;
-
-    // Recipient (outbox) relays: best-effort reach, off the user's critical
-    // path. Failures here never surface — the note is already on the network.
-    if (opts.backgroundRelays) {
-      const extraUrls = await opts.backgroundRelays.catch(() => [] as readonly string[]);
-      const extra = targetRelays(ndk, extraUrls).filter((relay) => !finalByUrl.has(relay.url));
-      if (extra.length > 0) {
-        await fanOut(extra, event, timeoutMs, policy, finalByUrl, {
-          resolveOn: 'all-settled',
-          onRelayResult: opts.onRelayResult,
-        });
+    try {
+      const base = targetRelays(ndk, opts.relays);
+      if (base.length === 0) {
+        nostrLog.warn('nostr.publish.no_relays', { kind: event.kind });
+        resolveAssured(err({ type: 'no-relays' }));
+        return;
       }
-    }
 
-    const accepted = [...finalByUrl.values()].filter((r) => r.ok).length;
-    nostrLog.info('nostr.publish.optimistic_settled', {
-      kind: event.kind,
-      accepted,
-      relayCount: finalByUrl.size,
-    });
+      await fanOut(base, event, timeoutMs, policy, finalByUrl, {
+        resolveOn: 'all-settled',
+        onAccept,
+        onRelayResult: opts.onRelayResult,
+        onRoundSettled: (attempt, anyAccepted) => {
+          if (attempt === 0 && !anyAccepted) {
+            // Nothing accepted on the first attempt: surface the failure now so
+            // the user keeps their draft, and don't leave a zombie background
+            // publish running for a post they'll likely retry.
+            nostrLog.error('nostr.publish.all_failed', {
+              kind: event.kind,
+              relayCount: finalByUrl.size,
+            });
+            resolveAssured(err({ type: 'all-failed', relayResults: [...finalByUrl.values()] }));
+            return true;
+          }
+          return false;
+        },
+      });
+
+      if (!status.ok) return;
+
+      // Recipient (outbox) relays: best-effort reach, off the user's critical
+      // path. Failures here never surface — the note is already on the network.
+      if (opts.backgroundRelays) {
+        const extraUrls = await opts.backgroundRelays.catch((error: unknown) => {
+          nostrLog.warn('nostr.publish.background_relays_unresolved', {
+            kind: event.kind,
+            message: error instanceof Error ? error.message : String(error),
+          });
+          return [] as readonly string[];
+        });
+        const extra = targetRelays(ndk, extraUrls).filter((relay) => !finalByUrl.has(relay.url));
+        if (extra.length > 0) {
+          await fanOut(extra, event, timeoutMs, policy, finalByUrl, {
+            resolveOn: 'all-settled',
+            onRelayResult: opts.onRelayResult,
+          });
+        }
+      }
+
+      const accepted = [...finalByUrl.values()].filter((r) => r.ok).length;
+      nostrLog.info('nostr.publish.optimistic_settled', {
+        kind: event.kind,
+        accepted,
+        relayCount: finalByUrl.size,
+      });
+    } catch (error) {
+      // Never let the UI hang: if anything threw before delivery was assured,
+      // settle `assured` now (idempotent, so a post-assurance throw is just
+      // logged). Guarantees the returned promise always resolves.
+      nostrLog.error('nostr.publish.optimistic_threw', {
+        kind: event.kind,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      resolveAssured(err({ type: 'all-failed', relayResults: [...finalByUrl.values()] }));
+    }
   })();
 
   return { assured, done };

--- a/shared/lib/nostr/publish/publishEvent.ts
+++ b/shared/lib/nostr/publish/publishEvent.ts
@@ -337,16 +337,12 @@ async function runPublish(opts: PublishOptions): Promise<Result<PublishResult, P
   if (existing) return existing;
 
   if (resolveOn === 'optimistic') {
+    // `assured` resolves on first accept; the dedup entry is held until the
+    // background fan-out finishes. `done` settles its own errors internally
+    // (see runOptimistic), so it never rejects — just clean up when it's done.
     const { assured, done } = runOptimistic(ndk, event, eventId, timeoutMs, policy, opts);
     inFlight.set(eventId, assured);
-    void done
-      .catch((error: unknown) =>
-        nostrLog.error('nostr.publish.background_failed', {
-          kind: event.kind,
-          message: error instanceof Error ? error.message : String(error),
-        })
-      )
-      .finally(() => inFlight.delete(eventId));
+    void done.finally(() => inFlight.delete(eventId));
     return assured;
   }
 

--- a/shared/lib/nostr/publish/types.ts
+++ b/shared/lib/nostr/publish/types.ts
@@ -62,8 +62,22 @@ export interface PublishOptions {
    * `'first-ok'` stops retrying as soon as one relay accepts (latency-sensitive
    * writes like reactions). `'all-settled'` runs the full retry budget so the
    * event lands as widely as possible (replaceable lists, drafts).
+   *
+   * `'optimistic'` resolves the moment the first relay accepts — so the UI can
+   * dismiss immediately — while the remaining fan-out and retries (plus any
+   * {@link PublishOptions.backgroundRelays}) continue in the background. If the
+   * initial round over {@link PublishOptions.relays} accepts nowhere, it
+   * resolves `all-failed` straight away (so the caller can keep the composer
+   * open and preserve the draft) and abandons the background work.
    */
-  resolveOn?: 'first-ok' | 'all-settled';
+  resolveOn?: 'first-ok' | 'all-settled' | 'optimistic';
+  /**
+   * Extra relays resolved asynchronously (e.g. outbox recipient read relays),
+   * folded into the BACKGROUND fan-out once they arrive. Only honored with
+   * `resolveOn: 'optimistic'` — keeps recipient-relay fetches off the critical
+   * path to first delivery. Relays already covered by {@link relays} are skipped.
+   */
+  backgroundRelays?: Promise<readonly string[]>;
   /** Streamed terminal per-relay outcomes — drives live publish progress UI. */
   onRelayResult?: (result: PublishRelayResult) => void;
 }

--- a/shared/lib/popup/popups/notePublished.ts
+++ b/shared/lib/popup/popups/notePublished.ts
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { guardedRouter } from '@/shared/hooks/useGuardedRouter';
+import { popupLog } from '@/shared/lib/logger';
+
+import { StatusToast } from '../StatusToast';
+import { showCustomToast } from './bridge';
+
+/**
+ * Toast shown after a note is published optimistically. "View" opens the
+ * thread, which renders instantly from `ownContentStore` (the note is local
+ * before it has round-tripped through relays/nagg).
+ */
+export function notePublishedPopup(payload: { eventId: string }): void {
+  const { eventId } = payload;
+  popupLog.info('popup.note_published.show', { eventIdLength: eventId.length });
+  showCustomToast({
+    component: (toastProps) =>
+      React.createElement(StatusToast, {
+        status: 'confirmed',
+        title: 'Posted',
+        action: {
+          label: 'View',
+          onPress: () => {
+            guardedRouter.push({ pathname: '/(user-flow)/thread', params: { eventId } });
+            toastProps.hide?.();
+          },
+        },
+        debugFields: { eventId },
+        toastProps,
+      }),
+    duration: 3000,
+    debugLabel: 'note-published',
+    debugFields: { eventId },
+  });
+}

--- a/shared/stores/profile/ownContentStore.ts
+++ b/shared/stores/profile/ownContentStore.ts
@@ -1,0 +1,208 @@
+/**
+ * @fileoverview `ownContentStore` — a per-profile local cache of the notes we
+ * authored (kind:1: notes, replies, quotes).
+ *
+ * Two jobs, one deep module:
+ *  1. Optimistic publish: a note is recorded the instant we publish it, so it
+ *     is readable locally by id (the toast's "View" can open its thread before
+ *     the event has round-tripped through relays/nagg).
+ *  2. Cross-client convergence: own notes the app encounters from a relay /
+ *     app-view (e.g. posted on another client) are ingested here too, so the
+ *     app reflects our own content without depending on a live relay sub.
+ *
+ * Reconciliation is by exact `event.id` — a signed note already knows its id, so
+ * the relay echo is the same key (no timestamp/content-hash guessing). Lifecycle:
+ *   record('pending')  → publish in flight
+ *   confirmOwn         → delivery assured (first relay accepted) → 'local'
+ *   removeOwn          → publish failed → dropped (never a phantom)
+ *   ingestSeen         → seen from a relay/app-view → 'confirmed'
+ *
+ * Profile isolation is defense-in-depth: profile-scoped persisted storage, plus
+ * a per-entry `authorPubkey` that reads filter against the active viewer.
+ *
+ * Retention: `confirmed` entries are FIFO-capped; a `local` entry relays never
+ * echo back ages out after a grace window (assumed landed); `pending`/`local`
+ * are otherwise kept. On persist, `pending` is written as `local` so an
+ * app-kill mid-publish rehydrates as a recoverable local copy rather than a
+ * stuck pending.
+ */
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { z } from 'zod';
+
+import type { FeedEvent } from '@/features/feed/components/nostr/feedTypes';
+import { createProfileScopedStorage } from '@/shared/lib/cashu/profileScopedStorage';
+import { persistConfig } from '@/shared/lib/persist/persistConfig';
+
+/** A note we authored is `pending` until publish is assured, then `local`
+ *  until a relay/app-view echoes it back, then `confirmed`. */
+type OwnContentStatus = 'pending' | 'local' | 'confirmed';
+
+interface OwnContentEntry {
+  /** The authored kind:1 event, in thread-renderable shape. */
+  event: FeedEvent;
+  /** Author pubkey — must match the active viewer to be read (profile isolation). */
+  authorPubkey: string;
+  status: OwnContentStatus;
+  /** Epoch ms of the last status change (drives age-out + FIFO eviction). */
+  updatedAt: number;
+}
+
+/** Max `confirmed` entries kept; older own notes are refetchable from nagg/relays. */
+export const MAX_CONFIRMED = 200;
+/** A `local` note relays never echo back is assumed landed after this and becomes evictable. */
+export const LOCAL_GRACE_MS = 24 * 60 * 60 * 1000;
+
+interface OwnContentStore {
+  byId: Record<string, OwnContentEntry>;
+  /** Record a note we authored at the given lifecycle status. */
+  recordOwn: (event: FeedEvent, status: OwnContentStatus) => void;
+  /** Promote a `pending` entry to `local` once delivery is assured. */
+  confirmOwn: (id: string) => void;
+  /** Drop an entry (publish failed) so a non-delivered post never renders. */
+  removeOwn: (id: string) => void;
+  /** Settle an own note encountered from a relay/app-view (→ `confirmed`). */
+  ingestSeen: (event: FeedEvent) => void;
+  /** Read a stored own note by id, scoped to the active author when supplied. */
+  getOwn: (id: string, authorPubkey?: string) => OwnContentEntry | undefined;
+}
+
+const feedEventFrom = (event: FeedEvent): FeedEvent => ({
+  id: event.id,
+  kind: event.kind,
+  pubkey: event.pubkey,
+  content: event.content,
+  tags: event.tags,
+  created_at: event.created_at,
+});
+
+/** Drop aged-out `local` entries and FIFO-cap `confirmed`; keep recent pending/local. */
+function prune(
+  byId: Record<string, OwnContentEntry>,
+  nowMs: number
+): Record<string, OwnContentEntry> {
+  const cutoff = nowMs - LOCAL_GRACE_MS;
+  const kept: Record<string, OwnContentEntry> = {};
+  const confirmed: OwnContentEntry[] = [];
+  for (const [id, entry] of Object.entries(byId)) {
+    if (entry.status === 'local' && entry.updatedAt < cutoff) continue; // assumed landed
+    kept[id] = entry;
+    if (entry.status === 'confirmed') confirmed.push(entry);
+  }
+  if (confirmed.length > MAX_CONFIRMED) {
+    confirmed.sort((a, b) => a.updatedAt - b.updatedAt); // oldest first
+    for (let i = 0; i < confirmed.length - MAX_CONFIRMED; i += 1) {
+      delete kept[confirmed[i].event.id];
+    }
+  }
+  return kept;
+}
+
+const PersistedFeedEvent = z.looseObject({
+  id: z.string().max(128),
+  kind: z.number().int(),
+  pubkey: z.string().max(128),
+  content: z.string().max(65_536),
+  tags: z.array(z.array(z.string().max(8192)).max(200)).max(5000),
+  created_at: z.number().int().nonnegative(),
+});
+
+const PersistedOwnEntry = z.looseObject({
+  event: PersistedFeedEvent,
+  authorPubkey: z.string().max(128),
+  status: z.enum(['pending', 'local', 'confirmed']),
+  updatedAt: z.number().int().nonnegative(),
+});
+
+const PersistedOwnContentStore = z.object({
+  byId: z.record(z.string().max(128), PersistedOwnEntry).default({}),
+});
+
+export const useOwnContentStore = create<OwnContentStore>()(
+  persist(
+    (set, get) => ({
+      byId: {},
+
+      recordOwn: (event, status) =>
+        set((state) => {
+          const entry: OwnContentEntry = {
+            event: feedEventFrom(event),
+            authorPubkey: event.pubkey,
+            status,
+            updatedAt: Date.now(),
+          };
+          return { byId: prune({ ...state.byId, [event.id]: entry }, Date.now()) };
+        }),
+
+      confirmOwn: (id) =>
+        set((state) => {
+          const cur = state.byId[id];
+          if (!cur || cur.status !== 'pending') return state;
+          return {
+            byId: { ...state.byId, [id]: { ...cur, status: 'local', updatedAt: Date.now() } },
+          };
+        }),
+
+      removeOwn: (id) =>
+        set((state) => {
+          if (!state.byId[id]) return state;
+          const next = { ...state.byId };
+          delete next[id];
+          return { byId: next };
+        }),
+
+      ingestSeen: (event) =>
+        set((state) => {
+          const cur = state.byId[event.id];
+          if (cur && cur.status === 'confirmed') return state; // already settled
+          const entry: OwnContentEntry = {
+            event: feedEventFrom(event),
+            authorPubkey: event.pubkey,
+            status: 'confirmed',
+            updatedAt: Date.now(),
+          };
+          return { byId: prune({ ...state.byId, [event.id]: entry }, Date.now()) };
+        }),
+
+      getOwn: (id, authorPubkey) => {
+        const entry = get().byId[id];
+        if (!entry) return undefined;
+        if (authorPubkey && entry.authorPubkey !== authorPubkey) return undefined;
+        return entry;
+      },
+    }),
+    persistConfig({
+      name: 'own-content-store',
+      storage: createProfileScopedStorage(),
+      schema: PersistedOwnContentStore,
+      logKey: 'own_content',
+      // Persist `pending` as `local`: an app-kill mid-publish should rehydrate
+      // as a recoverable local copy, never a stuck pending. A live pending that
+      // fails is removed (removeOwn) and so leaves storage too.
+      partialize: (state) => ({
+        byId: Object.fromEntries(
+          Object.entries(state.byId).map(([id, entry]) => [
+            id,
+            entry.status === 'pending' ? { ...entry, status: 'local' as const } : entry,
+          ])
+        ),
+      }),
+    })
+  )
+);
+
+/**
+ * Passive-ingest seam: record any own-authored kind:1 notes the app already
+ * encountered (feed/thread/profile reads) as `confirmed`. No-op for events that
+ * aren't ours — keeps cross-client convergence on the path the app already runs.
+ */
+export function ingestOwnContent(
+  events: Iterable<FeedEvent>,
+  viewerPubkey: string | undefined
+): void {
+  if (!viewerPubkey) return;
+  const { ingestSeen } = useOwnContentStore.getState();
+  for (const event of events) {
+    if (event.kind === 1 && event.pubkey === viewerPubkey) ingestSeen(event);
+  }
+}


### PR DESCRIPTION
## Why

Posting felt slow, and the app kept no local record of notes we authored — so a just-posted note wasn't viewable until it round-tripped through relays/nagg.

Diagnosis (read-only exploration) ruled out the usual suspects: publishing was **already parallel** and connections are **warm**. The cost was the composer awaiting `all-settled` — waiting for the *slowest* relay across the full retry budget.

## What (3 parts, one branch)

**1. Optimistic publishing.** New publish-seam mode `optimistic`: resolve on the first relay accept (composer dismisses), finish fan-out + retries in the background. Round-0 all-fail resolves immediately so the draft is kept. Recipient (outbox) relays move off the critical path via `backgroundRelays`. `first-ok`/`all-settled` unchanged; replaceable lists + polls keep `all-settled`.

**2. Local own-content store** (`ownContentStore`, per-profile, persisted, id-keyed). Records own kind:1 notes optimistically; reconciles by exact `event.id`; lifecycle `pending → local → confirmed`; failed publish removed (no phantom). Profile isolation is defense-in-depth (scoped storage + per-entry author filter). Bounded (FIFO cap + grace age-out; `pending` persisted as `local`). Passive convergence: own notes the app already encounters (feed/thread) are ingested — no always-on subscription.

**3. Post → toast → instant View.** `notePublishedPopup` (reuses `StatusToast` + `guardedRouter`); "View" opens the thread, rendered from the local store. `useThread` falls back to the store on a seed/nagg miss and no longer shows "Post not found" for a not-yet-on-nagg own note.

## Scope notes

- **Viewer-state in nagg** (did *I* like/repost/quote/reply; followed?) across feed/thread/profile endpoints is the **planned follow-up in the nagg repo** (ADR 0001) — different repo, separate PR.
- Quote/repost-button highlight from own q-tags is a deferred fast-follow.

## Docs

`CONTEXT.md` publishing/own-content glossary + `docs/adr/0001-optimistic-publish-and-own-content-store.md`.

## Verification

`type-check` ✓ · `lint` ✓ · `knip` ✓ (no new dead code) · tests for the publish seam (incl. hang-on-throw), `ownContentStore` (lifecycle/ingest/eviction/age-out/profile-scope), and `publishComposed` (records→confirms→toast / removes-on-fail). 50 tests across the touched suites pass.

Reviewed via multi-agent passes (correctness + regression + cleanup), findings fixed (notably an assured-promise hang). Do not merge.