### PR TITLE
feat(nostr): client-side own-events sync — authoritative viewer-state without nagg

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -70,6 +70,24 @@ heuristics, unlike engagement state.
 without a dedicated always-on subscription. Seam: `ingestOwnContent`.
 
 **Viewer-state** — a viewer's relation to a post (did _I_ like / repost / quote /
-reply; do I follow this profile). Today derived client-side from relay
-subscriptions; the authoritative source is planned to be nagg app-view payloads
-(see ADR 0001).
+reply; do I follow this profile). Authoritative source is the client-side
+own-events relay sync (NOT nagg) — see **own-events sync** and ADR 0002 (which
+supersedes ADR 0001's nagg approach).
+
+**Own-events sync** — `useOwnEventsSync` (`shared/lib/nostr/ownsync/`): one
+long-lived app-level relay subscription for all our own events
+`{ authors:[me], kinds:[0,1,3,5,6,7] }` that hydrates the canonical own-state
+stores so they're authoritative everywhere. The single owner of "keep my own
+state synced"; replaces the former per-screen engagement subs, profile-screen
+contact sub, and boot kind:0 sync. `partitionOwnEvents` is the pure routing.
+
+**Global upsert** — `nostrSocialStore.ingestOwnLikes/Reposts/Replies`: merge our
+own engagement keyed by target, newest-per-target, recency-capped
+(`MAX_ENGAGEMENT_ENTRIES`). Unlike the removed scoped `syncLikesFromRelay`, it
+never deletes by an on-screen target set; deletions come via `applyOwnDeletions`
+(our kind:5). The canonical maps are the source of truth, overlaid by optimistic
+toggles.
+
+**Replied index** — `nostrSocialStore.repliedByEventId` (target id → our reply):
+drives the "you replied" comment-icon highlight, populated from our own kind:1
+reply e-tags by the own-events sync.

--- a/__tests__/feedRows.test.ts
+++ b/__tests__/feedRows.test.ts
@@ -16,6 +16,7 @@ const DEFAULT_METRICS: NoteMetrics = {
 const DEFAULT_ENGAGEMENT = {
   liked: false,
   reposted: false,
+  replied: false,
   likePending: false,
   repostPending: false,
 };

--- a/__tests__/nostrSocialStoreOwnSync.test.ts
+++ b/__tests__/nostrSocialStoreOwnSync.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Unit tests for nostrSocialStore's own-events ingest path (used by
+ * useOwnEventsSync): global upsert of likes/reposts/replies, kind:5 deletions,
+ * and the replied index.
+ */
+import { useNostrSocialStore } from '@/shared/stores/profile/nostrSocialStore';
+
+jest.mock('@/shared/lib/logger', () => ({
+  storeLog: { info: jest.fn(), debug: jest.fn(), warn: jest.fn(), error: jest.fn() },
+  log: { info: jest.fn(), debug: jest.fn(), warn: jest.fn(), error: jest.fn() },
+  redactError: (e: unknown) => e,
+}));
+
+jest.mock('@/shared/lib/cashu/profileScopedStorage', () => ({
+  createProfileScopedStorage: () => ({
+    getItem: async () => null,
+    setItem: async () => {},
+    removeItem: async () => {},
+  }),
+}));
+
+beforeEach(() => {
+  useNostrSocialStore.setState({
+    likesByEventId: {},
+    repostsByEventId: {},
+    repliedByEventId: {},
+  });
+});
+
+describe('nostrSocialStore own-events ingest', () => {
+  it('upserts likes by target, newest createdAt wins, no scoped delete', () => {
+    const s = useNostrSocialStore.getState();
+    s.ingestOwnLikes([
+      { targetEventId: 't1', reactionEventId: 'r1', createdAt: 100 },
+      { targetEventId: 't2', reactionEventId: 'r2', createdAt: 100 },
+    ]);
+    // A second batch that omits t2 must NOT delete it (unlike the old scoped sync).
+    s.ingestOwnLikes([{ targetEventId: 't1', reactionEventId: 'r1b', createdAt: 200 }]);
+
+    const { likesByEventId } = useNostrSocialStore.getState();
+    expect(likesByEventId.t1.reactionEventId).toBe('r1b'); // newer wins
+    expect(likesByEventId.t2.reactionEventId).toBe('r2'); // preserved
+  });
+
+  it('populates the replied index for the "you replied" highlight', () => {
+    useNostrSocialStore
+      .getState()
+      .ingestOwnReplies([{ targetEventId: 'parent1', replyEventId: 'reply1', createdAt: 100 }]);
+    expect(useNostrSocialStore.getState().repliedByEventId.parent1.replyEventId).toBe('reply1');
+  });
+
+  it('applies kind:5 deletions by own event id across likes/reposts/replies', () => {
+    const s = useNostrSocialStore.getState();
+    s.ingestOwnLikes([{ targetEventId: 't1', reactionEventId: 'like-del', createdAt: 100 }]);
+    s.ingestOwnReposts([{ targetEventId: 't2', repostEventId: 'repost-keep', createdAt: 100 }]);
+    s.ingestOwnReplies([{ targetEventId: 't3', replyEventId: 'reply-del', createdAt: 100 }]);
+
+    s.applyOwnDeletions(['like-del', 'reply-del']);
+
+    const next = useNostrSocialStore.getState();
+    expect(next.likesByEventId.t1).toBeUndefined(); // like deleted → un-highlight
+    expect(next.repliedByEventId.t3).toBeUndefined(); // reply deleted
+    expect(next.repostsByEventId.t2?.repostEventId).toBe('repost-keep'); // untouched
+  });
+});

--- a/__tests__/partitionOwnEvents.test.ts
+++ b/__tests__/partitionOwnEvents.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Unit tests for partitionOwnEvents — the pure routing of our own events into
+ * per-store rows. Focuses on the bug-prone bits: reply-target detection
+ * (NIP-10 markers vs quotes/mentions), like content filtering, and dedupe of
+ * latest profile/contacts.
+ */
+import type { FeedEvent } from '@/features/feed/components/nostr/feedTypes';
+import { partitionOwnEvents } from '@/shared/lib/nostr/ownsync/partitionOwnEvents';
+
+function ev(over: Partial<FeedEvent> & { kind: number }): FeedEvent {
+  return {
+    id: over.id ?? 'id',
+    kind: over.kind,
+    pubkey: over.pubkey ?? 'me',
+    content: over.content ?? '',
+    tags: over.tags ?? [],
+    created_at: over.created_at ?? 1000,
+  };
+}
+
+describe('partitionOwnEvents', () => {
+  it('routes likes from kind:7 with a + / empty reaction, skips other reactions', () => {
+    const part = partitionOwnEvents([
+      ev({ kind: 7, id: 'r1', content: '+', tags: [['e', 'target1']] }),
+      ev({ kind: 7, id: 'r2', content: '', tags: [['e', 'target2']] }),
+      ev({ kind: 7, id: 'r3', content: '😀', tags: [['e', 'target3']] }), // not a like
+      ev({ kind: 7, id: 'r4', content: '+', tags: [] }), // no target
+    ]);
+    expect(part.likes).toEqual([
+      { targetEventId: 'target1', reactionEventId: 'r1', createdAt: 1000 },
+      { targetEventId: 'target2', reactionEventId: 'r2', createdAt: 1000 },
+    ]);
+  });
+
+  it('routes reposts from kind:6 by their e-tag target', () => {
+    const part = partitionOwnEvents([ev({ kind: 6, id: 'rp1', tags: [['e', 'orig1']] })]);
+    expect(part.reposts).toEqual([
+      { targetEventId: 'orig1', repostEventId: 'rp1', createdAt: 1000 },
+    ]);
+  });
+
+  it('detects replies via NIP-10 markers but not quotes/mentions or top-level notes', () => {
+    const part = partitionOwnEvents([
+      // reply-marked → parent2
+      ev({
+        kind: 1,
+        id: 'a',
+        tags: [
+          ['e', 'root1', '', 'root'],
+          ['e', 'parent2', '', 'reply'],
+        ],
+      }),
+      // only root marker → root3
+      ev({ kind: 1, id: 'b', tags: [['e', 'root3', '', 'root']] }),
+      // legacy positional (unmarked) → last e-tag
+      ev({
+        kind: 1,
+        id: 'c',
+        tags: [
+          ['e', 'x'],
+          ['e', 'last4'],
+        ],
+      }),
+      // quote/mention only → NOT a reply
+      ev({
+        kind: 1,
+        id: 'd',
+        tags: [
+          ['e', 'quoted5', '', 'mention'],
+          ['q', 'quoted5'],
+        ],
+      }),
+      // top-level note → NOT a reply
+      ev({ kind: 1, id: 'e', tags: [] }),
+    ]);
+
+    expect(part.replies).toEqual([
+      { targetEventId: 'parent2', replyEventId: 'a', createdAt: 1000 },
+      { targetEventId: 'root3', replyEventId: 'b', createdAt: 1000 },
+      { targetEventId: 'last4', replyEventId: 'c', createdAt: 1000 },
+    ]);
+    // All kind:1 (incl. quote + top-level) are captured as own notes.
+    expect(part.ownNotes.map((n) => n.id)).toEqual(['a', 'b', 'c', 'd', 'e']);
+  });
+
+  it('keeps only the newest profile (kind:0) and contacts (kind:3)', () => {
+    const part = partitionOwnEvents([
+      ev({ kind: 0, id: 'p-old', created_at: 100 }),
+      ev({ kind: 0, id: 'p-new', created_at: 200 }),
+      ev({ kind: 3, id: 'c-new', created_at: 500 }),
+      ev({ kind: 3, id: 'c-old', created_at: 400 }),
+    ]);
+    expect(part.latestProfile?.id).toBe('p-new');
+    expect(part.latestContacts?.id).toBe('c-new');
+  });
+
+  it('collects deletion target ids from kind:5 e-tags', () => {
+    const part = partitionOwnEvents([
+      ev({
+        kind: 5,
+        id: 'del',
+        tags: [
+          ['e', 'gone1'],
+          ['e', 'gone2'],
+          ['k', '7'],
+        ],
+      }),
+    ]);
+    expect(part.deletedEventIds).toEqual(['gone1', 'gone2']);
+  });
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -51,8 +51,7 @@ import { useProfileStore } from '@/shared/stores/global/profileStore';
 import { useAppBalance } from '@/features/wallet';
 import { usePaymentStatusListener } from '@/shared/hooks/usePaymentStatusListener';
 import { useSwapStatusListener } from '@/shared/hooks/useSwapStatusListener';
-import { useSubscribe } from '@nostr-dev-kit/ndk-mobile';
-import { Metadata } from 'nostr-tools/kinds';
+import { useOwnEventsSync } from '@/shared/lib/nostr/ownsync/useOwnEventsSync';
 import PopupHost from '@/shared/blocks/popup/PopupHost';
 import { ActionMenuHost } from '@/shared/blocks/popup/ActionMenuHost';
 import { AndroidImageOverlayHost } from '@/features/feed/components/nostr/image-overlay/AndroidImageOverlayHost';
@@ -239,30 +238,14 @@ function ProfileBalanceSync() {
   return null;
 }
 
-/** Invisible component that syncs the active profile's Nostr kind-0 metadata to profileStore */
-function ProfileMetadataSync() {
-  const { keys: nostrKeys } = useNostrKeysContext();
-  const activeAccountIndex = useProfileStore((s) => s.activeAccountIndex);
-
-  const filters = useMemo(
-    () => (nostrKeys?.pubkey ? [{ kinds: [Metadata], authors: [nostrKeys.pubkey], limit: 1 }] : []),
-    [nostrKeys?.pubkey]
-  );
-
-  const { events } = useSubscribe({ filters });
-
-  useEffect(() => {
-    if (!events?.length) return;
-    try {
-      const parsed = JSON.parse(events[0].content);
-      const displayName = parsed.display_name || parsed.name || undefined;
-      const picture = parsed.picture || undefined;
-      useProfileStore.getState().updateProfileMetadata(activeAccountIndex, displayName, picture);
-    } catch {
-      // Malformed kind-0 content — ignore
-    }
-  }, [events, activeAccountIndex]);
-
+/**
+ * Invisible component that runs the single own-events relay sync: hydrates the
+ * canonical own-state stores (profile, follows, likes, reposts, replies, own
+ * notes) so they're authoritative everywhere. Subsumes the former kind-0-only
+ * `ProfileMetadataSync`.
+ */
+function OwnEventsSync() {
+  useOwnEventsSync();
   return null;
 }
 
@@ -368,7 +351,7 @@ function RootLayoutContent() {
       <PaymentStatusListener />
       <SwapStatusListener />
       <ProfileBalanceSync />
-      <ProfileMetadataSync />
+      <OwnEventsSync />
       <StatusBar
         backgroundColor={background}
         style={currentTheme.includes('light') ? 'dark' : 'light'}

--- a/docs/adr/0002-client-own-events-sync.md
+++ b/docs/adr/0002-client-own-events-sync.md
@@ -1,0 +1,57 @@
+# 2. Client-side own-events relay sync owns viewer-state
+
+Date: 2026-06-20
+Status: Accepted (supersedes ADR 0001's "viewer-state belongs in nagg")
+
+## Context
+
+ADR 0001 recorded that authoritative viewer-state (did *I* like / repost / quote
+/ reply; do I follow this profile) should come from nagg app-view payloads. On
+reflection we want the opposite: viewer-state should be **relay-direct and
+client-owned**, not routed through nagg. nagg carries only aggregate counts
+today; per-viewer state from nagg would need new schema + a ClickHouse pivot,
+and would still lag our own optimistic actions.
+
+Before this change, own-state was learned **scattered and incompletely**:
+- likes/reposts: per-screen subscriptions scoped to on-screen `eventIds` (no
+  global index — couldn't answer "did I like X" off-screen);
+- follows (kind:3): fetched only when you opened your own profile;
+- profile (kind:0): a one-shot boot sync;
+- replies: not tracked at all.
+
+## Decision
+
+Add **`useOwnEventsSync`** — one long-lived, app-level relay subscription for all
+our own events `{ authors:[me], kinds:[0,1,3,5,6,7] }` — as the single owner of
+"keep my own state synced". It does **not** use nagg. A pure `partitionOwnEvents`
+splits the batch and dispatches each kind into its existing **canonical store**:
+
+- kind 0 → `profileStore` metadata
+- kind 3 → `nostrSocialStore` contacts/follows (+ settle follow optimism)
+- kind 1 → `ownContentStore.ingestSeen` + reply e-tags → `repliedByEventId`
+- kind 6/7 → `nostrSocialStore` global-upsert likes/reposts
+- kind 5 → `nostrSocialStore.applyOwnDeletions`
+
+The two stores stay **separate** (clean domain split: authored content vs
+engagement/social graph); the sync feeds both — no third store. The canonical
+engagement maps gain a **recency cap** (the sync can backfill thousands of
+events) and a new **`repliedByEventId`** index for the "you replied" highlight.
+`useNostrEngagement` drops its per-screen subscription and reads the now-global
+store (keeping the optimistic toggle). The profile-screen kind:3 sub and the
+boot kind:0 sync are removed (subsumed).
+
+## Consequences
+
+- Viewer-state is correct for any post the sync has covered — not just on-screen
+  ones — and never depends on nagg or a live per-screen sub.
+- One subscription replaces three scattered ones (a reuse/consolidation win).
+- Bounded: a backfill window + recency-capped compact indices keep storage and
+  rehydrate bounded; engagement older than the window/cap won't highlight (rare).
+- The nagg viewer-state work (ADR 0001) is **dropped**.
+
+## Alternatives considered
+
+- **nagg viewer-state (ADR 0001)** — cross-repo, lags optimistic actions, and
+  still needs client reconciliation; superseded.
+- **Keep per-screen subs** — leaves the off-screen gap and duplicate subs.
+- **Merge the two stores** — rejected; incompatible lifecycles/retention.

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -74,7 +74,7 @@
   },
   "features/feed/hooks/useNostrEngagement.ts": {
     "@typescript-eslint/no-explicit-any": {
-      "count": 3
+      "count": 1
     }
   },
   "features/feed/screens/NotificationsScreen.tsx": {

--- a/features/feed/components/HomeFeed.tsx
+++ b/features/feed/components/HomeFeed.tsx
@@ -1077,6 +1077,7 @@ export function HomeFeed({ activeFilter }: HomeFeedProps) {
                 reposterPubkey={row.reposterPubkey ?? item.repostEvent.pubkey}
                 reposters={row.reposters}
                 liked={repostEngagement.liked}
+                replied={repostEngagement.replied}
                 reposted={repostEngagement.reposted}
                 likePending={repostEngagement.likePending}
                 repostPending={repostEngagement.repostPending}
@@ -1108,6 +1109,7 @@ export function HomeFeed({ activeFilter }: HomeFeedProps) {
           reposterPubkey={row.reposterPubkey ?? item.repostEvent.pubkey}
           reposters={row.reposters}
           liked={repostEngagement.liked}
+          replied={repostEngagement.replied}
           reposted={repostEngagement.reposted}
           likePending={repostEngagement.likePending}
           repostPending={repostEngagement.repostPending}

--- a/features/feed/components/HomeFeed.tsx
+++ b/features/feed/components/HomeFeed.tsx
@@ -882,6 +882,7 @@ export function HomeFeed({ activeFilter }: HomeFeedProps) {
                   profiles={row.profiles}
                   getMetrics={getMetrics}
                   liked={engagement.liked}
+                  replied={engagement.replied}
                   reposted={engagement.reposted}
                   likePending={engagement.likePending}
                   repostPending={engagement.repostPending}
@@ -915,6 +916,7 @@ export function HomeFeed({ activeFilter }: HomeFeedProps) {
                         profiles={row.profiles}
                         getMetrics={getMetrics}
                         liked={replyEngagement.liked}
+                        replied={replyEngagement.replied}
                         reposted={replyEngagement.reposted}
                         likePending={replyEngagement.likePending}
                         repostPending={replyEngagement.repostPending}
@@ -952,6 +954,7 @@ export function HomeFeed({ activeFilter }: HomeFeedProps) {
                   profiles={row.profiles}
                   getMetrics={getMetrics}
                   liked={rootEngagement.liked}
+                  replied={rootEngagement.replied}
                   reposted={rootEngagement.reposted}
                   likePending={rootEngagement.likePending}
                   repostPending={rootEngagement.repostPending}
@@ -978,6 +981,7 @@ export function HomeFeed({ activeFilter }: HomeFeedProps) {
                   profiles={row.profiles}
                   getMetrics={getMetrics}
                   liked={engagement.liked}
+                  replied={engagement.replied}
                   reposted={engagement.reposted}
                   likePending={engagement.likePending}
                   repostPending={engagement.repostPending}
@@ -1005,6 +1009,7 @@ export function HomeFeed({ activeFilter }: HomeFeedProps) {
             profiles={row.profiles}
             getMetrics={getMetrics}
             liked={engagement.liked}
+            replied={engagement.replied}
             reposted={engagement.reposted}
             likePending={engagement.likePending}
             repostPending={engagement.repostPending}
@@ -1042,6 +1047,7 @@ export function HomeFeed({ activeFilter }: HomeFeedProps) {
                 profiles={row.profiles}
                 getMetrics={getMetrics}
                 liked={rootEngagement.liked}
+                replied={rootEngagement.replied}
                 reposted={rootEngagement.reposted}
                 likePending={rootEngagement.likePending}
                 repostPending={rootEngagement.repostPending}

--- a/features/feed/components/ThreadView.tsx
+++ b/features/feed/components/ThreadView.tsx
@@ -507,6 +507,7 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
           showLineAbove={isParent ? index > 0 : isTarget ? hasParents : false}
           showLineBelow={isParent}
           liked={engagement.liked}
+          replied={engagement.replied}
           reposted={engagement.reposted}
           likePending={engagement.likePending}
           repostPending={engagement.repostPending}

--- a/features/feed/components/ThreadView.tsx
+++ b/features/feed/components/ThreadView.tsx
@@ -733,6 +733,7 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
             <EmbedActionBar
               metrics={getDisplayMetrics(targetEvent.id)}
               liked={getEngagementState(targetEvent.id).liked}
+              replied={getEngagementState(targetEvent.id).replied}
               reposted={getEngagementState(targetEvent.id).reposted}
               likePending={getEngagementState(targetEvent.id).likePending}
               repostPending={getEngagementState(targetEvent.id).repostPending}

--- a/features/feed/components/UserFeed.tsx
+++ b/features/feed/components/UserFeed.tsx
@@ -134,6 +134,7 @@ export const RepostCard = React.memo(function RepostCard({
   onOverlayOpenedFromIndex,
   onVideoTap,
   liked = false,
+  replied = false,
   reposted = false,
   likePending = false,
   repostPending = false,
@@ -156,11 +157,12 @@ export const RepostCard = React.memo(function RepostCard({
   getMetrics: (eventId: string) => NoteMetrics;
   reposterName: string;
   reposterPubkey: string;
-  reposters?: Array<{ name: string; pubkey: string }>;
+  reposters?: { name: string; pubkey: string }[];
   feedIndex?: number;
   onOverlayOpenedFromIndex?: (index: number) => void;
   onVideoTap?: (url: string) => void;
   liked?: boolean;
+  replied?: boolean;
   reposted?: boolean;
   likePending?: boolean;
   repostPending?: boolean;
@@ -285,6 +287,7 @@ export const RepostCard = React.memo(function RepostCard({
             onOverlayOpenedFromIndex={onOverlayOpenedFromIndex}
             onVideoTap={onVideoTap}
             liked={liked}
+            replied={replied}
             reposted={reposted}
             likePending={likePending}
             repostPending={repostPending}
@@ -888,6 +891,7 @@ export function UserFeed({
                 profiles={row.profiles}
                 getMetrics={getMetrics}
                 liked={rootEngagement.liked}
+                replied={rootEngagement.replied}
                 reposted={rootEngagement.reposted}
                 likePending={rootEngagement.likePending}
                 repostPending={rootEngagement.repostPending}
@@ -911,6 +915,7 @@ export function UserFeed({
                 profiles={row.profiles}
                 getMetrics={getMetrics}
                 liked={engagement.liked}
+                replied={engagement.replied}
                 reposted={engagement.reposted}
                 likePending={engagement.likePending}
                 repostPending={engagement.repostPending}
@@ -937,6 +942,7 @@ export function UserFeed({
             profiles={row.profiles}
             getMetrics={getMetrics}
             liked={engagement.liked}
+            replied={engagement.replied}
             reposted={engagement.reposted}
             likePending={engagement.likePending}
             repostPending={engagement.repostPending}
@@ -970,6 +976,7 @@ export function UserFeed({
               profiles={row.profiles}
               getMetrics={getMetrics}
               liked={rootEngagement.liked}
+              replied={rootEngagement.replied}
               reposted={rootEngagement.reposted}
               likePending={rootEngagement.likePending}
               repostPending={rootEngagement.repostPending}
@@ -996,6 +1003,7 @@ export function UserFeed({
               reposterPubkey={row.reposterPubkey ?? pubkey}
               reposters={row.reposters}
               liked={engagement.liked}
+              replied={engagement.replied}
               reposted={engagement.reposted}
               likePending={engagement.likePending}
               repostPending={engagement.repostPending}
@@ -1026,6 +1034,7 @@ export function UserFeed({
           reposterPubkey={row.reposterPubkey ?? pubkey}
           reposters={row.reposters}
           liked={engagement.liked}
+          replied={engagement.replied}
           reposted={engagement.reposted}
           likePending={engagement.likePending}
           repostPending={engagement.repostPending}

--- a/features/feed/components/nostr/MetricsFooter.tsx
+++ b/features/feed/components/nostr/MetricsFooter.tsx
@@ -7,6 +7,7 @@ import { HStack } from '@/shared/ui/primitives/View/HStack';
 import { View } from '@/shared/ui/primitives/View/View';
 import Icon from 'assets/icons';
 import { useThemeColor } from '@/shared/hooks/useThemeColor';
+import { COMMENT_ACCENT } from '@/shared/lib/brandColors';
 import { openRepostMenu } from '@/features/feed/lib/repostMenu';
 import type { NoteMetrics } from './feedTypes';
 import { formatCount, formatSats } from './feedFormat';
@@ -93,7 +94,7 @@ export const MetricsFooter = React.memo(function MetricsFooter({
   onActionPressOut?: () => void;
 }) {
   const repostedColor = useThemeColor('success');
-  const repliedColor = useThemeColor('link');
+  const repliedColor = COMMENT_ACCENT;
   const iconColor = opacity(borderColor, alpha.disabled);
   const textColor = opacity(borderColor, alpha.disabled);
   const likedColor = '#ff5a7a';

--- a/features/feed/components/nostr/MetricsFooter.tsx
+++ b/features/feed/components/nostr/MetricsFooter.tsx
@@ -66,6 +66,7 @@ export const MetricsFooter = React.memo(function MetricsFooter({
   onLikePress,
   reposted = false,
   liked = false,
+  replied = false,
   repostPending = false,
   likePending = false,
   repostPendingDirection: _repostPendingDirection,
@@ -83,6 +84,7 @@ export const MetricsFooter = React.memo(function MetricsFooter({
   onLikePress?: () => void;
   reposted?: boolean;
   liked?: boolean;
+  replied?: boolean;
   repostPending?: boolean;
   likePending?: boolean;
   repostPendingDirection?: 'activating' | 'deactivating';
@@ -91,6 +93,7 @@ export const MetricsFooter = React.memo(function MetricsFooter({
   onActionPressOut?: () => void;
 }) {
   const repostedColor = useThemeColor('success');
+  const repliedColor = useThemeColor('link');
   const iconColor = opacity(borderColor, alpha.disabled);
   const textColor = opacity(borderColor, alpha.disabled);
   const likedColor = '#ff5a7a';
@@ -118,14 +121,18 @@ export const MetricsFooter = React.memo(function MetricsFooter({
           onPressIn={onActionPressIn}
           onPressOut={onActionPressOut}
           accessibilityRole="button"
-          accessibilityLabel={`Reply, ${metrics.replyCount} replies`}
+          accessibilityLabel={`${replied ? 'Replied' : 'Reply'}, ${metrics.replyCount} replies`}
           hitSlop={{ top: 12, bottom: 12, left: 8, right: 8 }}>
-          <HStack align="center" gap={5}>
-            <Icon name="iconamoon:comment-fill" size={iconSizes.comment} color={iconColor} />
-            <Text size={textSize} style={{ color: textColor }}>
-              {formatCount(metrics.replyCount)}
-            </Text>
-          </HStack>
+          <AnimatedMetric
+            iconName="iconamoon:comment-fill"
+            iconSize={iconSizes.comment}
+            text={formatCount(metrics.replyCount)}
+            inactiveColor={textColor}
+            activeColor={repliedColor}
+            textSize={textSize}
+            isActive={replied}
+            pending={false}
+          />
         </Pressable>
         <Pressable
           onPress={handleRepostPress}

--- a/features/feed/components/nostr/NoteContent.tsx
+++ b/features/feed/components/nostr/NoteContent.tsx
@@ -429,6 +429,7 @@ export const NoteContent = React.memo(function NoteContent({
   profile: overlayProfile,
   reposted,
   liked,
+  replied,
   repostPending,
   likePending,
   repostPendingDirection,
@@ -465,6 +466,7 @@ export const NoteContent = React.memo(function NoteContent({
   profile?: ProfileInfo | null;
   reposted?: boolean;
   liked?: boolean;
+  replied?: boolean;
   repostPending?: boolean;
   likePending?: boolean;
   repostPendingDirection?: 'activating' | 'deactivating';
@@ -556,6 +558,7 @@ export const NoteContent = React.memo(function NoteContent({
             profile: overlayProfile ?? null,
             reposted,
             liked,
+            replied,
             repostPending,
             likePending,
             repostPendingDirection,
@@ -580,6 +583,7 @@ export const NoteContent = React.memo(function NoteContent({
     overlayProfile,
     reposted,
     liked,
+    replied,
     repostPending,
     likePending,
     repostPendingDirection,
@@ -802,6 +806,7 @@ export const NoteContent = React.memo(function NoteContent({
                     profile={overlayProfile}
                     reposted={reposted}
                     liked={liked}
+                    replied={replied}
                     repostPending={repostPending}
                     likePending={likePending}
                     repostPendingDirection={repostPendingDirection}

--- a/features/feed/components/nostr/PostCard.tsx
+++ b/features/feed/components/nostr/PostCard.tsx
@@ -418,6 +418,7 @@ export const PostCard = React.memo(function PostCard({
           onOverlayOpenedFromIndex={onOverlayOpenedFromIndex}
           reposted={reposted}
           liked={liked}
+          replied={replied}
           repostPending={repostPending}
           likePending={likePending}
           repostPendingDirection={repostPendingDirection}

--- a/features/feed/components/nostr/PostCard.tsx
+++ b/features/feed/components/nostr/PostCard.tsx
@@ -83,6 +83,7 @@ interface PostCardProps {
   onMorePress?: () => void;
   reposted?: boolean;
   liked?: boolean;
+  replied?: boolean;
   repostPending?: boolean;
   likePending?: boolean;
   repostPendingDirection?: 'activating' | 'deactivating';
@@ -122,6 +123,7 @@ export const PostCard = React.memo(function PostCard({
   onMorePress,
   reposted = false,
   liked = false,
+  replied = false,
   repostPending = false,
   likePending = false,
   repostPendingDirection,
@@ -302,6 +304,7 @@ export const PostCard = React.memo(function PostCard({
               onLikePress={onLikePress}
               reposted={reposted}
               liked={liked}
+              replied={replied}
               repostPending={repostPending}
               likePending={likePending}
               repostPendingDirection={repostPendingDirection}
@@ -448,6 +451,7 @@ export const PostCard = React.memo(function PostCard({
             onLikePress={onLikePress}
             reposted={reposted}
             liked={liked}
+            replied={replied}
             repostPending={repostPending}
             likePending={likePending}
             repostPendingDirection={repostPendingDirection}

--- a/features/feed/components/nostr/image-overlay/BottomPanel.tsx
+++ b/features/feed/components/nostr/image-overlay/BottomPanel.tsx
@@ -25,6 +25,7 @@ import type { ContentSegment } from '../feedTypes';
 import type { ImageOverlayPost } from './types';
 import { BOTTOM_PANEL_PADDING_HORIZONTAL, BOTTOM_PANEL_PADDING_TOP } from './config';
 import { useThemeColor } from '@/shared/hooks/useThemeColor';
+import { COMMENT_ACCENT } from '@/shared/lib/brandColors';
 import { openRepostMenu } from '@/features/feed/lib/repostMenu';
 import { useQuotePost } from '@/features/feed/lib/useQuotePost';
 import { Log } from '@/shared/lib/logger';
@@ -239,12 +240,12 @@ export const ImageOverlayBottomPanelContent = React.memo(function ImageOverlayBo
   /** Dismisses the lightbox so the Repost/Quote menu can render over it. */
   onRequestClose?: () => void;
 }) {
-  const [foreground, muted, repostedColor, repliedColor] = useThemeColor([
+  const [foreground, muted, repostedColor] = useThemeColor([
     'foreground',
     'muted',
     'success',
-    'link',
   ] as const);
+  const repliedColor = COMMENT_ACCENT;
   const [contentExpanded, setContentExpanded] = useState(initialContentExpanded ?? false);
 
   useEffect(() => {
@@ -428,7 +429,7 @@ export const ImageOverlayAbsoluteBar = React.memo(function ImageOverlayAbsoluteB
   onRequestClose?: () => void;
 }) {
   const repostedColor = useThemeColor('success');
-  const repliedColor = useThemeColor('link');
+  const repliedColor = COMMENT_ACCENT;
   const handleRepostPress = useOverlayRepostMenu(post, onRequestClose);
   const { event, metrics, profile, reposted, liked, replied, onLikePress } = post;
   const displayName = profile?.name ?? `${event.pubkey.slice(0, 8)}…`;

--- a/features/feed/components/nostr/image-overlay/BottomPanel.tsx
+++ b/features/feed/components/nostr/image-overlay/BottomPanel.tsx
@@ -28,6 +28,7 @@ import { useThemeColor } from '@/shared/hooks/useThemeColor';
 import { openRepostMenu } from '@/features/feed/lib/repostMenu';
 import { useQuotePost } from '@/features/feed/lib/useQuotePost';
 import { Log } from '@/shared/lib/logger';
+import { POST_ACTION_ICON_SIZES } from '../MetricsFooter';
 
 // The Repost/Quote menu can't render over the image overlay (a FullWindowOverlay
 // the menu's bottom sheet mounts beneath), so the overlay closes first, then the
@@ -51,7 +52,6 @@ function useOverlayRepostMenu(post: ImageOverlayPost, onRequestClose?: () => voi
     }, OVERLAY_CLOSE_BEFORE_MENU_MS);
   }, [post, onRequestClose, quotePost]);
 }
-import { POST_ACTION_ICON_SIZES } from '../MetricsFooter';
 // Absolute bar text stays white — it floats over the dark, blurred image, not
 // over the sheet's `surface` background.
 const PANEL_TEXT = 'rgba(255,255,255,0.95)';
@@ -239,10 +239,11 @@ export const ImageOverlayBottomPanelContent = React.memo(function ImageOverlayBo
   /** Dismisses the lightbox so the Repost/Quote menu can render over it. */
   onRequestClose?: () => void;
 }) {
-  const [foreground, muted, repostedColor] = useThemeColor([
+  const [foreground, muted, repostedColor, repliedColor] = useThemeColor([
     'foreground',
     'muted',
     'success',
+    'link',
   ] as const);
   const [contentExpanded, setContentExpanded] = useState(initialContentExpanded ?? false);
 
@@ -252,7 +253,7 @@ export const ImageOverlayBottomPanelContent = React.memo(function ImageOverlayBo
       onConsumedExpand?.();
     }
   }, [initialContentExpanded, onConsumedExpand]);
-  const { event, metrics, profile, reposted, liked, onLikePress } = post;
+  const { event, metrics, profile, reposted, liked, replied, onLikePress } = post;
   const handleRepostPress = useOverlayRepostMenu(post, onRequestClose);
   const displayName = profile?.name ?? `${event.pubkey.slice(0, 8)}…`;
   const shortTime = formatRelative(event.created_at * 1000, 'compact');
@@ -363,9 +364,9 @@ export const ImageOverlayBottomPanelContent = React.memo(function ImageOverlayBo
             <Icon
               name="iconamoon:comment-fill"
               size={POST_ACTION_ICON_SIZES.regular.comment}
-              color={muted}
+              color={replied ? repliedColor : muted}
             />
-            <Text size={13} style={{ color: muted }}>
+            <Text size={13} style={{ color: replied ? repliedColor : muted }}>
               {formatCount(metrics.replyCount)}
             </Text>
           </View>
@@ -427,8 +428,9 @@ export const ImageOverlayAbsoluteBar = React.memo(function ImageOverlayAbsoluteB
   onRequestClose?: () => void;
 }) {
   const repostedColor = useThemeColor('success');
+  const repliedColor = useThemeColor('link');
   const handleRepostPress = useOverlayRepostMenu(post, onRequestClose);
-  const { event, metrics, profile, reposted, liked, onLikePress } = post;
+  const { event, metrics, profile, reposted, liked, replied, onLikePress } = post;
   const displayName = profile?.name ?? `${event.pubkey.slice(0, 8)}…`;
   const shortTime = formatRelative(event.created_at * 1000, 'compact');
   const fullContent = event.content.trim();
@@ -498,9 +500,9 @@ export const ImageOverlayAbsoluteBar = React.memo(function ImageOverlayAbsoluteB
             <Icon
               name="iconamoon:comment-fill"
               size={POST_ACTION_ICON_SIZES.regular.comment}
-              color={PANEL_TEXT_MUTED}
+              color={replied ? repliedColor : PANEL_TEXT_MUTED}
             />
-            <Text size={13} style={{ color: PANEL_TEXT_MUTED }}>
+            <Text size={13} style={{ color: replied ? repliedColor : PANEL_TEXT_MUTED }}>
               {formatCount(metrics.replyCount)}
             </Text>
           </Pressable>

--- a/features/feed/components/nostr/image-overlay/ImageBlock.tsx
+++ b/features/feed/components/nostr/image-overlay/ImageBlock.tsx
@@ -42,6 +42,7 @@ interface ImageBlockOverlayPostProps {
   profile?: ProfileInfo | null;
   reposted?: boolean;
   liked?: boolean;
+  replied?: boolean;
   repostPending?: boolean;
   likePending?: boolean;
   repostPendingDirection?: 'activating' | 'deactivating';
@@ -70,6 +71,7 @@ export const ImageBlock = React.memo(function ImageBlock({
   profile: overlayProfile,
   reposted,
   liked,
+  replied,
   repostPending,
   likePending,
   repostPendingDirection,
@@ -291,6 +293,7 @@ export const ImageBlock = React.memo(function ImageBlock({
                 profile: overlayProfile ?? null,
                 reposted,
                 liked,
+                replied,
                 repostPending,
                 likePending,
                 repostPendingDirection,
@@ -342,6 +345,7 @@ export const ImageBlock = React.memo(function ImageBlock({
       overlayProfile,
       reposted,
       liked,
+      replied,
       repostPending,
       likePending,
       repostPendingDirection,

--- a/features/feed/components/nostr/image-overlay/types.ts
+++ b/features/feed/components/nostr/image-overlay/types.ts
@@ -25,6 +25,7 @@ export interface ImageOverlayPost {
   profile?: ProfileInfo | null;
   reposted?: boolean;
   liked?: boolean;
+  replied?: boolean;
   repostPending?: boolean;
   likePending?: boolean;
   repostPendingDirection?: 'activating' | 'deactivating';

--- a/features/feed/components/thread-embed/EmbedActionBar.tsx
+++ b/features/feed/components/thread-embed/EmbedActionBar.tsx
@@ -34,6 +34,7 @@ import { useThreadEmbed } from './ThreadEmbedProvider';
 export const EmbedActionBar = React.memo(function EmbedActionBar({
   metrics,
   liked,
+  replied,
   reposted,
   likePending,
   repostPending,
@@ -44,6 +45,7 @@ export const EmbedActionBar = React.memo(function EmbedActionBar({
 }: {
   metrics: NoteMetrics;
   liked: boolean;
+  replied: boolean;
   reposted: boolean;
   likePending: boolean;
   repostPending: boolean;
@@ -125,6 +127,7 @@ export const EmbedActionBar = React.memo(function EmbedActionBar({
           onLikePress={onLikePress}
           reposted={reposted}
           liked={liked}
+          replied={replied}
           repostPending={repostPending}
           likePending={likePending}
         />

--- a/features/feed/hooks/useNostrEngagement.ts
+++ b/features/feed/hooks/useNostrEngagement.ts
@@ -255,6 +255,7 @@ export function useNostrEngagement(
     eventIds,
     likesByEventId,
     repostsByEventId,
+    repliedByEventId,
     optimisticLikesByEventId,
     optimisticRepostsByEventId,
   ]);

--- a/features/feed/hooks/useNostrEngagement.ts
+++ b/features/feed/hooks/useNostrEngagement.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 
-import { NDKEvent, useNDK, useSubscribe } from '@nostr-dev-kit/ndk-mobile';
+import { NDKEvent, useNDK } from '@nostr-dev-kit/ndk-mobile';
 import { EventDeletion, Reaction, Repost } from 'nostr-tools/kinds';
 import { useShallow } from 'zustand/shallow';
 
@@ -15,6 +15,7 @@ import { useNostrKeysContext } from '@/shared/providers/NostrKeysProvider';
 type EngagementState = {
   liked: boolean;
   reposted: boolean;
+  replied: boolean;
   likePending: boolean;
   repostPending: boolean;
   likePendingDirection?: 'activating' | 'deactivating';
@@ -25,80 +26,6 @@ export type EngagementViewState = EngagementState;
 
 const OPTIMISTIC_SETTLE_GRACE_MS = 15_000;
 const OPTIMISTIC_STALE_WARN_MS = 30_000;
-
-// ---------------------------------------------------------------------------
-// Shared Nostr-event tag helpers
-// ---------------------------------------------------------------------------
-
-function normalizeTags(input: unknown): string[][] {
-  if (!Array.isArray(input)) return [];
-  return input.filter(Array.isArray) as string[][];
-}
-
-function getFirstTagValue(tags: string[][], name: string): string | undefined {
-  const tag = tags.find((t) => t[0] === name && !!t[1]);
-  return tag?.[1];
-}
-
-// ---------------------------------------------------------------------------
-// Generic relay-engagement builder (deduplicates relayLikes / relayReposts)
-// ---------------------------------------------------------------------------
-
-interface RelayEngagement {
-  targetEventId: string;
-  engagementEventId: string;
-  createdAt: number;
-}
-
-/**
- * Builds a de-duplicated, most-recent-per-target list of relay engagements
- * (likes or reposts) from raw NDK subscription events, after filtering out
- * deletions of the specified `kind`.
- */
-function buildRelayEngagements(opts: {
-  rawEvents: any[] | undefined;
-  deletionEvents: any[] | undefined;
-  knownTargets: Map<string, FeedEvent>;
-  kind: number;
-  contentFilter?: (content: string) => boolean;
-}): RelayEngagement[] {
-  const { rawEvents, deletionEvents, knownTargets, kind, contentFilter } = opts;
-
-  const targetByEngagementId = new Map<string, string>();
-  for (const event of rawEvents || []) {
-    if (typeof event.id !== 'string') continue;
-    if (contentFilter && typeof event.content === 'string' && !contentFilter(event.content))
-      continue;
-    const tags = normalizeTags(event.tags);
-    const targetId = getFirstTagValue(tags, 'e');
-    if (!targetId || !knownTargets.has(targetId)) continue;
-    targetByEngagementId.set(event.id, targetId);
-  }
-
-  const deletedIds = new Set<string>();
-  for (const event of deletionEvents || []) {
-    const tags = normalizeTags(event.tags);
-    if (getFirstTagValue(tags, 'k') !== String(kind)) continue;
-    const eid = getFirstTagValue(tags, 'e');
-    if (eid) deletedIds.add(eid);
-  }
-
-  const latest = new Map<string, RelayEngagement>();
-  for (const event of rawEvents || []) {
-    if (typeof event.id !== 'string' || deletedIds.has(event.id)) continue;
-    const targetId = targetByEngagementId.get(event.id);
-    if (!targetId) continue;
-    const candidate: RelayEngagement = {
-      targetEventId: targetId,
-      engagementEventId: event.id,
-      createdAt: event.created_at || 0,
-    };
-    const prev = latest.get(targetId);
-    if (!prev || candidate.createdAt >= prev.createdAt) latest.set(targetId, candidate);
-  }
-
-  return Array.from(latest.values());
-}
 
 // ---------------------------------------------------------------------------
 // Generic toggle-engagement helper (deduplicates toggleLike / toggleRepost)
@@ -239,16 +166,24 @@ export function useNostrEngagement(
   const { ndk } = useNDK();
   const { keys: nostrKeys } = useNostrKeysContext();
 
-  // State slices — grouped with useShallow to minimise re-subscriptions
-  const { likesByEventId, repostsByEventId, optimisticLikesByEventId, optimisticRepostsByEventId } =
-    useNostrSocialStore(
-      useShallow((s) => ({
-        likesByEventId: s.likesByEventId,
-        repostsByEventId: s.repostsByEventId,
-        optimisticLikesByEventId: s.optimisticLikesByEventId,
-        optimisticRepostsByEventId: s.optimisticRepostsByEventId,
-      }))
-    );
+  // State slices — grouped with useShallow to minimise re-subscriptions. The
+  // canonical maps are populated globally by useOwnEventsSync, so this hook only
+  // reads them (no per-screen relay subscription) and owns the optimistic toggle.
+  const {
+    likesByEventId,
+    repostsByEventId,
+    repliedByEventId,
+    optimisticLikesByEventId,
+    optimisticRepostsByEventId,
+  } = useNostrSocialStore(
+    useShallow((s) => ({
+      likesByEventId: s.likesByEventId,
+      repostsByEventId: s.repostsByEventId,
+      repliedByEventId: s.repliedByEventId,
+      optimisticLikesByEventId: s.optimisticLikesByEventId,
+      optimisticRepostsByEventId: s.optimisticRepostsByEventId,
+    }))
+  );
 
   const lastStaleWarningRef = useRef(0);
 
@@ -262,74 +197,7 @@ export function useNostrEngagement(
 
   const eventIds = useMemo(() => Array.from(eventsById.keys()), [eventsById]);
 
-  // ---- relay subscription filters ----
-
-  const reactionFilters = useMemo(() => {
-    if (!nostrKeys?.pubkey || eventIds.length === 0) return null;
-    return [{ authors: [nostrKeys.pubkey], kinds: [Reaction], '#e': eventIds, limit: 500 }];
-  }, [eventIds, nostrKeys?.pubkey]);
-
-  const repostFilters = useMemo(() => {
-    if (!nostrKeys?.pubkey || eventIds.length === 0) return null;
-    return [{ authors: [nostrKeys.pubkey], kinds: [Repost], '#e': eventIds, limit: 500 }];
-  }, [eventIds, nostrKeys?.pubkey]);
-
-  const deletionFilters = useMemo(() => {
-    if (!nostrKeys?.pubkey) return null;
-    return [{ authors: [nostrKeys.pubkey], kinds: [EventDeletion], '#k': ['6', '7'], limit: 500 }];
-  }, [nostrKeys?.pubkey]);
-
-  const { events: myReactionEvents } = useSubscribe({ filters: reactionFilters });
-  const { events: myRepostEvents } = useSubscribe({ filters: repostFilters });
-  const { events: myDeletionEvents } = useSubscribe({ filters: deletionFilters });
-
-  // ---- build relay engagements (unified) ----
-
-  const relayLikes = useMemo(
-    () =>
-      buildRelayEngagements({
-        rawEvents: myReactionEvents,
-        deletionEvents: myDeletionEvents,
-        knownTargets: eventsById,
-        kind: Reaction,
-        contentFilter: (c) => c === '+' || c === '',
-      }),
-    [eventsById, myDeletionEvents, myReactionEvents]
-  );
-
-  const relayReposts = useMemo(
-    () =>
-      buildRelayEngagements({
-        rawEvents: myRepostEvents,
-        deletionEvents: myDeletionEvents,
-        knownTargets: eventsById,
-        kind: Repost,
-      }),
-    [eventsById, myDeletionEvents, myRepostEvents]
-  );
-
-  // ---- sync relay data into store ----
-
-  useEffect(() => {
-    if (eventIds.length === 0) return;
-    const { syncLikesFromRelay, syncRepostsFromRelay } = useNostrSocialStore.getState();
-
-    const likesPayload = relayLikes.map((l) => ({
-      targetEventId: l.targetEventId,
-      reactionEventId: l.engagementEventId,
-      createdAt: l.createdAt,
-    }));
-    const repostsPayload = relayReposts.map((r) => ({
-      targetEventId: r.targetEventId,
-      repostEventId: r.engagementEventId,
-      createdAt: r.createdAt,
-    }));
-
-    syncLikesFromRelay(eventIds, likesPayload);
-    syncRepostsFromRelay(eventIds, repostsPayload);
-  }, [eventIds, relayLikes, relayReposts]);
-
-  // ---- settle optimistic entries when relay catches up ----
+  // ---- settle optimistic entries when the global sync catches up ----
 
   useEffect(() => {
     const { clearLikeOptimistic, clearRepostOptimistic } = useNostrSocialStore.getState();
@@ -403,6 +271,7 @@ export function useNostrEngagement(
       return {
         liked: optLike ? optLike.value : baseLiked,
         reposted: optRepost ? optRepost.value : baseReposted,
+        replied: !!repliedByEventId[eventId],
         likePending: !!optLike?.pending,
         repostPending: !!optRepost?.pending,
         likePendingDirection: optLike?.pending
@@ -417,7 +286,13 @@ export function useNostrEngagement(
           : undefined,
       };
     },
-    [likesByEventId, optimisticLikesByEventId, optimisticRepostsByEventId, repostsByEventId]
+    [
+      likesByEventId,
+      repliedByEventId,
+      optimisticLikesByEventId,
+      optimisticRepostsByEventId,
+      repostsByEventId,
+    ]
   );
 
   const getDisplayMetrics = useCallback(

--- a/features/feed/lib/feedRows.ts
+++ b/features/feed/lib/feedRows.ts
@@ -21,6 +21,7 @@ export type FeedRow = {
 export const DEFAULT_ENGAGEMENT_STATE: EngagementViewState = Object.freeze({
   liked: false,
   reposted: false,
+  replied: false,
   likePending: false,
   repostPending: false,
 });

--- a/features/feed/lib/feedRows.ts
+++ b/features/feed/lib/feedRows.ts
@@ -235,6 +235,7 @@ function engagementEqual(a: EngagementViewState, b: EngagementViewState): boolea
   return (
     a.liked === b.liked &&
     a.reposted === b.reposted &&
+    a.replied === b.replied &&
     a.likePending === b.likePending &&
     a.repostPending === b.repostPending &&
     a.likePendingDirection === b.likePendingDirection &&

--- a/features/user/screens/UserProfileScreen.tsx
+++ b/features/user/screens/UserProfileScreen.tsx
@@ -47,7 +47,7 @@ import { usePaymentFlowMachine } from '@sovranbitcoin/colada/react';
 import { useWalletContext } from '@/shared/providers/WalletContextProvider';
 import { ScreenHeaderAction } from '@/shared/ui/composed/ScreenHeaderAction';
 import { SendMessageMenu } from '@/features/user/components/SendMessageMenu';
-import { NDKEvent, useNDK, useSubscribe } from '@nostr-dev-kit/ndk-mobile';
+import { NDKEvent, useNDK } from '@nostr-dev-kit/ndk-mobile';
 import { Contacts } from 'nostr-tools/kinds';
 import { nip19 } from 'nostr-tools';
 import { copyPopup, type CopyTarget, staticPopup, paramPopup } from '@/shared/lib/popup';
@@ -818,21 +818,11 @@ export function UserProfileScreen() {
   // entry is shared across surfaces and persists across launches.
   const { metadata: cachedProfile, isLoading: isMetadataLoading } = useNostrProfileMetadata(pubkey);
 
-  const contactListFilters = useMemo(
-    () =>
-      nostrKeys?.pubkey ? [{ authors: [nostrKeys.pubkey], kinds: [Contacts], limit: 20 }] : null,
-    [nostrKeys?.pubkey]
-  );
-  const { events: contactListEvents } = useSubscribe({ filters: contactListFilters });
-
   const contactsTags = useNostrSocialStore((state) => state.contactsTags);
   const contactsContent = useNostrSocialStore((state) => state.contactsContent);
   const setContactsFromRelay = useNostrSocialStore((state) => state.setContactsFromRelay);
   const setFollowOptimistic = useNostrSocialStore((state) => state.setFollowOptimistic);
   const clearFollowOptimistic = useNostrSocialStore((state) => state.clearFollowOptimistic);
-  const clearSettledFollowOptimistic = useNostrSocialStore(
-    (state) => state.clearSettledFollowOptimistic
-  );
   const followOptimisticEntry = useNostrSocialStore((state) =>
     pubkey ? state.optimisticFollowsByPubkey[pubkey] : undefined
   );
@@ -924,33 +914,8 @@ export function UserProfileScreen() {
       ? formatDate(profileData.created_at * 1000, 'long-date')
       : undefined;
 
-  const latestContactListEvent = useMemo(() => {
-    if (!nostrKeys?.pubkey) return null;
-    const candidates = (contactListEvents || []).filter(
-      (event) => event.kind === Contacts && event.pubkey === nostrKeys.pubkey
-    );
-    if (candidates.length === 0) return null;
-    return [...candidates].sort((a, b) => {
-      const byCreatedAt = (b.created_at || 0) - (a.created_at || 0);
-      if (byCreatedAt !== 0) return byCreatedAt;
-      return (b.id || '').localeCompare(a.id || '');
-    })[0];
-  }, [contactListEvents, nostrKeys?.pubkey]);
-
-  useEffect(() => {
-    if (!latestContactListEvent) return;
-    const tags = Array.isArray(latestContactListEvent.tags)
-      ? (latestContactListEvent.tags as string[][])
-      : [];
-    const content =
-      typeof latestContactListEvent.content === 'string' ? latestContactListEvent.content : '';
-    setContactsFromRelay({
-      tags,
-      content,
-      createdAt: latestContactListEvent.created_at || 0,
-    });
-    clearSettledFollowOptimistic();
-  }, [latestContactListEvent, setContactsFromRelay, clearSettledFollowOptimistic]);
+  // Our kind:3 contacts are synced globally by useOwnEventsSync (which also
+  // settles follow optimism); no per-screen contact subscription needed.
 
   // Displayed aggregation counts come from Vertex (nagg) everywhere for
   // consistency — both follower and following. On the own profile we fall back

--- a/shared/lib/brandColors.ts
+++ b/shared/lib/brandColors.ts
@@ -14,6 +14,12 @@ export const BLUETOOTH_ACCENT = '#0A84FF';
  *  channel state — bitchat mesh broadcast icon, BLE peer connected dots. */
 export const CONNECTED_ACCENT = '#34C759';
 
+/** Reply/comment accent (#3B9EFF). Fixed cross-theme blue used to highlight
+ *  the comment icon when the viewer has replied to a post — a sibling to the
+ *  fixed pink "like" accent (so the cue reads the same on every theme, unlike
+ *  the theme-derived `link` token which can render greyish). */
+export const COMMENT_ACCENT = '#3B9EFF';
+
 /** Bitcoin orange (#F7931A). Used wherever a "bitcoin-accepting" or
  *  "bitcoin-denominated" semantic cue is rendered: BTCMap markers, splitBill
  *  participant pills, mint-info bitcoin glyphs. Matches `orange-300` in

--- a/shared/lib/cashu/profileScopedStorage.ts
+++ b/shared/lib/cashu/profileScopedStorage.ts
@@ -219,6 +219,7 @@ async function rehydrateProfileStores(): Promise<void> {
         followingPubkeys: {},
         likesByEventId: {},
         repostsByEventId: {},
+        repliedByEventId: {},
         deletedRepostOriginalIds: {},
         optimisticFollowsByPubkey: {},
         optimisticLikesByEventId: {},

--- a/shared/lib/nostr/ownsync/partitionOwnEvents.ts
+++ b/shared/lib/nostr/ownsync/partitionOwnEvents.ts
@@ -18,23 +18,23 @@ import {
 
 import type { FeedEvent } from '@/features/feed/components/nostr/feedTypes';
 
-export interface OwnLikeRow {
+interface OwnLikeRow {
   targetEventId: string;
   reactionEventId: string;
   createdAt: number;
 }
-export interface OwnRepostRow {
+interface OwnRepostRow {
   targetEventId: string;
   repostEventId: string;
   createdAt: number;
 }
-export interface OwnReplyRow {
+interface OwnReplyRow {
   targetEventId: string;
   replyEventId: string;
   createdAt: number;
 }
 
-export interface OwnEventsPartition {
+interface OwnEventsPartition {
   /** Newest kind:0 in the batch. */
   latestProfile?: FeedEvent;
   /** Newest kind:3 in the batch. */

--- a/shared/lib/nostr/ownsync/partitionOwnEvents.ts
+++ b/shared/lib/nostr/ownsync/partitionOwnEvents.ts
@@ -1,0 +1,148 @@
+/**
+ * @fileoverview Pure partitioner for the own-events sync.
+ *
+ * Takes a batch of our own Nostr events (from the single `useOwnEventsSync`
+ * subscription) and splits them into the rows each canonical store ingests:
+ * profile (kind 0), contacts (kind 3), likes (7), reposts (6), replies (1 with
+ * a reply e-tag), all own notes (1), and deletions (5). Kept pure so the
+ * routing logic is unit-testable without NDK or stores.
+ */
+import {
+  Contacts,
+  EventDeletion,
+  Metadata,
+  Reaction,
+  Repost,
+  ShortTextNote,
+} from 'nostr-tools/kinds';
+
+import type { FeedEvent } from '@/features/feed/components/nostr/feedTypes';
+
+export interface OwnLikeRow {
+  targetEventId: string;
+  reactionEventId: string;
+  createdAt: number;
+}
+export interface OwnRepostRow {
+  targetEventId: string;
+  repostEventId: string;
+  createdAt: number;
+}
+export interface OwnReplyRow {
+  targetEventId: string;
+  replyEventId: string;
+  createdAt: number;
+}
+
+export interface OwnEventsPartition {
+  /** Newest kind:0 in the batch. */
+  latestProfile?: FeedEvent;
+  /** Newest kind:3 in the batch. */
+  latestContacts?: FeedEvent;
+  likes: OwnLikeRow[];
+  reposts: OwnRepostRow[];
+  replies: OwnReplyRow[];
+  /** Every own kind:1 (posts, replies, quotes) — for ownContentStore. */
+  ownNotes: FeedEvent[];
+  /** Target event ids deleted by our kind:5 events. */
+  deletedEventIds: string[];
+}
+
+/** First `e` tag value (the target of a like/repost). */
+function firstETag(tags: string[][]): string | undefined {
+  return tags.find((t) => t[0] === 'e' && !!t[1])?.[1];
+}
+
+/**
+ * The reply target of a kind:1 per NIP-10: the `reply`-marked e-tag, else the
+ * `root`-marked one, else the last UNMARKED e-tag (legacy positional). Returns
+ * undefined for top-level notes and for quotes/mentions (whose e-tags are
+ * `mention`-marked or absent) so they don't count as replies.
+ */
+function replyTarget(tags: string[][]): string | undefined {
+  const eTags = tags.filter((t) => t[0] === 'e' && !!t[1]);
+  if (eTags.length === 0) return undefined;
+  const marked = (marker: string) => eTags.find((t) => t[3] === marker)?.[1];
+  const reply = marked('reply');
+  if (reply) return reply;
+  const root = marked('root');
+  if (root) return root;
+  const unmarked = eTags.filter((t) => !t[3]);
+  return unmarked.length > 0 ? unmarked[unmarked.length - 1][1] : undefined;
+}
+
+/** NIP-25: only `+` / empty reactions count as a "like". */
+function isLikeReaction(content: string): boolean {
+  return content === '+' || content === '';
+}
+
+export function partitionOwnEvents(events: readonly FeedEvent[]): OwnEventsPartition {
+  const out: OwnEventsPartition = {
+    likes: [],
+    reposts: [],
+    replies: [],
+    ownNotes: [],
+    deletedEventIds: [],
+  };
+
+  for (const event of events) {
+    switch (event.kind) {
+      case Metadata:
+        if (!out.latestProfile || event.created_at > out.latestProfile.created_at) {
+          out.latestProfile = event;
+        }
+        break;
+      case Contacts:
+        if (!out.latestContacts || event.created_at > out.latestContacts.created_at) {
+          out.latestContacts = event;
+        }
+        break;
+      case Reaction: {
+        const target = firstETag(event.tags);
+        if (target && isLikeReaction(event.content)) {
+          out.likes.push({
+            targetEventId: target,
+            reactionEventId: event.id,
+            createdAt: event.created_at,
+          });
+        }
+        break;
+      }
+      case Repost: {
+        const target = firstETag(event.tags);
+        if (target) {
+          out.reposts.push({
+            targetEventId: target,
+            repostEventId: event.id,
+            createdAt: event.created_at,
+          });
+        }
+        break;
+      }
+      case ShortTextNote: {
+        out.ownNotes.push(event);
+        const target = replyTarget(event.tags);
+        if (target) {
+          out.replies.push({
+            targetEventId: target,
+            replyEventId: event.id,
+            createdAt: event.created_at,
+          });
+        }
+        break;
+      }
+      case EventDeletion:
+        for (const tag of event.tags) {
+          if (tag[0] === 'e' && tag[1]) out.deletedEventIds.push(tag[1]);
+        }
+        break;
+      default:
+        break;
+    }
+  }
+
+  return out;
+}
+
+/** Kinds the own-events sync subscribes to. */
+export const OWN_EVENT_KINDS = [Metadata, ShortTextNote, Contacts, EventDeletion, Repost, Reaction];

--- a/shared/lib/nostr/ownsync/partitionOwnEvents.ts
+++ b/shared/lib/nostr/ownsync/partitionOwnEvents.ts
@@ -16,7 +16,19 @@ import {
   ShortTextNote,
 } from 'nostr-tools/kinds';
 
-import type { FeedEvent } from '@/features/feed/components/nostr/feedTypes';
+/**
+ * Minimal Nostr event shape this layer needs. Defined here (not imported from
+ * the feature layer) so the own-sync core stays a shared module with no
+ * `features` dependency; structurally compatible with feed `FeedEvent`.
+ */
+export interface OwnSyncEvent {
+  id: string;
+  kind: number;
+  pubkey: string;
+  content: string;
+  tags: string[][];
+  created_at: number;
+}
 
 interface OwnLikeRow {
   targetEventId: string;
@@ -36,14 +48,14 @@ interface OwnReplyRow {
 
 interface OwnEventsPartition {
   /** Newest kind:0 in the batch. */
-  latestProfile?: FeedEvent;
+  latestProfile?: OwnSyncEvent;
   /** Newest kind:3 in the batch. */
-  latestContacts?: FeedEvent;
+  latestContacts?: OwnSyncEvent;
   likes: OwnLikeRow[];
   reposts: OwnRepostRow[];
   replies: OwnReplyRow[];
   /** Every own kind:1 (posts, replies, quotes) — for ownContentStore. */
-  ownNotes: FeedEvent[];
+  ownNotes: OwnSyncEvent[];
   /** Target event ids deleted by our kind:5 events. */
   deletedEventIds: string[];
 }
@@ -76,7 +88,7 @@ function isLikeReaction(content: string): boolean {
   return content === '+' || content === '';
 }
 
-export function partitionOwnEvents(events: readonly FeedEvent[]): OwnEventsPartition {
+export function partitionOwnEvents(events: readonly OwnSyncEvent[]): OwnEventsPartition {
   const out: OwnEventsPartition = {
     likes: [],
     reposts: [],

--- a/shared/lib/nostr/ownsync/useOwnEventsSync.ts
+++ b/shared/lib/nostr/ownsync/useOwnEventsSync.ts
@@ -19,14 +19,13 @@ import { useEffect, useMemo, useRef } from 'react';
 
 import { useSubscribe } from '@nostr-dev-kit/ndk-mobile';
 
-import type { FeedEvent } from '@/features/feed/components/nostr/feedTypes';
 import { nostrLog } from '@/shared/lib/logger';
 import { useNostrKeysContext } from '@/shared/providers/NostrKeysProvider';
 import { useProfileStore } from '@/shared/stores/global/profileStore';
 import { useNostrSocialStore } from '@/shared/stores/profile/nostrSocialStore';
 import { useOwnContentStore } from '@/shared/stores/profile/ownContentStore';
 
-import { OWN_EVENT_KINDS, partitionOwnEvents } from './partitionOwnEvents';
+import { OWN_EVENT_KINDS, partitionOwnEvents, type OwnSyncEvent } from './partitionOwnEvents';
 
 /** Backfill window for our own events. Replaceable kinds (0/3) ignore it. */
 const BACKFILL_SEC = 365 * 24 * 60 * 60; // 1 year
@@ -37,14 +36,14 @@ const PER_KIND_LIMIT = 5000;
 // useNostrProfileMetadata). closeOnEose:false keeps it live for cross-client updates.
 const OWN_SUBSCRIBE_OPTS = { closeOnEose: false } as const;
 
-function toFeedEvent(raw: {
+function toOwnSyncEvent(raw: {
   id: string;
   kind: number;
   pubkey: string;
   content?: unknown;
   tags?: unknown;
   created_at?: number;
-}): FeedEvent {
+}): OwnSyncEvent {
   return {
     id: raw.id,
     kind: raw.kind,
@@ -55,7 +54,7 @@ function toFeedEvent(raw: {
   };
 }
 
-function applyProfile(event: FeedEvent, accountIndex: number): void {
+function applyProfile(event: OwnSyncEvent, accountIndex: number): void {
   try {
     const parsed = JSON.parse(event.content) as {
       display_name?: string;
@@ -86,18 +85,22 @@ export function useOwnEventsSync(): void {
 
   // Only dispatch events we haven't seen; reset when the active profile changes.
   const processedRef = useRef<Set<string>>(new Set());
+  // Newest kind:0 created_at applied so far — guards against an older profile
+  // event (in a later/out-of-order batch) regressing the cached name/avatar.
+  const lastProfileAtRef = useRef(0);
   useEffect(() => {
     processedRef.current = new Set();
+    lastProfileAtRef.current = 0;
   }, [pubkey]);
 
   useEffect(() => {
     if (!pubkey || !events?.length) return;
-    const fresh: FeedEvent[] = [];
+    const fresh: OwnSyncEvent[] = [];
     for (const raw of events) {
       const id = (raw as { id?: string }).id;
       if (!id || processedRef.current.has(id)) continue;
       processedRef.current.add(id);
-      fresh.push(toFeedEvent(raw as Parameters<typeof toFeedEvent>[0]));
+      fresh.push(toOwnSyncEvent(raw as Parameters<typeof toOwnSyncEvent>[0]));
     }
     if (fresh.length === 0) return;
 
@@ -119,7 +122,10 @@ export function useOwnEventsSync(): void {
       });
       social.clearSettledFollowOptimistic();
     }
-    if (part.latestProfile) applyProfile(part.latestProfile, activeAccountIndex);
+    if (part.latestProfile && part.latestProfile.created_at > lastProfileAtRef.current) {
+      applyProfile(part.latestProfile, activeAccountIndex);
+      lastProfileAtRef.current = part.latestProfile.created_at;
+    }
 
     nostrLog.debug('nostr.ownsync.ingested', {
       fresh: fresh.length,

--- a/shared/lib/nostr/ownsync/useOwnEventsSync.ts
+++ b/shared/lib/nostr/ownsync/useOwnEventsSync.ts
@@ -1,0 +1,133 @@
+/**
+ * @fileoverview `useOwnEventsSync` — one long-lived, app-level relay
+ * subscription for ALL of our own events (kind 0/1/3/5/6/7), hydrating the
+ * canonical own-state stores so they're authoritative everywhere.
+ *
+ * This is the single owner of "keep my own state synced from relays". It
+ * replaces the previously-scattered fetches (per-screen engagement subs, the
+ * profile-screen contact sub, the boot kind:0 sync) and does NOT use nagg —
+ * viewer-state (liked/reposted/replied/followed) is relay-direct (see ADR 0002).
+ *
+ * Dispatch (via the pure `partitionOwnEvents`):
+ *   kind 0 → profileStore metadata
+ *   kind 3 → nostrSocialStore.setContactsFromRelay (follows)
+ *   kind 1 → ownContentStore.ingestSeen + reply e-tags → nostrSocialStore.ingestOwnReplies
+ *   kind 6/7 → nostrSocialStore.ingestOwnReposts/ingestOwnLikes (global upsert)
+ *   kind 5 → nostrSocialStore.applyOwnDeletions
+ */
+import { useEffect, useMemo, useRef } from 'react';
+
+import { useSubscribe } from '@nostr-dev-kit/ndk-mobile';
+
+import type { FeedEvent } from '@/features/feed/components/nostr/feedTypes';
+import { nostrLog } from '@/shared/lib/logger';
+import { useNostrKeysContext } from '@/shared/providers/NostrKeysProvider';
+import { useProfileStore } from '@/shared/stores/global/profileStore';
+import { useNostrSocialStore } from '@/shared/stores/profile/nostrSocialStore';
+import { useOwnContentStore } from '@/shared/stores/profile/ownContentStore';
+
+import { OWN_EVENT_KINDS, partitionOwnEvents } from './partitionOwnEvents';
+
+/** Backfill window for our own events. Replaceable kinds (0/3) ignore it. */
+const BACKFILL_SEC = 365 * 24 * 60 * 60; // 1 year
+const PER_KIND_LIMIT = 5000;
+
+// Module-level so the reference is stable across renders — a fresh opts object
+// makes useSubscribe tear down on EOSE and re-render-loop (see
+// useNostrProfileMetadata). closeOnEose:false keeps it live for cross-client updates.
+const OWN_SUBSCRIBE_OPTS = { closeOnEose: false } as const;
+
+function toFeedEvent(raw: {
+  id: string;
+  kind: number;
+  pubkey: string;
+  content?: unknown;
+  tags?: unknown;
+  created_at?: number;
+}): FeedEvent {
+  return {
+    id: raw.id,
+    kind: raw.kind,
+    pubkey: raw.pubkey,
+    content: typeof raw.content === 'string' ? raw.content : '',
+    tags: Array.isArray(raw.tags) ? (raw.tags as string[][]) : [],
+    created_at: raw.created_at ?? 0,
+  };
+}
+
+function applyProfile(event: FeedEvent, accountIndex: number): void {
+  try {
+    const parsed = JSON.parse(event.content) as {
+      display_name?: string;
+      name?: string;
+      picture?: string;
+    };
+    const displayName = parsed.display_name || parsed.name || undefined;
+    const picture = parsed.picture || undefined;
+    useProfileStore.getState().updateProfileMetadata(accountIndex, displayName, picture);
+  } catch {
+    // Malformed kind:0 content — ignore.
+  }
+}
+
+export function useOwnEventsSync(): void {
+  const { keys } = useNostrKeysContext();
+  const pubkey = keys?.pubkey;
+  const activeAccountIndex = useProfileStore((s) => s.activeAccountIndex);
+
+  // Stable per-pubkey filters (since computed once per pubkey, not per render).
+  const filters = useMemo(() => {
+    if (!pubkey) return null;
+    const since = Math.floor(Date.now() / 1000) - BACKFILL_SEC;
+    return [{ authors: [pubkey], kinds: OWN_EVENT_KINDS, since, limit: PER_KIND_LIMIT }];
+  }, [pubkey]);
+
+  const { events } = useSubscribe({ filters, opts: OWN_SUBSCRIBE_OPTS });
+
+  // Only dispatch events we haven't seen; reset when the active profile changes.
+  const processedRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    processedRef.current = new Set();
+  }, [pubkey]);
+
+  useEffect(() => {
+    if (!pubkey || !events?.length) return;
+    const fresh: FeedEvent[] = [];
+    for (const raw of events) {
+      const id = (raw as { id?: string }).id;
+      if (!id || processedRef.current.has(id)) continue;
+      processedRef.current.add(id);
+      fresh.push(toFeedEvent(raw as Parameters<typeof toFeedEvent>[0]));
+    }
+    if (fresh.length === 0) return;
+
+    const part = partitionOwnEvents(fresh);
+    const social = useNostrSocialStore.getState();
+    social.ingestOwnLikes(part.likes);
+    social.ingestOwnReposts(part.reposts);
+    social.ingestOwnReplies(part.replies);
+    social.applyOwnDeletions(part.deletedEventIds);
+    if (part.ownNotes.length > 0) {
+      const own = useOwnContentStore.getState();
+      for (const note of part.ownNotes) own.ingestSeen(note);
+    }
+    if (part.latestContacts) {
+      social.setContactsFromRelay({
+        tags: part.latestContacts.tags,
+        content: part.latestContacts.content,
+        createdAt: part.latestContacts.created_at,
+      });
+      social.clearSettledFollowOptimistic();
+    }
+    if (part.latestProfile) applyProfile(part.latestProfile, activeAccountIndex);
+
+    nostrLog.debug('nostr.ownsync.ingested', {
+      fresh: fresh.length,
+      likes: part.likes.length,
+      reposts: part.reposts.length,
+      replies: part.replies.length,
+      notes: part.ownNotes.length,
+      deletions: part.deletedEventIds.length,
+    });
+  }, [events, pubkey, activeAccountIndex]);
+}

--- a/shared/stores/profile/nostrSocialStore.ts
+++ b/shared/stores/profile/nostrSocialStore.ts
@@ -20,6 +20,20 @@ type NostrRepostState = {
   updatedAt: number;
 };
 
+type NostrRepliedState = {
+  replyEventId?: string;
+  updatedAt: number;
+};
+
+/**
+ * Recency cap on the canonical own-engagement maps. The global own-events sync
+ * (`useOwnEventsSync`) can backfill thousands of our likes/reposts/replies; cap
+ * each map to the most-recent N by `updatedAt` so the persisted blob and
+ * rehydrate stay bounded. Engagement older than the cap simply won't highlight
+ * (rare, and the post would have to be re-encountered).
+ */
+const MAX_ENGAGEMENT_ENTRIES = 5000;
+
 type FollowOptimisticState = {
   value: boolean;
   pending: boolean;
@@ -43,6 +57,8 @@ interface NostrSocialState {
 
   likesByEventId: Record<string, NostrReactionState>;
   repostsByEventId: Record<string, NostrRepostState>;
+  /** Target event id → our reply to it. Drives the "you replied" highlight. */
+  repliedByEventId: Record<string, NostrRepliedState>;
   deletedRepostOriginalIds: Record<string, number>;
 
   optimisticFollowsByPubkey: Record<string, FollowOptimisticState>;
@@ -59,14 +75,23 @@ interface NostrSocialActions {
   markRepostDeleted: (originalEventId: string) => void;
   unmarkRepostDeleted: (originalEventId: string) => void;
 
-  syncLikesFromRelay: (
-    targetEventIds: string[],
+  /**
+   * Global upsert of our own likes from the own-events sync. Unlike the legacy
+   * scoped `syncLikesFromRelay`, this never deletes (no on-screen target set):
+   * it merges newer entries and recency-caps. Deletions arrive via
+   * {@link applyOwnDeletions}.
+   */
+  ingestOwnLikes: (
     likes: { targetEventId: string; reactionEventId: string; createdAt: number }[]
   ) => void;
-  syncRepostsFromRelay: (
-    targetEventIds: string[],
+  ingestOwnReposts: (
     reposts: { targetEventId: string; repostEventId: string; createdAt: number }[]
   ) => void;
+  ingestOwnReplies: (
+    replies: { targetEventId: string; replyEventId: string; createdAt: number }[]
+  ) => void;
+  /** Apply our own kind:5 deletions: drop any like/repost/reply whose own event id was deleted. */
+  applyOwnDeletions: (deletedEventIds: string[]) => void;
 
   setLikeOptimistic: (
     eventId: string,
@@ -90,7 +115,6 @@ interface NostrSocialActions {
   ) => void;
   clearLikeOptimistic: (eventId: string) => void;
   clearRepostOptimistic: (eventId: string) => void;
-  clearSettledEngagementOptimistic: () => void;
 }
 
 type NostrSocialStore = NostrSocialState & NostrSocialActions;
@@ -125,6 +149,34 @@ function withOptimisticEntry<V extends { updatedAt: number }>(
   return { ...map, [key]: { ...params, updatedAt: Date.now() } as unknown as V };
 }
 
+/** Keep only the `max` most-recent entries (by `updatedAt`); no-op under the cap. */
+function capByRecency<V extends { updatedAt: number }>(
+  map: Record<string, V>,
+  max: number
+): Record<string, V> {
+  const keys = Object.keys(map);
+  if (keys.length <= max) return map;
+  const kept = keys
+    .sort((a, b) => map[b].updatedAt - map[a].updatedAt)
+    .slice(0, max);
+  const next: Record<string, V> = {};
+  for (const key of kept) next[key] = map[key];
+  return next;
+}
+
+/** Merge own-engagement rows (target → record) into a map, keeping the newest per target. */
+function upsertByTarget<V extends { updatedAt: number }>(
+  base: Record<string, V>,
+  rows: { targetEventId: string; createdAt: number; record: V }[]
+): Record<string, V> {
+  const next = { ...base };
+  for (const { targetEventId, createdAt, record } of rows) {
+    const existing = next[targetEventId];
+    if (!existing || createdAt >= existing.updatedAt) next[targetEventId] = record;
+  }
+  return capByRecency(next, MAX_ENGAGEMENT_ENTRIES);
+}
+
 // ---------------------------------------------------------------------------
 // Store
 // ---------------------------------------------------------------------------
@@ -136,6 +188,7 @@ const INITIAL_STATE: NostrSocialState = {
   followingPubkeys: {},
   likesByEventId: {},
   repostsByEventId: {},
+  repliedByEventId: {},
   deletedRepostOriginalIds: {},
   optimisticFollowsByPubkey: {},
   optimisticLikesByEventId: {},
@@ -152,6 +205,10 @@ const PersistedReactionState = z.looseObject({
 });
 const PersistedRepostState = z.looseObject({
   repostEventId: z.string().max(128).optional(),
+  updatedAt: z.number().int().nonnegative(),
+});
+const PersistedRepliedState = z.looseObject({
+  replyEventId: z.string().max(128).optional(),
   updatedAt: z.number().int().nonnegative(),
 });
 const PersistedFollowOptimistic = z.looseObject({
@@ -176,8 +233,15 @@ const PersistedNostrSocialStore = z.object({
   contactsContent: z.string().max(65_536).default(''),
   contactsUpdatedAt: z.number().int().nonnegative().default(0),
   followingPubkeys: z.record(z.string().max(128), z.literal(true)).default({}),
-  likesByEventId: z.record(z.string().max(128), PersistedReactionState).default({}),
-  repostsByEventId: z.record(z.string().max(128), PersistedRepostState).default({}),
+  likesByEventId: z
+    .record(z.string().max(128), PersistedReactionState)
+    .default({}),
+  repostsByEventId: z
+    .record(z.string().max(128), PersistedRepostState)
+    .default({}),
+  repliedByEventId: z
+    .record(z.string().max(128), PersistedRepliedState)
+    .default({}),
   deletedRepostOriginalIds: z
     .record(z.string().max(128), z.number().int().nonnegative())
     .default({}),
@@ -282,64 +346,83 @@ export const useNostrSocialStore = create<NostrSocialStore>()(
         }));
       },
 
-      // ---- sync from relay ----
+      // ---- own-events sync (global upsert; see useOwnEventsSync) ----
 
-      syncLikesFromRelay: (targetEventIds, likes) => {
-        storeLog.info('social.likes.sync', {
-          targetCount: targetEventIds.length,
-          likeCount: likes.length,
-        });
-        const byTarget: Record<string, NostrReactionState> = {};
-        for (const like of likes) {
-          const existing = byTarget[like.targetEventId];
-          if (!existing || like.createdAt >= existing.updatedAt) {
-            byTarget[like.targetEventId] = {
-              reactionEventId: like.reactionEventId,
-              updatedAt: like.createdAt,
-            };
-          }
-        }
-
-        set((state) => {
-          const nextLikes = { ...state.likesByEventId };
-          for (const id of targetEventIds) {
-            const relay = byTarget[id];
-            if (relay) nextLikes[id] = relay;
-            else delete nextLikes[id];
-          }
-          return { likesByEventId: nextLikes };
-        });
+      ingestOwnLikes: (likes) => {
+        if (likes.length === 0) return;
+        storeLog.info('social.likes.ingest', { likeCount: likes.length });
+        set((state) => ({
+          likesByEventId: upsertByTarget(
+            state.likesByEventId,
+            likes.map((l) => ({
+              targetEventId: l.targetEventId,
+              createdAt: l.createdAt,
+              record: { reactionEventId: l.reactionEventId, updatedAt: l.createdAt },
+            }))
+          ),
+        }));
       },
 
-      syncRepostsFromRelay: (targetEventIds, reposts) => {
-        storeLog.info('social.reposts.sync', {
-          targetCount: targetEventIds.length,
-          repostCount: reposts.length,
-        });
-        const byTarget: Record<string, NostrRepostState> = {};
-        for (const repost of reposts) {
-          const existing = byTarget[repost.targetEventId];
-          if (!existing || repost.createdAt >= existing.updatedAt) {
-            byTarget[repost.targetEventId] = {
-              repostEventId: repost.repostEventId,
-              updatedAt: repost.createdAt,
-            };
-          }
-        }
+      ingestOwnReposts: (reposts) => {
+        if (reposts.length === 0) return;
+        storeLog.info('social.reposts.ingest', { repostCount: reposts.length });
+        set((state) => ({
+          repostsByEventId: upsertByTarget(
+            state.repostsByEventId,
+            reposts.map((r) => ({
+              targetEventId: r.targetEventId,
+              createdAt: r.createdAt,
+              record: { repostEventId: r.repostEventId, updatedAt: r.createdAt },
+            }))
+          ),
+        }));
+      },
 
+      ingestOwnReplies: (replies) => {
+        if (replies.length === 0) return;
+        storeLog.info('social.replies.ingest', { replyCount: replies.length });
+        set((state) => ({
+          repliedByEventId: upsertByTarget(
+            state.repliedByEventId,
+            replies.map((r) => ({
+              targetEventId: r.targetEventId,
+              createdAt: r.createdAt,
+              record: { replyEventId: r.replyEventId, updatedAt: r.createdAt },
+            }))
+          ),
+        }));
+      },
+
+      applyOwnDeletions: (deletedEventIds) => {
+        if (deletedEventIds.length === 0) return;
+        const deleted = new Set(deletedEventIds);
         set((state) => {
-          const nextReposts = { ...state.repostsByEventId };
-          const nextDeleted = { ...state.deletedRepostOriginalIds };
-          for (const id of targetEventIds) {
-            const relay = byTarget[id];
-            if (relay) {
-              nextReposts[id] = relay;
-            } else {
-              delete nextReposts[id];
-              delete nextDeleted[id];
+          const prune = <V extends { [k: string]: unknown }>(
+            map: Record<string, V>,
+            ownIdKey: keyof V
+          ): { next: Record<string, V>; removed: number } => {
+            let removed = 0;
+            const next: Record<string, V> = {};
+            for (const [target, record] of Object.entries(map)) {
+              const ownId = record[ownIdKey];
+              if (typeof ownId === 'string' && deleted.has(ownId)) {
+                removed += 1;
+                continue;
+              }
+              next[target] = record;
             }
-          }
-          return { repostsByEventId: nextReposts, deletedRepostOriginalIds: nextDeleted };
+            return { next, removed };
+          };
+          const likes = prune(state.likesByEventId, 'reactionEventId');
+          const reposts = prune(state.repostsByEventId, 'repostEventId');
+          const replies = prune(state.repliedByEventId, 'replyEventId');
+          const removed = likes.removed + reposts.removed + replies.removed;
+          if (removed > 0) storeLog.info('social.own.deletions_applied', { removed });
+          return {
+            likesByEventId: likes.next,
+            repostsByEventId: reposts.next,
+            repliedByEventId: replies.next,
+          };
         });
       },
 
@@ -388,39 +471,6 @@ export const useNostrSocialStore = create<NostrSocialStore>()(
           optimisticRepostsByEventId: omitKey(state.optimisticRepostsByEventId, eventId),
         }));
       },
-
-      clearSettledEngagementOptimistic: () => {
-        set((state) => {
-          const filterSettled = <Base>(
-            optimistic: Record<string, EngagementOptimisticState>,
-            base: Record<string, Base>
-          ) => {
-            const next: Record<string, EngagementOptimisticState> = {};
-            for (const [id, opt] of Object.entries(optimistic)) {
-              if (opt.pending || opt.value !== !!base[id]) next[id] = opt;
-            }
-            return next;
-          };
-
-          const nextLikes = filterSettled(state.optimisticLikesByEventId, state.likesByEventId);
-          const nextReposts = filterSettled(
-            state.optimisticRepostsByEventId,
-            state.repostsByEventId
-          );
-          const clearedLikes =
-            Object.keys(state.optimisticLikesByEventId).length - Object.keys(nextLikes).length;
-          const clearedReposts =
-            Object.keys(state.optimisticRepostsByEventId).length - Object.keys(nextReposts).length;
-          if (clearedLikes > 0 || clearedReposts > 0) {
-            storeLog.debug('social.engagement.settled.clear', { clearedLikes, clearedReposts });
-          }
-
-          return {
-            optimisticLikesByEventId: nextLikes,
-            optimisticRepostsByEventId: nextReposts,
-          };
-        });
-      },
     }),
     persistConfig({
       name: 'nostr-social-store',
@@ -434,6 +484,7 @@ export const useNostrSocialStore = create<NostrSocialStore>()(
         followingPubkeys: state.followingPubkeys,
         likesByEventId: state.likesByEventId,
         repostsByEventId: state.repostsByEventId,
+        repliedByEventId: state.repliedByEventId,
         deletedRepostOriginalIds: state.deletedRepostOriginalIds,
         optimisticFollowsByPubkey: state.optimisticFollowsByPubkey,
         optimisticLikesByEventId: state.optimisticLikesByEventId,

--- a/shared/stores/profile/nostrSocialStore.ts
+++ b/shared/stores/profile/nostrSocialStore.ts
@@ -156,9 +156,7 @@ function capByRecency<V extends { updatedAt: number }>(
 ): Record<string, V> {
   const keys = Object.keys(map);
   if (keys.length <= max) return map;
-  const kept = keys
-    .sort((a, b) => map[b].updatedAt - map[a].updatedAt)
-    .slice(0, max);
+  const kept = keys.sort((a, b) => map[b].updatedAt - map[a].updatedAt).slice(0, max);
   const next: Record<string, V> = {};
   for (const key of kept) next[key] = map[key];
   return next;
@@ -233,15 +231,9 @@ const PersistedNostrSocialStore = z.object({
   contactsContent: z.string().max(65_536).default(''),
   contactsUpdatedAt: z.number().int().nonnegative().default(0),
   followingPubkeys: z.record(z.string().max(128), z.literal(true)).default({}),
-  likesByEventId: z
-    .record(z.string().max(128), PersistedReactionState)
-    .default({}),
-  repostsByEventId: z
-    .record(z.string().max(128), PersistedRepostState)
-    .default({}),
-  repliedByEventId: z
-    .record(z.string().max(128), PersistedRepliedState)
-    .default({}),
+  likesByEventId: z.record(z.string().max(128), PersistedReactionState).default({}),
+  repostsByEventId: z.record(z.string().max(128), PersistedRepostState).default({}),
+  repliedByEventId: z.record(z.string().max(128), PersistedRepliedState).default({}),
   deletedRepostOriginalIds: z
     .record(z.string().max(128), z.number().int().nonnegative())
     .default({}),
@@ -256,7 +248,7 @@ const PersistedNostrSocialStore = z.object({
 
 export const useNostrSocialStore = create<NostrSocialStore>()(
   persist(
-    (set, get) => ({
+    (set) => ({
       ...INITIAL_STATE,
 
       // ---- contacts ----


### PR DESCRIPTION
## Why

Our own viewer-state (did *I* like / repost / reply; do I follow this profile) was learned **scattered and incompletely**: likes/reposts subscribed only to *on-screen* posts, follows synced only on your own profile screen, replies weren't tracked at all, and nagg carries no viewer-state. You asked for one **client-side relay sync of all our own events** that makes our stores authoritative everywhere — explicitly **not** via nagg.

## What

**`useOwnEventsSync`** — one long-lived app-level subscription `{authors:[me], kinds:[0,1,3,5,6,7]}` (relay-direct), the single owner of "keep my own state synced". A pure `partitionOwnEvents` routes each kind into its **existing canonical store** (no third store):

- kind 0 → `profileStore` (subsumes the old boot `ProfileMetadataSync`)
- kind 3 → `nostrSocialStore` follows (subsumes the profile-screen contact sub) + settle follow-optimism
- kind 1 → `ownContentStore.ingestSeen` + reply e-tags → new `repliedByEventId` index
- kind 6/7 → `nostrSocialStore` **global-upsert** likes/reposts
- kind 5 → `applyOwnDeletions`

**Consolidation:** three scattered subscriptions → one owner. `useNostrEngagement` drops its per-screen sub and reads the now-global store (keeps optimistic toggle). 

**Stores stay two** (your "why two?" — kept separate: authored content vs engagement/social graph; incompatible lifecycles). Added: `repliedByEventId` index, recency cap (`MAX_ENGAGEMENT_ENTRIES`) on canonical maps, global-upsert ingest; removed the dead `clearSettledEngagementOptimistic` and the scoped `syncLikes/RepostsFromRelay`.

**"You replied" highlight** in `MetricsFooter` (theme `link` color), wired on feed + thread.

## Decision

**ADR 0002 supersedes ADR 0001** — viewer-state is client-side relay sync, not nagg.

## Scope / deferred

Replied highlight is wired on the home feed + thread; the fullscreen image-overlay action bar, the thread floating bar, RepostCard, and UserFeed render sites are a documented fast-follow (they accept liked/reposted but not yet replied — they default off, not broken).

## Verification

`type-check` ✓ · `lint` ✓ · `knip` ✓ (no new dead code; stale eslint suppression pruned correctly) · tests for `partitionOwnEvents` (NIP-10 reply detection, like filter, deletions) and `nostrSocialStore` own-sync (global upsert, replied index, deletions). 40 tests across touched suites pass.

Backfill is bounded (1-year window + recency-capped compact indices); engagement older than the window/cap won't highlight (rare).

Do not merge.