### PR TITLE
feat(thread): anchor the focused note via maintainVisibleContentPosition

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -147,6 +147,14 @@ backend-free relay tier. Unread = `count(created_at > seenUntil)`.
 fixed while the parent chain prepends above it (the T1 full-thread update) and
 replies append below. Achieved by `initialScrollIndex` (land on the note) +
 `maintainVisibleContentPosition` (bare → `{ data: true, size: true }`: `data`
-compensates the parent prepend, `size` absorbs measurement reconciliation). The
-thread never auto-pins to the bottom — it omits the DM `ChatScreen`'s
-`initialScrollAtEnd` / `alignItemsAtEnd` / `maintainScrollAtEnd`. See ADR 0004.
+compensates the parent prepend, `size` absorbs measurement reconciliation) +
+`anchoredEndSpace` (the **end reserve**). The thread never auto-pins to the
+bottom — it omits the DM `ChatScreen`'s `initialScrollAtEnd` / `alignItemsAtEnd` /
+`maintainScrollAtEnd`. See ADR 0004.
+
+**End reserve** — `anchoredEndSpace={{ anchorIndex: targetIndex }}`: tail space the
+thread reserves so the focused note can scroll to the top. mVCP's prepend
+compensation is clamped at the max scroll offset, so without room below, a short
+thread still drops the note when parents load. The reserve = `viewport − (content
+from the note down) − footer − paddingBottom`, shrinking to 0 once replies fill
+the screen. See [[Thread anchor]] and ADR 0004.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -148,13 +148,15 @@ fixed while the parent chain prepends above it (the T1 full-thread update) and
 replies append below. Achieved by `initialScrollIndex` (land on the note) +
 `maintainVisibleContentPosition` (bare → `{ data: true, size: true }`: `data`
 compensates the parent prepend, `size` absorbs measurement reconciliation) +
-`anchoredEndSpace` (the **end reserve**). The thread never auto-pins to the
-bottom — it omits the DM `ChatScreen`'s `initialScrollAtEnd` / `alignItemsAtEnd` /
-`maintainScrollAtEnd`. See ADR 0004.
+the **focus reserve**. The thread never auto-pins to the bottom — it omits the DM
+`ChatScreen`'s `initialScrollAtEnd` / `alignItemsAtEnd` / `maintainScrollAtEnd`.
+See ADR 0004.
 
-**End reserve** — `anchoredEndSpace={{ anchorIndex: targetIndex }}`: tail space the
-thread reserves so the focused note can scroll to the top. mVCP's prepend
+**Focus reserve** — `focusReserve`: extra `paddingBottom` the thread adds so the
+focused note can be scrolled to (and held at) the top. mVCP's prepend
 compensation is clamped at the max scroll offset, so without room below, a short
-thread still drops the note when parents load. The reserve = `viewport − (content
-from the note down) − footer − paddingBottom`, shrinking to 0 once replies fill
-the screen. See [[Thread anchor]] and ADR 0004.
+thread drops the note when parents load, the scroll snaps, and the note can't be
+refocused. The reserve = `viewport − (rows below the note × approx height)`,
+shrinking to 0 as replies fill the screen. Owned in `ThreadView` (not the
+library's opaque `anchoredEndSpace`) so it's deterministic and logged
+(`thread.reserve`). See [[Thread anchor]] and ADR 0004.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -140,3 +140,13 @@ relays.
 **Seen state** — one timestamp "seen-up-to" published as a NIP-78 kind-30078
 app-data event so it syncs across devices via relays AND is readable on the
 backend-free relay tier. Unread = `count(created_at > seenUntil)`.
+
+## Thread reading
+
+**Thread anchor** — the tapped/focused note a thread opens on. It stays visually
+fixed while the parent chain prepends above it (the T1 full-thread update) and
+replies append below. Achieved by `initialScrollIndex` (land on the note) +
+`maintainVisibleContentPosition` (bare → `{ data: true, size: true }`: `data`
+compensates the parent prepend, `size` absorbs measurement reconciliation). The
+thread never auto-pins to the bottom — it omits the DM `ChatScreen`'s
+`initialScrollAtEnd` / `alignItemsAtEnd` / `maintainScrollAtEnd`. See ADR 0004.

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
         "@gandlaf21/bolt11-decode": "^3.1.1",
         "@gorhom/bottom-sheet": "5.2.9",
         "@internet-privacy/marmot-ts": "file:./vendor/marmot-ts",
-        "@legendapp/list": "3.0.0",
+        "@legendapp/list": "3.0.6",
         "@mealection/react-native-boring-avatars": "1.1.2",
         "@monicon/metro": "^2.0.7",
         "@monicon/native": "^1.2.2",
@@ -820,7 +820,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@legendapp/list": ["@legendapp/list@3.0.0", "", { "dependencies": { "use-sync-external-store": "^1.5.0" }, "peerDependencies": { "react": "*" } }, "sha512-b5PzA2OUQrBATFqFi0978N7pNuMPRiANfLWuYzKsl6+CWEN8o5KSDlor2CrLNtxDbIirHJVionON5vQCS4bF2A=="],
+    "@legendapp/list": ["@legendapp/list@3.0.6", "", { "dependencies": { "use-sync-external-store": "^1.5.0" }, "peerDependencies": { "react": "*" } }, "sha512-umEkE+WQpw61Ep1lLQC6f/UzXl19Jxqysg+WUP5VnvfA9TxCCj0VsxU8n2ukEFTovSIrY3ab4aFNKgJt9P1Ngg=="],
 
     "@manypkg/find-root": ["@manypkg/find-root@1.1.0", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@types/node": "^12.7.1", "find-up": "^4.1.0", "fs-extra": "^8.1.0" } }, "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA=="],
 

--- a/docs/adr/0004-thread-list-anchoring.md
+++ b/docs/adr/0004-thread-list-anchoring.md
@@ -46,9 +46,10 @@ library's correction" failure mode.
 Anchor the thread declaratively, reusing the same mechanism the DM `ChatScreen`
 already relies on:
 
-1. **`maintainVisibleContentPosition` (bare → `{ data: true, size: true }`)** on
-   the thread `LegendList`. `data:true` compensates the parent prepend; `size:true`
-   absorbs estimate→measured reconciliation.
+1. **`maintainVisibleContentPosition={{ data: true, size: false }}`** on the thread
+   `LegendList`. `data:true` lets the library compensate the parent prepend;
+   `size:false` hands the size axis entirely to our counter-scroll (3) so the two
+   never both move the scroll — that double-correction is what oscillated into jitter.
 2. **`focusReserve` — explicit bottom padding** so the focused note can reach (and
    be held at) the top of the viewport. mVCP compensates a prepend by _raising the
    scroll offset_, but that is clamped at the max scroll offset — a thread with
@@ -65,19 +66,24 @@ already relies on:
    dependency-version ambiguity), and emits a `thread.reserve` log so a trace can
    confirm it's live and its size.
 
-3. **Own the prepend's size reconciliation** (`onItemSizeChanged`). mVCP scrolls to
-   hold the note when the parent prepends, but it anchors against the parent's
-   _estimate_ (`estimatedItemSize`) and never reconciles the gap once the parent
-   measures to its real height — the note ends up off by exactly `estimate −
-measured` (live trace: estimate 200 vs measured 145 → note jumped **up 55px**;
-   an earlier media parent measured 523 → **down 323px**). A single global
-   `estimatedItemSize` can't fix this (parents range ~145–523px), and v3 exposes no
-   per-item estimate. So when a row **above** the note changes size **before the
-   reader has scrolled**, we counter-scroll by the delta (`scrollToOffset(scroll +
-(size − previous))`). This is the report's "manual offset compensation when you
-   control insertion timing" — a one-time reconciliation per parent measure, not a
-   sustained re-pin (which is why it doesn't race mVCP the way PR #225 did). A
-   `readerMovedRef` (set on `onScrollBeginDrag`) hands control back to the user.
+3. **Own the size axis** (`onItemSizeChanged`). While the reader hasn't scrolled, we
+   counter-scroll by the exact delta (`scrollToOffset(scroll + (size − previous))`)
+   for **every** size change of a row **above** the note. This covers two things a
+   single global `estimatedItemSize` can't (parents range ~145–523px; v3 has no
+   per-item estimate):
+   - the prepend's **estimate→measured** jump (live trace: estimate 200 vs measured
+     145 → note moved up 55px; a media parent measured 523 → down 323px), and
+   - **late media**: an image with no `imeta` dims (and not cached) reserves a 16:9
+     box, then reshapes to its real aspect on `onLoad` — a second, larger above-note
+     change (videos are locked to imeta-or-16:9, so they don't reshape).
+
+   Because the parents sit off-screen above the pinned note, absorbing their growth
+   keeps the note fixed. It's the report's "manual offset compensation when you
+   control insertion timing," and it's the **sole** owner of this axis (mVCP runs
+   `size:false`), so it can't race the library the way PR #225's `scrollToIndex`
+   re-pin did. A `readerMovedRef` (set on `onScrollBeginDrag`) hands control back to
+   the user, after which mVCP `data` still anchors future prepends.
+
 4. **`initialScrollIndex={targetIndex}`** lands the first paint on the tapped note.
 5. **No bottom-dock / auto-pin props.** Unlike `ChatScreen`, the thread omits
    `initialScrollAtEnd`, `alignItemsAtEnd`, and `maintainScrollAtEnd` — it anchors

--- a/docs/adr/0004-thread-list-anchoring.md
+++ b/docs/adr/0004-thread-list-anchoring.md
@@ -73,6 +73,11 @@ already relies on:
   RN ≥ 0.72; satisfied by our Expo SDK). The known racy edge (LegendApp/legend-list
   #463) bites *near the bottom* of a list; our anchor is the top-pinned note with a
   single prepend — the well-behaved case.
+- **Requires `@legendapp/list` ≥ 3.0.4.** The combination was inert/janky on the
+  first v3 release (3.0.0): the data-anchoring path was mis-batched (fixed 3.0.3),
+  `anchoredEndSpace` reported stale sizes during load (fixed 3.0.4), and
+  `scrollToIndex`/`initialScrollIndex` mislanded on iOS (fixed 3.0.1). We pin 3.0.6.
+  Re-verify these prop contracts on any future bump — v3 is still beta.
 
 ## Alternatives rejected
 

--- a/docs/adr/0004-thread-list-anchoring.md
+++ b/docs/adr/0004-thread-list-anchoring.md
@@ -49,15 +49,22 @@ already relies on:
 1. **`maintainVisibleContentPosition` (bare → `{ data: true, size: true }`)** on
    the thread `LegendList`. `data:true` compensates the parent prepend; `size:true`
    absorbs estimate→measured reconciliation.
-2. **`anchoredEndSpace={{ anchorIndex: targetIndex }}`** reserves tail space so the
-   focused note can reach the top of the viewport. mVCP compensates a prepend by
-   *raising the scroll offset*, but that is clamped at the max scroll offset — a
-   thread with little content below the target can't scroll far enough, so the note
-   drops anyway. The reserve sizes to `viewport − (content from anchorIndex down) −
-   footer − paddingBottom`, shrinking to 0 once the replies below already fill the
-   screen (no dead gap on long threads), and waits for measured sizes (no estimate
-   thrash). It is read by the v3.0.0 RN runtime but omitted from the exported RN
-   prop type, so it is typed locally and passed via spread.
+2. **`focusReserve` — explicit bottom padding** so the focused note can reach (and
+   be held at) the top of the viewport. mVCP compensates a prepend by _raising the
+   scroll offset_, but that is clamped at the max scroll offset — a thread with
+   little content below the target can't scroll far enough, so the note drops, the
+   scroll bottoms out (snaps), and the note can't be refocused. We add
+   `viewport − (rows already below the note × approx row height)` to `paddingBottom`,
+   so it's generous on short threads and shrinks toward 0 as replies fill the screen
+   (no dead gap on long threads).
+
+   This is owned in `ThreadView` rather than the library's `anchoredEndSpace` on
+   purpose: `anchoredEndSpace` is opaque (no public type on the RN entry; not
+   reflected in our shift logs) and behaved inconsistently across 3.0.x. The
+   explicit reserve is deterministic, hot-reloads with the component (no bundle /
+   dependency-version ambiguity), and emits a `thread.reserve` log so a trace can
+   confirm it's live and its size.
+
 3. **`initialScrollIndex={targetIndex}`** lands the first paint on the tapped note.
 4. **No bottom-dock / auto-pin props.** Unlike `ChatScreen`, the thread omits
    `initialScrollAtEnd`, `alignItemsAtEnd`, and `maintainScrollAtEnd` — it anchors
@@ -71,7 +78,7 @@ already relies on:
   proof is on-device (native `ScrollView` mVCP cannot be exercised in jest).
 - `data:true` routes the data path through native `ScrollView` mVCP (Android needs
   RN ≥ 0.72; satisfied by our Expo SDK). The known racy edge (LegendApp/legend-list
-  #463) bites *near the bottom* of a list; our anchor is the top-pinned note with a
+  #463) bites _near the bottom_ of a list; our anchor is the top-pinned note with a
   single prepend — the well-behaved case.
 - **Requires `@legendapp/list` ≥ 3.0.4.** The combination was inert/janky on the
   first v3 release (3.0.0): the data-anchoring path was mis-batched (fixed 3.0.3),

--- a/docs/adr/0004-thread-list-anchoring.md
+++ b/docs/adr/0004-thread-list-anchoring.md
@@ -88,27 +88,30 @@ already relies on:
 5. **No bottom-dock / auto-pin props.** Unlike `ChatScreen`, the thread omits
    `initialScrollAtEnd`, `alignItemsAtEnd`, and `maintainScrollAtEnd` — it anchors
    on the note, not the tail, and must never auto-scroll down.
-6. **Resolve off-screen, land authoritatively, then swap directly.** Even with
-   (1)–(3), the prepend + re-anchor plays out over several frames and _reads as jitter_
-   on screen. So we render **two lists**: a **seed list** (tapped note + replies,
-   parents filtered out) that the reader sees immediately, and the **real list** (full
-   thread) that resolves **off-screen** (`opacity: 0`, `pointerEvents: none`). Once the
-   above-note rows stop changing size (`scheduleReveal` debounce + fallback), we do one
-   **`scrollToIndex(noteIndex, { viewPosition: 0 })`** to put the note at the top —
-   exact for any parent count, by which point the parents are measured — and reveal on
-   the next frame (so the scroll has applied while still hidden). The **swap is
-   instant** (`revealed` flips, seed unmounts); no fade, because the resolved view is a
-   pixel match for the seed. This replaces both the older per-row opacity "reveal hack"
-   and the fragile delta-summing landing.
+6. **Resolve the WHOLE thread off-screen, land authoritatively, then crossfade.** Even
+   with (1)–(3), the reconcile plays out over several frames and _reads as jitter_. So
+   we render **two lists**: a **seed list** (tapped note + reply **skeletons**, no
+   parents) the reader sees immediately, and the **real list** (full thread) that
+   resolves **off-screen** (`opacity: 0`, `pointerEvents: none`) — parents settle AND
+   replies measure + load their images there. We wait for the on-screen rows to stop
+   changing size (`scheduleReveal` debounce **+ absolute cap**, so a slow network image
+   can't stall the seed forever), then do one **`scrollToIndex(noteIndex,
+{ viewPosition: 0 })`** to land the note (exact for any parent count, parents
+   measured by now) and **crossfade** the real list in over the seed (`listOpacity`
+   0→1, ~200ms), dropping the seed when the fade finishes. The crossfade is seamless
+   for the note (pixel match — looks static) and gives the replies their skeleton→real
+   fade. This replaces the per-row "reveal hack", the fragile delta-summing landing,
+   and the earlier instant swap.
 
-7. **Withhold real reply content until revealed.** Both lists pre-reveal show reply
-   **skeletons** only — `seedData` and the hidden `realData` filter out real `reply`
-   rows. If the hidden real list rendered real replies, they'd load (text + images) and
-   reach a half-loaded state off-screen, then be shown un-settled at the swap, their
-   `REPLY_FADE_IN` skeleton→real crossfade already spent while invisible (the "replies
-   show before they've settled" bug). Gating means reply rows mount only once the list
-   is visible, so the fade plays as designed. Parents are unaffected — they still need
-   to settle off-screen for the landing (6), and they're above the note, not below.
+7. **Replies resolve off-screen so they don't reshift after appearing.** The real list
+   renders the full thread (incl. replies) the whole time, so replies measure and load
+   images while hidden and are **already settled** when the crossfade reveals them —
+   no post-appearance reshift, and the skeleton→real transition is the crossfade (6),
+   not a live reflow. The seed shows reply **skeletons** only (`seedData` filters out
+   `parent` and `reply` rows) so it's stable and doesn't double-load the reply images
+   (only the real list renders real replies). Tradeoff: a reply image slower than the
+   cap finishes after the crossfade — but it's below the focus and rare (imeta dims /
+   the warmed aspect cache settle it off-screen in the common case).
 
 ## Consequences
 

--- a/docs/adr/0004-thread-list-anchoring.md
+++ b/docs/adr/0004-thread-list-anchoring.md
@@ -82,15 +82,18 @@ measured` (live trace: estimate 200 vs measured 145 → note jumped **up 55px**;
 5. **No bottom-dock / auto-pin props.** Unlike `ChatScreen`, the thread omits
    `initialScrollAtEnd`, `alignItemsAtEnd`, and `maintainScrollAtEnd` — it anchors
    on the note, not the tail, and must never auto-scroll down.
-6. **Crossfade the reconciliation off-screen.** Even with (1)–(3), the prepend +
-   re-anchor plays out over several frames and _reads as jitter_ on screen. So the
-   list withholds the parents (`listData` filters them out) and renders only the
-   seed (tapped note + skeletons) at full opacity. When the full thread is ready we
-   fade the list out (120ms), inject the parents while hidden (`showParents`), let
-   the scroll settle (revealed when the above-note size-changes go quiet, with a
-   fallback), then fade back in (180ms). The reader sees the tapped note → a brief
-   crossfade → the settled thread, never the reconciliation. This replaces the older
-   per-row opacity "reveal hack" (which only masked the rows _below_ the note).
+6. **Resolve off-screen, then swap directly.** Even with (1)–(3), the prepend +
+   re-anchor plays out over several frames and _reads as jitter_ on screen. So we
+   render **two lists**: a **seed list** (tapped note + replies, parents filtered out)
+   that the reader sees immediately, and the **real list** (full thread) that resolves
+   **off-screen** (`opacity: 0`, `pointerEvents: none`). The counter-scroll lands the
+   note off-screen; once the above-note rows stop changing size (`scheduleReveal`
+   debounce + fallback), we **swap instantly** — `revealed` flips, the real list shows,
+   the seed unmounts. No fade is needed because the resolved view is a pixel match for
+   the seed: same note at the top, same replies below; the parents are simply scrolled
+   off above. (A fade would only be masking a residual — and (3) makes the landing
+   exact.) This replaces the older per-row opacity "reveal hack" (which only masked the
+   rows _below_ the note).
 
 ## Consequences
 

--- a/docs/adr/0004-thread-list-anchoring.md
+++ b/docs/adr/0004-thread-list-anchoring.md
@@ -82,6 +82,15 @@ measured` (live trace: estimate 200 vs measured 145 → note jumped **up 55px**;
 5. **No bottom-dock / auto-pin props.** Unlike `ChatScreen`, the thread omits
    `initialScrollAtEnd`, `alignItemsAtEnd`, and `maintainScrollAtEnd` — it anchors
    on the note, not the tail, and must never auto-scroll down.
+6. **Crossfade the reconciliation off-screen.** Even with (1)–(3), the prepend +
+   re-anchor plays out over several frames and _reads as jitter_ on screen. So the
+   list withholds the parents (`listData` filters them out) and renders only the
+   seed (tapped note + skeletons) at full opacity. When the full thread is ready we
+   fade the list out (120ms), inject the parents while hidden (`showParents`), let
+   the scroll settle (revealed when the above-note size-changes go quiet, with a
+   fallback), then fade back in (180ms). The reader sees the tapped note → a brief
+   crossfade → the settled thread, never the reconciliation. This replaces the older
+   per-row opacity "reveal hack" (which only masked the rows _below_ the note).
 
 ## Consequences
 

--- a/docs/adr/0004-thread-list-anchoring.md
+++ b/docs/adr/0004-thread-list-anchoring.md
@@ -66,40 +66,40 @@ already relies on:
    dependency-version ambiguity), and emits a `thread.reserve` log so a trace can
    confirm it's live and its size.
 
-3. **Own the size axis** (`onItemSizeChanged`). While the reader hasn't scrolled, we
-   counter-scroll by the exact delta (`scrollToOffset(scroll + (size − previous))`)
-   for **every** size change of a row **above** the note. This covers two things a
-   single global `estimatedItemSize` can't (parents range ~145–523px; v3 has no
-   per-item estimate):
-   - the prepend's **estimate→measured** jump (live trace: estimate 200 vs measured
-     145 → note moved up 55px; a media parent measured 523 → down 323px), and
-   - **late media**: an image with no `imeta` dims (and not cached) reserves a 16:9
-     box, then reshapes to its real aspect on `onLoad` — a second, larger above-note
-     change (videos are locked to imeta-or-16:9, so they don't reshape).
+3. **Own the size axis** (`onItemSizeChanged`), split on whether the real list is
+   shown yet (`revealedRef`). The note can be moved by above-note rows changing size:
+   the prepend's **estimate→measured** jump (parents range ~145–523px; v3 has no
+   per-item estimate) and **late media** (an image with no `imeta` dims reshapes 16:9
+   → real on `onLoad`; videos are locked, so they don't reshape).
+   - **Before the swap (off-screen):** do **not** counter-scroll per row. Summing many
+     deltas in a burst undershoots — with 3 parents (711px total) it landed at scroll
+     575, ~136px short, and arrived as one visible `jumpY:−530` at the swap. Instead we
+     just wait for the parents to go quiet, then (4) lands the note authoritatively.
+   - **After the swap:** a slow parent image can still reshape; the parent is off-screen
+     above the note, so we counter-scroll by its exact delta to absorb it. One change at
+     a time here → no burst, no undershoot.
 
-   Because the parents sit off-screen above the pinned note, absorbing their growth
-   keeps the note fixed. It's the report's "manual offset compensation when you
-   control insertion timing," and it's the **sole** owner of this axis (mVCP runs
-   `size:false`), so it can't race the library the way PR #225's `scrollToIndex`
-   re-pin did. A `readerMovedRef` (set on `onScrollBeginDrag`) hands control back to
-   the user, after which mVCP `data` still anchors future prepends.
+   We're the **sole** owner of this axis (mVCP runs `size:false`), so it can't race the
+   library the way PR #225's sustained `scrollToIndex` re-pin did. A `readerMovedRef`
+   (set on `onScrollBeginDrag`) hands control back to the user, after which mVCP `data`
+   still anchors future prepends.
 
 4. **`initialScrollIndex={targetIndex}`** lands the first paint on the tapped note.
 5. **No bottom-dock / auto-pin props.** Unlike `ChatScreen`, the thread omits
    `initialScrollAtEnd`, `alignItemsAtEnd`, and `maintainScrollAtEnd` — it anchors
    on the note, not the tail, and must never auto-scroll down.
-6. **Resolve off-screen, then swap directly.** Even with (1)–(3), the prepend +
-   re-anchor plays out over several frames and _reads as jitter_ on screen. So we
-   render **two lists**: a **seed list** (tapped note + replies, parents filtered out)
-   that the reader sees immediately, and the **real list** (full thread) that resolves
-   **off-screen** (`opacity: 0`, `pointerEvents: none`). The counter-scroll lands the
-   note off-screen; once the above-note rows stop changing size (`scheduleReveal`
-   debounce + fallback), we **swap instantly** — `revealed` flips, the real list shows,
-   the seed unmounts. No fade is needed because the resolved view is a pixel match for
-   the seed: same note at the top, same replies below; the parents are simply scrolled
-   off above. (A fade would only be masking a residual — and (3) makes the landing
-   exact.) This replaces the older per-row opacity "reveal hack" (which only masked the
-   rows _below_ the note).
+6. **Resolve off-screen, land authoritatively, then swap directly.** Even with
+   (1)–(3), the prepend + re-anchor plays out over several frames and _reads as jitter_
+   on screen. So we render **two lists**: a **seed list** (tapped note + replies,
+   parents filtered out) that the reader sees immediately, and the **real list** (full
+   thread) that resolves **off-screen** (`opacity: 0`, `pointerEvents: none`). Once the
+   above-note rows stop changing size (`scheduleReveal` debounce + fallback), we do one
+   **`scrollToIndex(noteIndex, { viewPosition: 0 })`** to put the note at the top —
+   exact for any parent count, by which point the parents are measured — and reveal on
+   the next frame (so the scroll has applied while still hidden). The **swap is
+   instant** (`revealed` flips, seed unmounts); no fade, because the resolved view is a
+   pixel match for the seed. This replaces both the older per-row opacity "reveal hack"
+   and the fragile delta-summing landing.
 
 ## Consequences
 

--- a/docs/adr/0004-thread-list-anchoring.md
+++ b/docs/adr/0004-thread-list-anchoring.md
@@ -116,6 +116,16 @@ already relies on:
   `anchoredEndSpace` reported stale sizes during load (fixed 3.0.4), and
   `scrollToIndex`/`initialScrollIndex` mislanded on iOS (fixed 3.0.1). We pin 3.0.6.
   Re-verify these prop contracts on any future bump — v3 is still beta.
+- **Known residual (out of scope): replies settling _below_ the note.** The anchor
+  holds the note perfectly (verified: pageY constant across a 49-reply load), but the
+  replies under it still reflow as they resolve — reply skeletons (fixed height) don't
+  match variable real-reply heights, and reply images without `imeta` dims reshape on
+  load (16:9 → real). The two-list swap can't hide this: the seed list renders the
+  same replies, so reply reflow is visible on whichever list is shown (unlike the
+  parents, which exist only on the real list). This is the same variable-height /
+  media-reservation problem the feed has; the durable fix is feed-wide (skeleton
+  height matching + reply-image dimension reservation via `imeta` / the aspect cache),
+  not thread-anchor work.
 
 ## Alternatives rejected
 

--- a/docs/adr/0004-thread-list-anchoring.md
+++ b/docs/adr/0004-thread-list-anchoring.md
@@ -49,8 +49,17 @@ already relies on:
 1. **`maintainVisibleContentPosition` (bare → `{ data: true, size: true }`)** on
    the thread `LegendList`. `data:true` compensates the parent prepend; `size:true`
    absorbs estimate→measured reconciliation.
-2. **`initialScrollIndex={targetIndex}`** lands the first paint on the tapped note.
-3. **No bottom-dock / auto-pin props.** Unlike `ChatScreen`, the thread omits
+2. **`anchoredEndSpace={{ anchorIndex: targetIndex }}`** reserves tail space so the
+   focused note can reach the top of the viewport. mVCP compensates a prepend by
+   *raising the scroll offset*, but that is clamped at the max scroll offset — a
+   thread with little content below the target can't scroll far enough, so the note
+   drops anyway. The reserve sizes to `viewport − (content from anchorIndex down) −
+   footer − paddingBottom`, shrinking to 0 once the replies below already fill the
+   screen (no dead gap on long threads), and waits for measured sizes (no estimate
+   thrash). It is read by the v3.0.0 RN runtime but omitted from the exported RN
+   prop type, so it is typed locally and passed via spread.
+3. **`initialScrollIndex={targetIndex}`** lands the first paint on the tapped note.
+4. **No bottom-dock / auto-pin props.** Unlike `ChatScreen`, the thread omits
    `initialScrollAtEnd`, `alignItemsAtEnd`, and `maintainScrollAtEnd` — it anchors
    on the note, not the tail, and must never auto-scroll down.
 

--- a/docs/adr/0004-thread-list-anchoring.md
+++ b/docs/adr/0004-thread-list-anchoring.md
@@ -65,8 +65,21 @@ already relies on:
    dependency-version ambiguity), and emits a `thread.reserve` log so a trace can
    confirm it's live and its size.
 
-3. **`initialScrollIndex={targetIndex}`** lands the first paint on the tapped note.
-4. **No bottom-dock / auto-pin props.** Unlike `ChatScreen`, the thread omits
+3. **Own the prepend's size reconciliation** (`onItemSizeChanged`). mVCP scrolls to
+   hold the note when the parent prepends, but it anchors against the parent's
+   _estimate_ (`estimatedItemSize`) and never reconciles the gap once the parent
+   measures to its real height — the note ends up off by exactly `estimate −
+measured` (live trace: estimate 200 vs measured 145 → note jumped **up 55px**;
+   an earlier media parent measured 523 → **down 323px**). A single global
+   `estimatedItemSize` can't fix this (parents range ~145–523px), and v3 exposes no
+   per-item estimate. So when a row **above** the note changes size **before the
+   reader has scrolled**, we counter-scroll by the delta (`scrollToOffset(scroll +
+(size − previous))`). This is the report's "manual offset compensation when you
+   control insertion timing" — a one-time reconciliation per parent measure, not a
+   sustained re-pin (which is why it doesn't race mVCP the way PR #225 did). A
+   `readerMovedRef` (set on `onScrollBeginDrag`) hands control back to the user.
+4. **`initialScrollIndex={targetIndex}`** lands the first paint on the tapped note.
+5. **No bottom-dock / auto-pin props.** Unlike `ChatScreen`, the thread omits
    `initialScrollAtEnd`, `alignItemsAtEnd`, and `maintainScrollAtEnd` — it anchors
    on the note, not the tail, and must never auto-scroll down.
 

--- a/docs/adr/0004-thread-list-anchoring.md
+++ b/docs/adr/0004-thread-list-anchoring.md
@@ -1,0 +1,75 @@
+# 0004 — Thread list anchoring: anchor on the tapped note, never auto-pin
+
+Status: accepted
+Date: 2026-06-21
+
+## Context
+
+Opening a thread on a reply must land on that reply and keep it visually fixed
+while the rest of the thread fills in. The data arrives in two passes
+(`features/feed/hooks/useThread.ts`):
+
+- **T0 (seed):** a cached slice renders the target (focused) note immediately —
+  stable key `t_${event.id}`.
+- **T1 (full fetch):** `buildThreadItemsFromResult` rebuilds `items` as
+  `[...parents, target, ...replies]`, **prepending the entire parent/ancestor
+  chain above the target in one update**. Replies then append below on
+  pagination.
+
+The reader's requirement: the focused note must not move when (a) the parent
+chain mounts above it or (b) replies load below it, and the thread must never
+auto-scroll to the bottom like a chat.
+
+The thread `LegendList` (`@legendapp/list@3.0.0`) was rendered **without**
+`maintainVisibleContentPosition`. In v3 the prop normalizes via
+`normalizeMaintainVisibleContentPosition`:
+
+```
+true            → { data: true,  size: true  }
+{ … }           → { data: ?? false, size: ?? true }
+false           → { data: false, size: false }
+(omitted)       → { data: false, size: true }   // ← what the thread got
+```
+
+The prepend offset-compensation path is gated on `.data`
+(`if (dataChanged && doMVCP && state.props.maintainVisibleContentPosition.data && …)`).
+With `data:false` it never runs, so the T1 parent prepend was not compensated and
+the focused note dropped by the measured height of the parent chain.
+
+A prior attempt (PR #225) layered manual `scrollToIndex` re-pins on top
+(one-shot, then sustained via `onItemSizeChanged`). It still shifted: those
+manual corrections race the library's own anchoring — the "don't fight the
+library's correction" failure mode.
+
+## Decision
+
+Anchor the thread declaratively, reusing the same mechanism the DM `ChatScreen`
+already relies on:
+
+1. **`maintainVisibleContentPosition` (bare → `{ data: true, size: true }`)** on
+   the thread `LegendList`. `data:true` compensates the parent prepend; `size:true`
+   absorbs estimate→measured reconciliation.
+2. **`initialScrollIndex={targetIndex}`** lands the first paint on the tapped note.
+3. **No bottom-dock / auto-pin props.** Unlike `ChatScreen`, the thread omits
+   `initialScrollAtEnd`, `alignItemsAtEnd`, and `maintainScrollAtEnd` — it anchors
+   on the note, not the tail, and must never auto-scroll down.
+
+## Consequences
+
+- The focused note holds across the T0→T1 parent prepend with no manual scroll
+  math; replies appending below do not move it.
+- Behaviour is verified at the source level against the installed v3.0.0, and the
+  proof is on-device (native `ScrollView` mVCP cannot be exercised in jest).
+- `data:true` routes the data path through native `ScrollView` mVCP (Android needs
+  RN ≥ 0.72; satisfied by our Expo SDK). The known racy edge (LegendApp/legend-list
+  #463) bites *near the bottom* of a list; our anchor is the top-pinned note with a
+  single prepend — the well-behaved case.
+
+## Alternatives rejected
+
+- **Manual `scrollToIndex` re-pin (PR #225).** Races the library's anchoring;
+  still shifted in practice.
+- **`inverted`.** A transform hack; legend-list refuses it and the native mVCP
+  primitive explicitly ignores transforms.
+- **Sharing the DM bottom-dock preset.** Would auto-pin to bottom — the opposite
+  of the thread's anchor-on-note requirement.

--- a/docs/adr/0004-thread-list-anchoring.md
+++ b/docs/adr/0004-thread-list-anchoring.md
@@ -101,6 +101,15 @@ already relies on:
    pixel match for the seed. This replaces both the older per-row opacity "reveal hack"
    and the fragile delta-summing landing.
 
+7. **Withhold real reply content until revealed.** Both lists pre-reveal show reply
+   **skeletons** only — `seedData` and the hidden `realData` filter out real `reply`
+   rows. If the hidden real list rendered real replies, they'd load (text + images) and
+   reach a half-loaded state off-screen, then be shown un-settled at the swap, their
+   `REPLY_FADE_IN` skeleton→real crossfade already spent while invisible (the "replies
+   show before they've settled" bug). Gating means reply rows mount only once the list
+   is visible, so the fade plays as designed. Parents are unaffected — they still need
+   to settle off-screen for the landing (6), and they're above the note, not below.
+
 ## Consequences
 
 - The focused note holds across the T0→T1 parent prepend with no manual scroll

--- a/features/feed/components/ThreadView.tsx
+++ b/features/feed/components/ThreadView.tsx
@@ -298,24 +298,36 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
   const targetIndexRef = useRef(-1);
   const readerMovedRef = useRef(false);
 
-  // Direct swap after settle. The parent prepend reconciles (mVCP + our
-  // counter-scroll) over several frames; shown, that reads as jitter. So we render
-  // TWO lists: a seed list (tapped note + replies, no parents) the reader sees
-  // immediately, and the real list (full thread) that resolves OFF-SCREEN. Once the
-  // real list has settled at the focused note we swap to it INSTANTLY — no fade,
-  // because the resolved view is a pixel match for the seed (same note at top, same
-  // replies below; the parents are just scrolled off above). `revealed` = real list
-  // is shown.
+  // Direct swap after settle. We render TWO lists: a seed list (tapped note +
+  // replies, no parents) the reader sees immediately, and the real list (full
+  // thread) that resolves OFF-SCREEN. Once the parents above the note have stopped
+  // resizing, we land the note authoritatively and swap to the real list INSTANTLY —
+  // no fade, because the resolved view is a pixel match for the seed (same note at
+  // top, parents scrolled off above). `revealed`/`revealedRef` = real list is shown.
   const [revealed, setRevealed] = useState(false);
+  const revealedRef = useRef(false);
   const settleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Fire once the parents go quiet: put the note at the top with a single
+  // authoritative `scrollToIndex` (correct for ANY number of parents — far more
+  // robust than summing per-row counter-scroll deltas, which undershoot when several
+  // parents measure in a burst), then reveal next frame so the scroll has applied
+  // while still hidden.
   const scheduleReveal = useCallback((delayMs: number) => {
     if (settleTimerRef.current) clearTimeout(settleTimerRef.current);
-    settleTimerRef.current = setTimeout(() => setRevealed(true), delayMs);
+    settleTimerRef.current = setTimeout(() => {
+      revealedRef.current = true;
+      const idx = targetIndexRef.current;
+      if (idx > 0) {
+        void listRef.current?.scrollToIndex({ index: idx, viewPosition: 0, animated: false });
+      }
+      requestAnimationFrame(() => setRevealed(true));
+    }, delayMs);
   }, []);
 
   useEffect(() => {
     setRevealed(false);
+    revealedRef.current = false;
     readerMovedRef.current = false;
     if (settleTimerRef.current) clearTimeout(settleTimerRef.current);
   }, [eventId]);
@@ -380,6 +392,7 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
   useEffect(() => {
     if (!fullReady || revealed) return;
     if (!hasParents) {
+      revealedRef.current = true;
       setRevealed(true);
       return;
     }
@@ -444,9 +457,16 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
     getListState: () => listRef.current?.getState() ?? null,
   });
 
-  // Keep the visual-shift logging, then reconcile the parent prepend (see the
-  // `targetIndexRef`/`readerMovedRef` note above). Only rows above the focused
-  // note shift it, and only until the reader takes over scrolling.
+  // Above-note size changes (parents measuring / late media reshaping) are what
+  // would move the focused note. Two regimes, split on `revealed`:
+  //  - BEFORE the swap (off-screen): don't counter-scroll per row — summing many
+  //    deltas in a burst undershoots with multiple parents. Just keep pushing the
+  //    swap out until the parents go quiet; `scheduleReveal` then lands the note with
+  //    one authoritative `scrollToIndex`.
+  //  - AFTER the swap: a late parent image (no imeta dims, slow to load) can still
+  //    reshape; the parent is off-screen above the note, so counter-scroll by its
+  //    exact delta to absorb the growth and keep the note fixed. One change at a time
+  //    here, so no burst/undershoot. (mVCP runs `size:false` → we're the sole owner.)
   const handleItemSizeChanged = useCallback(
     (info: {
       size: number;
@@ -459,19 +479,14 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
       if (readerMovedRef.current) return;
       const tIndex = targetIndexRef.current;
       if (tIndex <= 0 || info.index >= tIndex) return;
-      // Compensate EVERY above-note size change by the exact delta, so the note holds
-      // through the prepend's estimate→measured jump AND late media: an image with no
-      // imeta dims (and not cached) reserves a 16:9 box, then reshapes to its real
-      // aspect on load — a second, larger above-note change. (We don't fight mVCP
-      // here: it runs `size:false`, so we are the sole owner of this axis — no
-      // double-correction, no oscillation.)
+      if (!revealedRef.current) {
+        scheduleReveal(150);
+        return;
+      }
       const delta = info.size - info.previous;
       if (delta === 0) return;
       const current = listRef.current?.getState()?.scroll ?? 0;
       void listRef.current?.scrollToOffset({ offset: current + delta, animated: false });
-      // While still hidden this also pushes the swap out until the above-note rows
-      // (incl. images that load fast) stop changing size, so we reveal a settled list.
-      scheduleReveal(150);
     },
     [visualList, scheduleReveal]
   );

--- a/features/feed/components/ThreadView.tsx
+++ b/features/feed/components/ThreadView.tsx
@@ -309,6 +309,23 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
   const targetItem = useMemo(() => items.find((item) => item.type === 'target'), [items]);
   const hasParents = useMemo(() => items.some((i) => i.type === 'parent'), [items]);
 
+  // Reserve just enough tail space for the focused note to reach the top of the
+  // viewport. Without it, a thread with little content below the target can't
+  // scroll far enough for `maintainVisibleContentPosition` to hold the note as
+  // the parent chain grows above — the compensation clamps at the max scroll
+  // offset and the note still drops. `anchoredEndSpace` sizes the reserve to
+  // `viewport - (content from anchorIndex down) - footer - paddingBottom`, so it
+  // shrinks to 0 once the replies below already fill the screen (no dead gap on
+  // long threads) and waits for measured sizes before sizing (no estimate thrash).
+  //
+  // The prop is consumed by the @legendapp/list@3.0.0 RN runtime
+  // (`state.props.anchoredEndSpace`) but the package omits it from the exported
+  // RN prop type, so it's typed locally and passed via spread (JSX spread
+  // bypasses excess-property checking — no `any`).
+  const anchoredEndSpaceProps: {
+    anchoredEndSpace?: { anchorIndex: number; anchorOffset?: number };
+  } = targetIndex >= 0 ? { anchoredEndSpace: { anchorIndex: targetIndex } } : {};
+
   const displayItems = useMemo<ThreadListItem[]>(() => {
     if (isLoading && items.length === 0) {
       // Include the sort-tabs row in the very first skeleton frame so it doesn't
@@ -664,6 +681,7 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
               />
             }>
             <LegendList
+              {...anchoredEndSpaceProps}
               ref={listRef}
               data={displayItems}
               keyExtractor={threadKeyExtractor}
@@ -721,6 +739,8 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
               //    note does NOT drop. This is OFF by default (`{ data: false }`); omitting
               //    the prop is exactly why the note used to shift when parents loaded in.
               //  - `size: true`  → absorbs the estimate→measured reconciliation of rows.
+              // Works together with `anchoredEndSpace` (above): mVCP holds the note,
+              // the reserve guarantees the scroll room mVCP needs to do so.
               // Mirrors the DM ChatScreen's anchoring half. We deliberately do NOT take
               // ChatScreen's `initialScrollAtEnd` / `alignItemsAtEnd` / `maintainScrollAtEnd`:
               // a thread anchors on the tapped note via `initialScrollIndex` and must never

--- a/features/feed/components/ThreadView.tsx
+++ b/features/feed/components/ThreadView.tsx
@@ -367,15 +367,22 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
     return withReplySortTabs([...items, ...createReplySkeletonItems(skeletonCount)]);
   }, [isFetching, isLoading, items, metricsRef]);
 
-  // Seed list data (what the reader sees until the swap): the full thread minus the
-  // parents, so the tapped note sits at the top with its replies below — exactly the
-  // visible region the resolved real list will show.
+  // Real reply CONTENT is withheld until the list is revealed. While the real list
+  // resolves off-screen we don't want replies rendering/loading there — they'd reach
+  // a half-loaded state and be shown un-settled at the swap, their skeleton→real fade
+  // already spent while invisible. So pre-reveal both lists show reply SKELETONS; the
+  // real reply rows mount only once the list is visible, where `REPLY_FADE_IN` plays
+  // as designed. (Parents are unaffected — they still settle off-screen.)
   const seedData = useMemo<ThreadListItem[]>(
-    () => displayItems.filter((i) => i.type !== 'parent'),
+    () => displayItems.filter((i) => i.type !== 'parent' && i.type !== 'reply'),
     [displayItems]
   );
-  // The real (hidden) list renders the full `displayItems`; this is the note's index
-  // there, for the counter-scroll, focus reserve, and initial landing.
+  const realData = useMemo<ThreadListItem[]>(
+    () => (revealed ? displayItems : displayItems.filter((i) => i.type !== 'reply')),
+    [revealed, displayItems]
+  );
+  // The note's index in the real list (parents precede it; replies/skeletons follow,
+  // so the index is the same gated or not) — for the focus reserve and the landing.
   const fullTargetIndex = useMemo(
     () => displayItems.findIndex((i) => i.type === 'target'),
     [displayItems]
@@ -785,7 +792,7 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
                 pointerEvents={revealed ? 'auto' : 'none'}>
                 <LegendList
                   ref={listRef}
-                  data={displayItems}
+                  data={realData}
                   keyExtractor={threadKeyExtractor}
                   getItemType={threadItemType}
                   getFixedItemSize={threadFixedItemSize}

--- a/features/feed/components/ThreadView.tsx
+++ b/features/feed/components/ThreadView.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, useWindowDimensions } from 'react-native';
 import Animated, {
   FadeIn,
   FadeOut,
@@ -110,6 +110,11 @@ const REPLY_SORT_OPTIONS: {
 // fades out — a crossfade in the same row slot.
 const REPLY_FADE_IN = FadeIn.duration(220);
 const SKELETON_FADE_OUT = FadeOut.duration(220);
+
+// Rough per-row height used only to discount the content already below the
+// focused note when sizing the focus reserve (see `focusReserve`). Deliberately
+// approximate — it just keeps the reserve from over-padding long threads.
+const FOCUS_RESERVE_ROW_APPROX = 150;
 
 type ThreadSkeletonItem =
   | { type: 'target-skeleton'; id: string }
@@ -245,6 +250,7 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
     'surface-tertiary',
   ] as const);
   const headerHeight = useHeaderHeight();
+  const { height: windowHeight } = useWindowDimensions();
   const imageOverlay = useImageOverlay();
   const embed = useThreadEmbed();
   const embedOpen = embed?.open;
@@ -309,23 +315,6 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
   const targetItem = useMemo(() => items.find((item) => item.type === 'target'), [items]);
   const hasParents = useMemo(() => items.some((i) => i.type === 'parent'), [items]);
 
-  // Reserve just enough tail space for the focused note to reach the top of the
-  // viewport. Without it, a thread with little content below the target can't
-  // scroll far enough for `maintainVisibleContentPosition` to hold the note as
-  // the parent chain grows above — the compensation clamps at the max scroll
-  // offset and the note still drops. `anchoredEndSpace` sizes the reserve to
-  // `viewport - (content from anchorIndex down) - footer - paddingBottom`, so it
-  // shrinks to 0 once the replies below already fill the screen (no dead gap on
-  // long threads) and waits for measured sizes before sizing (no estimate thrash).
-  //
-  // The prop is consumed by the @legendapp/list@3.0.0 RN runtime
-  // (`state.props.anchoredEndSpace`) but the package omits it from the exported
-  // RN prop type, so it's typed locally and passed via spread (JSX spread
-  // bypasses excess-property checking — no `any`).
-  const anchoredEndSpaceProps: {
-    anchoredEndSpace?: { anchorIndex: number; anchorOffset?: number };
-  } = targetIndex >= 0 ? { anchoredEndSpace: { anchorIndex: targetIndex } } : {};
-
   const displayItems = useMemo<ThreadListItem[]>(() => {
     if (isLoading && items.length === 0) {
       // Include the sort-tabs row in the very first skeleton frame so it doesn't
@@ -357,6 +346,35 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
 
     return withReplySortTabs([...items, ...createReplySkeletonItems(skeletonCount)]);
   }, [isFetching, isLoading, items, metricsRef]);
+
+  // Focus reserve: extra bottom space so the tapped reply can always be scrolled
+  // to (and held at) the top of the viewport, even when little content sits below
+  // it. Opening a thread on a reply lands a tall parent chain above the note; with
+  // no room below, the scroll bottoms out (clamps/snaps) and the note can't be
+  // refocused, and `maintainVisibleContentPosition` has nowhere to scroll to hold
+  // it as the parent grows. We reserve `viewport − (content already below the
+  // note)`, so the reserve is generous on short threads and shrinks toward 0 as
+  // replies fill the screen (no dead gap on long threads). Owned here (not the
+  // library's `anchoredEndSpace`) so it's deterministic, hot-reloadable, and
+  // logged. `targetIndex` indexes `displayItems` too — the sort-tabs row is
+  // inserted after the target and skeletons are appended last.
+  const focusReserve = useMemo(() => {
+    if (targetIndex <= 0) return 0;
+    const listViewport = Math.max(0, windowHeight - headerHeight - (replyBarHeight || 80));
+    const belowCount = Math.max(0, displayItems.length - 1 - targetIndex);
+    return Math.max(0, listViewport - belowCount * FOCUS_RESERVE_ROW_APPROX);
+  }, [targetIndex, windowHeight, headerHeight, replyBarHeight, displayItems.length]);
+
+  useEffect(() => {
+    if (focusReserve <= 0) return;
+    feedLog.info('thread.reserve', {
+      eventId,
+      targetIndex,
+      rows: displayItems.length,
+      focusReserve: Math.round(focusReserve),
+      windowHeight: Math.round(windowHeight),
+    });
+  }, [focusReserve, eventId, targetIndex, displayItems.length, windowHeight]);
 
   const threadPhase =
     isLoading && items.length === 0
@@ -681,7 +699,6 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
               />
             }>
             <LegendList
-              {...anchoredEndSpaceProps}
               ref={listRef}
               data={displayItems}
               keyExtractor={threadKeyExtractor}
@@ -728,8 +745,9 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
                 paddingTop: 0,
                 // replyBarHeight already includes the bottom safe-area inset (the
                 // bar's opaque container reaches the screen bottom), so the inset
-                // is not added again here.
-                paddingBottom: (replyBarHeight || 80) + 16,
+                // is not added again here. `focusReserve` adds room below the note
+                // so it can be scrolled to the top (see its definition above).
+                paddingBottom: (replyBarHeight || 80) + 16 + focusReserve,
               }}
               showsVerticalScrollIndicator={false}
               // Anchor-on-the-tapped-note stability. Bare `maintainVisibleContentPosition`
@@ -739,8 +757,8 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
               //    note does NOT drop. This is OFF by default (`{ data: false }`); omitting
               //    the prop is exactly why the note used to shift when parents loaded in.
               //  - `size: true`  → absorbs the estimate→measured reconciliation of rows.
-              // Works together with `anchoredEndSpace` (above): mVCP holds the note,
-              // the reserve guarantees the scroll room mVCP needs to do so.
+              // Works together with `focusReserve` (the bottom padding): mVCP holds the
+              // note, the reserve guarantees the scroll room mVCP needs to do so.
               // Mirrors the DM ChatScreen's anchoring half. We deliberately do NOT take
               // ChatScreen's `initialScrollAtEnd` / `alignItemsAtEnd` / `maintainScrollAtEnd`:
               // a thread anchors on the tapped note via `initialScrollIndex` and must never

--- a/features/feed/components/ThreadView.tsx
+++ b/features/feed/components/ThreadView.tsx
@@ -110,6 +110,12 @@ const SKELETON_FADE_OUT = FadeOut.duration(220);
 // approximate — it just keeps the reserve from over-padding long threads.
 const FOCUS_RESERVE_ROW_APPROX = 150;
 
+// `data: true` lets LegendList compensate the parent prepend; `size: false` hands
+// the size axis entirely to our `onItemSizeChanged` counter-scroll, so the library
+// and our correction never both move the scroll (that double-correction is what
+// oscillated into jitter). Module-level for a stable prop reference.
+const THREAD_MVCP = { data: true, size: false } as const;
+
 type ThreadSkeletonItem =
   | { type: 'target-skeleton'; id: string }
   | { type: 'reply-skeleton'; id: string; skeletonIndex: number };
@@ -285,9 +291,10 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
   // against the parent's *estimate* (`estimatedItemSize`) and never reconciles the
   // gap once the parent measures to its real height — leaving the note off by
   // exactly (estimate − measured) px (verified in the shift log: 200 vs 145 → the
-  // note jumped up 55px). We own that one reconciliation: when a row ABOVE the
-  // note changes size before the reader has scrolled, counter-scroll by the delta
-  // so the note stays put. Read via refs so the size-change callback is stable.
+  // note jumped up 55px). We own that reconciliation: while the reader hasn't
+  // scrolled, every size change of a row ABOVE the note (the prepend's
+  // estimate→measured jump, and late media reshaping) is countered by the delta so
+  // the note stays put. Read via refs so the size-change callback is stable.
   const targetIndexRef = useRef(-1);
   const readerMovedRef = useRef(false);
 
@@ -301,9 +308,6 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
   // is shown.
   const [revealed, setRevealed] = useState(false);
   const settleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Reconcile each above-note row once (no oscillation); resets the reveal timer so
-  // the swap waits until those rows stop changing size.
-  const correctedKeysRef = useRef<Set<string>>(new Set());
 
   const scheduleReveal = useCallback((delayMs: number) => {
     if (settleTimerRef.current) clearTimeout(settleTimerRef.current);
@@ -313,7 +317,6 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
   useEffect(() => {
     setRevealed(false);
     readerMovedRef.current = false;
-    correctedKeysRef.current = new Set();
     if (settleTimerRef.current) clearTimeout(settleTimerRef.current);
   }, [eventId]);
 
@@ -369,7 +372,10 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
 
   // Once the full thread is fetched, decide when to swap to the real list. With no
   // parents there's no prepend, so swap immediately. With parents, arm a generous
-  // fallback; the size-change handler shortens it as each above-note row settles.
+  // fallback (long enough for a fast/cached parent image to load + reshape
+  // off-screen, so the swap shows it already settled); the size-change handler
+  // shortens it as each above-note row goes quiet. Stragglers (slow network images)
+  // load post-swap and are absorbed by the counter-scroll.
   const fullReady = !isLoading && !isFetching && !!targetItem;
   useEffect(() => {
     if (!fullReady || revealed) return;
@@ -377,7 +383,7 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
       setRevealed(true);
       return;
     }
-    scheduleReveal(600);
+    scheduleReveal(900);
   }, [fullReady, revealed, hasParents, scheduleReveal]);
 
   // Focus reserve: extra bottom space so the tapped reply can always be scrolled
@@ -453,17 +459,19 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
       if (readerMovedRef.current) return;
       const tIndex = targetIndexRef.current;
       if (tIndex <= 0 || info.index >= tIndex) return;
-      // Reconcile each above-note row exactly once (its estimate→measured jump);
-      // re-correcting on every micro-change is what oscillated into jitter.
-      if (correctedKeysRef.current.has(info.itemKey)) return;
+      // Compensate EVERY above-note size change by the exact delta, so the note holds
+      // through the prepend's estimate→measured jump AND late media: an image with no
+      // imeta dims (and not cached) reserves a 16:9 box, then reshapes to its real
+      // aspect on load — a second, larger above-note change. (We don't fight mVCP
+      // here: it runs `size:false`, so we are the sole owner of this axis — no
+      // double-correction, no oscillation.)
       const delta = info.size - info.previous;
       if (delta === 0) return;
-      correctedKeysRef.current.add(info.itemKey);
       const current = listRef.current?.getState()?.scroll ?? 0;
       void listRef.current?.scrollToOffset({ offset: current + delta, animated: false });
-      // This correction happens off-screen (real list hidden) — push the swap until
-      // the above-note rows stop changing size, so we reveal a settled list.
-      scheduleReveal(120);
+      // While still hidden this also pushes the swap out until the above-note rows
+      // (incl. images that load fast) stop changing size, so we reveal a settled list.
+      scheduleReveal(150);
     },
     [visualList, scheduleReveal]
   );
@@ -815,20 +823,14 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
                     paddingBottom: (replyBarHeight || 80) + 16 + focusReserve,
                   }}
                   showsVerticalScrollIndicator={false}
-                  // Anchor-on-the-tapped-note stability. Bare `maintainVisibleContentPosition`
-                  // normalizes to `{ data: true, size: true }` in @legendapp/list v3:
-                  //  - `data: true`  → when the parent chain prepends above the focused note
-                  //    (the T1 full-thread update), LegendList compensates contentOffset so the
-                  //    note does NOT drop. This is OFF by default (`{ data: false }`); omitting
-                  //    the prop is exactly why the note used to shift when parents loaded in.
-                  //  - `size: true`  → absorbs the estimate→measured reconciliation of rows.
-                  // Works together with `focusReserve` (the bottom padding): mVCP holds the
-                  // note, the reserve guarantees the scroll room mVCP needs to do so.
-                  // Mirrors the DM ChatScreen's anchoring half. We deliberately do NOT take
-                  // ChatScreen's `initialScrollAtEnd` / `alignItemsAtEnd` / `maintainScrollAtEnd`:
-                  // a thread anchors on the tapped note via `initialScrollIndex` and must never
-                  // auto-pin to the bottom like a chat.
-                  maintainVisibleContentPosition
+                  // Anchor-on-the-tapped-note stability (see THREAD_MVCP): `data:true`
+                  // compensates the parent prepend; `size:false` leaves the size axis to our
+                  // `onItemSizeChanged` counter-scroll (sole owner → no double-correction).
+                  // Paired with `focusReserve` (bottom padding) for the scroll room it needs.
+                  // We deliberately do NOT take ChatScreen's `initialScrollAtEnd` /
+                  // `alignItemsAtEnd` / `maintainScrollAtEnd`: a thread anchors on the tapped
+                  // note via `initialScrollIndex` and must never auto-pin to the bottom.
+                  maintainVisibleContentPosition={THREAD_MVCP}
                   onScroll={(e: { nativeEvent: { contentOffset: { y: number } } }) => {
                     const y = e.nativeEvent.contentOffset.y;
                     if (imageOverlay?.scrollOffsetY != null) imageOverlay.scrollOffsetY.value = y;

--- a/features/feed/components/ThreadView.tsx
+++ b/features/feed/components/ThreadView.tsx
@@ -10,6 +10,7 @@ import { StyleSheet, useWindowDimensions } from 'react-native';
 import Animated, {
   FadeIn,
   FadeOut,
+  runOnJS,
   useAnimatedStyle,
   useSharedValue,
   withTiming,
@@ -297,34 +298,42 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
   const targetIndexRef = useRef(-1);
   const readerMovedRef = useRef(false);
 
-  // The sort-tabs ("Relevant") row and the replies sit below the target, so their
-  // on-screen position is whatever LegendList computes for the target — which
-  // starts at `estimatedItemSize` and snaps to the real measured height a frame
-  // later, shifting everything below. Rather than fight that reconciliation, we
-  // keep those rows occupying their space but at opacity 0 until the real target
-  // has laid out, then fade them in at their settled positions (the shift happens
-  // while they're invisible). The target itself is the stable anchor and renders
-  // immediately.
-  const revealedRef = useRef(false);
-  const revealOpacity = useSharedValue(0);
-  const revealStyle = useAnimatedStyle(() => ({ opacity: revealOpacity.value }));
-  const handleTargetSettled = useCallback(() => {
-    if (revealedRef.current) return;
-    revealedRef.current = true;
-    // One frame after the target measures, LegendList has repositioned the rows
-    // below it — reveal then so they fade in already in their final spot.
-    requestAnimationFrame(() => {
-      revealOpacity.value = withTiming(1, { duration: 220 });
-    });
-  }, [revealOpacity]);
-  useEffect(() => {
-    revealedRef.current = false;
-    revealOpacity.value = 0;
-    readerMovedRef.current = false;
-  }, [eventId, revealOpacity]);
+  // Crossfade-after-settle. The parent chain prepends into the list and reconciles
+  // (mVCP + our counter-scroll) over several frames; played out on screen that
+  // reconciliation reads as jitter. So we hold the parents OUT of the list and show
+  // only the seed (tapped note + skeletons) at full opacity. When the full thread is
+  // ready we fade the list out, inject the parents while hidden, let the scroll
+  // settle, then fade back in. The reader sees the tapped note → a brief crossfade →
+  // the settled thread, never the reconciliation. `listData`/`listTargetIndex` (below)
+  // are the gated data the list actually renders.
+  const listOpacity = useSharedValue(1);
+  const listAnimatedStyle = useAnimatedStyle(() => ({ opacity: listOpacity.value }));
+  const [showParents, setShowParents] = useState(false);
+  const settleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Each above-note row is reconciled once (no oscillation); also tracks which rows
+  // have settled so the crossfade reveals only after they're quiet.
+  const correctedKeysRef = useRef<Set<string>>(new Set());
 
-  const targetIndex = useMemo(() => items.findIndex((item) => item.type === 'target'), [items]);
-  targetIndexRef.current = targetIndex;
+  // Reveal once the post-inject reconcile goes quiet: each above-note correction
+  // pushes this out; with no corrections the fallback delay reveals anyway.
+  const scheduleSettleReveal = useCallback(
+    (delayMs: number) => {
+      if (settleTimerRef.current) clearTimeout(settleTimerRef.current);
+      settleTimerRef.current = setTimeout(() => {
+        listOpacity.value = withTiming(1, { duration: 180 });
+      }, delayMs);
+    },
+    [listOpacity]
+  );
+
+  useEffect(() => {
+    setShowParents(false);
+    listOpacity.value = 1;
+    readerMovedRef.current = false;
+    correctedKeysRef.current = new Set();
+    if (settleTimerRef.current) clearTimeout(settleTimerRef.current);
+  }, [eventId, listOpacity]);
+
   const targetItem = useMemo(() => items.find((item) => item.type === 'target'), [items]);
   const hasParents = useMemo(() => items.some((i) => i.type === 'parent'), [items]);
 
@@ -360,6 +369,36 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
     return withReplySortTabs([...items, ...createReplySkeletonItems(skeletonCount)]);
   }, [isFetching, isLoading, items, metricsRef]);
 
+  // Gated data the list renders: parents are withheld until `showParents` flips
+  // (after the fade-out), so the prepend never reconciles on screen.
+  const listData = useMemo<ThreadListItem[]>(
+    () => (showParents ? displayItems : displayItems.filter((i) => i.type !== 'parent')),
+    [showParents, displayItems]
+  );
+  const listTargetIndex = useMemo(() => listData.findIndex((i) => i.type === 'target'), [listData]);
+  targetIndexRef.current = listTargetIndex;
+
+  // Drive the crossfade. Once the full thread is fetched: if it has parents, fade
+  // out → inject them (hidden) → settle → fade in; if not, just show (no prepend,
+  // no jitter).
+  const fullReady = !isLoading && !isFetching && !!targetItem;
+  useEffect(() => {
+    if (!fullReady || showParents) return;
+    if (!hasParents) {
+      setShowParents(true);
+      return;
+    }
+    listOpacity.value = withTiming(0, { duration: 120 }, (finished) => {
+      if (finished) runOnJS(setShowParents)(true);
+    });
+  }, [fullReady, showParents, hasParents, listOpacity]);
+
+  // Parents are now injected (hidden). Arm the reveal with a generous fallback; the
+  // size-change handler shortens it as each above-note row settles.
+  useEffect(() => {
+    if (showParents && hasParents) scheduleSettleReveal(600);
+  }, [showParents, hasParents, scheduleSettleReveal]);
+
   // Focus reserve: extra bottom space so the tapped reply can always be scrolled
   // to (and held at) the top of the viewport, even when little content sits below
   // it. Opening a thread on a reply lands a tall parent chain above the note; with
@@ -372,22 +411,22 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
   // logged. `targetIndex` indexes `displayItems` too — the sort-tabs row is
   // inserted after the target and skeletons are appended last.
   const focusReserve = useMemo(() => {
-    if (targetIndex <= 0) return 0;
+    if (listTargetIndex <= 0) return 0;
     const listViewport = Math.max(0, windowHeight - headerHeight - (replyBarHeight || 80));
-    const belowCount = Math.max(0, displayItems.length - 1 - targetIndex);
+    const belowCount = Math.max(0, listData.length - 1 - listTargetIndex);
     return Math.max(0, listViewport - belowCount * FOCUS_RESERVE_ROW_APPROX);
-  }, [targetIndex, windowHeight, headerHeight, replyBarHeight, displayItems.length]);
+  }, [listTargetIndex, windowHeight, headerHeight, replyBarHeight, listData.length]);
 
   useEffect(() => {
     if (focusReserve <= 0) return;
     feedLog.info('thread.reserve', {
       eventId,
-      targetIndex,
-      rows: displayItems.length,
+      targetIndex: listTargetIndex,
+      rows: listData.length,
       focusReserve: Math.round(focusReserve),
       windowHeight: Math.round(windowHeight),
     });
-  }, [focusReserve, eventId, targetIndex, displayItems.length, windowHeight]);
+  }, [focusReserve, eventId, listTargetIndex, listData.length, windowHeight]);
 
   const threadPhase =
     isLoading && items.length === 0
@@ -433,12 +472,19 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
       if (readerMovedRef.current) return;
       const tIndex = targetIndexRef.current;
       if (tIndex <= 0 || info.index >= tIndex) return;
+      // Reconcile each above-note row exactly once (its estimate→measured jump);
+      // re-correcting on every micro-change is what oscillated into jitter.
+      if (correctedKeysRef.current.has(info.itemKey)) return;
       const delta = info.size - info.previous;
       if (delta === 0) return;
+      correctedKeysRef.current.add(info.itemKey);
       const current = listRef.current?.getState()?.scroll ?? 0;
       void listRef.current?.scrollToOffset({ offset: current + delta, animated: false });
+      // This correction happens while hidden — push the crossfade reveal until the
+      // above-note rows stop changing size.
+      scheduleSettleReveal(120);
     },
-    [visualList]
+    [visualList, scheduleSettleReveal]
   );
 
   const threadVisualState = useMemo(() => {
@@ -546,16 +592,13 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
       }
 
       if (item.type === 'reply-sort-tabs') {
-        // Hidden until the target settles, then fades in at its final position.
         return (
-          <Animated.View style={revealStyle}>
-            <ReplySortPicker
-              selected={replySort}
-              onSelect={setReplySort}
-              foreground={foreground}
-              surfaceTertiary={surfaceTertiary}
-            />
-          </Animated.View>
+          <ReplySortPicker
+            selected={replySort}
+            onSelect={setReplySort}
+            foreground={foreground}
+            surfaceTertiary={surfaceTertiary}
+          />
         );
       }
 
@@ -614,7 +657,6 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
       getEngagementState,
       getMetrics,
       hasParents,
-      revealStyle,
       profilesRef,
       quotedEventsRef,
       replySort,
@@ -637,7 +679,6 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
         itemType={threadItemType(props.item)}
         index={props.index}
         phase={threadPhase}
-        onLayout={props.item.type === 'target' ? handleTargetSettled : undefined}
         extra={{
           eventId,
           rows: displayItems.length,
@@ -651,7 +692,6 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
     [
       displayItems.length,
       eventId,
-      handleTargetSettled,
       isFetching,
       renderThreadItem,
       replyBarHeight,
@@ -734,89 +774,91 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
                 onHeightChange={setReplyBarHeight}
               />
             }>
-            <LegendList
-              ref={listRef}
-              data={displayItems}
-              keyExtractor={threadKeyExtractor}
-              getItemType={threadItemType}
-              getFixedItemSize={threadFixedItemSize}
-              estimatedItemSize={200}
-              drawDistance={500}
-              renderItem={renderItem}
-              extraData={[
-                dataVersion,
-                engagementRevision,
-                isFetching ? 1 : 0,
-                isLoadingMoreReplies ? 1 : 0,
-                hasMoreReplies ? 1 : 0,
-                replySort,
-              ].join(':')}
-              recycleItems
-              ListFooterComponent={
-                isLoadingMoreReplies ? (
-                  <View style={styles.hiddenReplyFooter}>
-                    <Spinner size={18} color={opacity(foreground, 0.45)} />
-                  </View>
-                ) : hiddenReplyCount > 0 && !isFetching && !hasMoreReplies ? (
-                  <View style={styles.hiddenReplyFooter}>
-                    <Text size={13} style={{ color: opacity(foreground, 0.4) }}>
-                      {hiddenReplyCount} more {hiddenReplyCount === 1 ? 'reply' : 'replies'} not
-                      loaded
-                    </Text>
-                  </View>
-                ) : null
-              }
-              onEndReached={handleEndReached}
-              onEndReachedThreshold={0.4}
-              onItemSizeChanged={handleItemSizeChanged}
-              onScrollBeginDrag={() => {
-                readerMovedRef.current = true;
-              }}
-              onLoad={visualList.onLoad}
-              onMetricsChange={visualList.onMetricsChange}
-              onStickyHeaderChange={visualList.onStickyHeaderChange}
-              onViewableItemsChanged={visualList.onViewableItemsChanged}
-              viewabilityConfig={VISUAL_LIST_VIEWABILITY_CONFIG}
-              style={{ flex: 1 }}
-              contentContainerStyle={{
-                // The embed sheet is positioned starting just below the header
-                // (`expandedOffset`), so the list itself no longer pads the top.
-                paddingTop: 0,
-                // replyBarHeight already includes the bottom safe-area inset (the
-                // bar's opaque container reaches the screen bottom), so the inset
-                // is not added again here. `focusReserve` adds room below the note
-                // so it can be scrolled to the top (see its definition above).
-                paddingBottom: (replyBarHeight || 80) + 16 + focusReserve,
-              }}
-              showsVerticalScrollIndicator={false}
-              // Anchor-on-the-tapped-note stability. Bare `maintainVisibleContentPosition`
-              // normalizes to `{ data: true, size: true }` in @legendapp/list v3:
-              //  - `data: true`  → when the parent chain prepends above the focused note
-              //    (the T1 full-thread update), LegendList compensates contentOffset so the
-              //    note does NOT drop. This is OFF by default (`{ data: false }`); omitting
-              //    the prop is exactly why the note used to shift when parents loaded in.
-              //  - `size: true`  → absorbs the estimate→measured reconciliation of rows.
-              // Works together with `focusReserve` (the bottom padding): mVCP holds the
-              // note, the reserve guarantees the scroll room mVCP needs to do so.
-              // Mirrors the DM ChatScreen's anchoring half. We deliberately do NOT take
-              // ChatScreen's `initialScrollAtEnd` / `alignItemsAtEnd` / `maintainScrollAtEnd`:
-              // a thread anchors on the tapped note via `initialScrollIndex` and must never
-              // auto-pin to the bottom like a chat.
-              maintainVisibleContentPosition
-              onScroll={(e: { nativeEvent: { contentOffset: { y: number } } }) => {
-                const y = e.nativeEvent.contentOffset.y;
-                if (imageOverlay?.scrollOffsetY != null) imageOverlay.scrollOffsetY.value = y;
-                if (embed) embed.scrollY.value = y;
-                remeasureVisualLayoutScope(threadVisualScope, 'scroll', {
-                  minIntervalMs: 500,
-                  maxItems: 32,
-                  extra: { eventId, scrollY: Math.round(y), replySort },
-                });
-              }}
-              scrollEventThrottle={16}
-              scrollEnabled={embed ? embed.listScrollEnabled : undefined}
-              initialScrollIndex={!isLoading && targetIndex > 0 ? targetIndex : undefined}
-            />
+            <Animated.View style={[styles.listWrap, listAnimatedStyle]}>
+              <LegendList
+                ref={listRef}
+                data={listData}
+                keyExtractor={threadKeyExtractor}
+                getItemType={threadItemType}
+                getFixedItemSize={threadFixedItemSize}
+                estimatedItemSize={200}
+                drawDistance={500}
+                renderItem={renderItem}
+                extraData={[
+                  dataVersion,
+                  engagementRevision,
+                  isFetching ? 1 : 0,
+                  isLoadingMoreReplies ? 1 : 0,
+                  hasMoreReplies ? 1 : 0,
+                  replySort,
+                ].join(':')}
+                recycleItems
+                ListFooterComponent={
+                  isLoadingMoreReplies ? (
+                    <View style={styles.hiddenReplyFooter}>
+                      <Spinner size={18} color={opacity(foreground, 0.45)} />
+                    </View>
+                  ) : hiddenReplyCount > 0 && !isFetching && !hasMoreReplies ? (
+                    <View style={styles.hiddenReplyFooter}>
+                      <Text size={13} style={{ color: opacity(foreground, 0.4) }}>
+                        {hiddenReplyCount} more {hiddenReplyCount === 1 ? 'reply' : 'replies'} not
+                        loaded
+                      </Text>
+                    </View>
+                  ) : null
+                }
+                onEndReached={handleEndReached}
+                onEndReachedThreshold={0.4}
+                onItemSizeChanged={handleItemSizeChanged}
+                onScrollBeginDrag={() => {
+                  readerMovedRef.current = true;
+                }}
+                onLoad={visualList.onLoad}
+                onMetricsChange={visualList.onMetricsChange}
+                onStickyHeaderChange={visualList.onStickyHeaderChange}
+                onViewableItemsChanged={visualList.onViewableItemsChanged}
+                viewabilityConfig={VISUAL_LIST_VIEWABILITY_CONFIG}
+                style={{ flex: 1 }}
+                contentContainerStyle={{
+                  // The embed sheet is positioned starting just below the header
+                  // (`expandedOffset`), so the list itself no longer pads the top.
+                  paddingTop: 0,
+                  // replyBarHeight already includes the bottom safe-area inset (the
+                  // bar's opaque container reaches the screen bottom), so the inset
+                  // is not added again here. `focusReserve` adds room below the note
+                  // so it can be scrolled to the top (see its definition above).
+                  paddingBottom: (replyBarHeight || 80) + 16 + focusReserve,
+                }}
+                showsVerticalScrollIndicator={false}
+                // Anchor-on-the-tapped-note stability. Bare `maintainVisibleContentPosition`
+                // normalizes to `{ data: true, size: true }` in @legendapp/list v3:
+                //  - `data: true`  → when the parent chain prepends above the focused note
+                //    (the T1 full-thread update), LegendList compensates contentOffset so the
+                //    note does NOT drop. This is OFF by default (`{ data: false }`); omitting
+                //    the prop is exactly why the note used to shift when parents loaded in.
+                //  - `size: true`  → absorbs the estimate→measured reconciliation of rows.
+                // Works together with `focusReserve` (the bottom padding): mVCP holds the
+                // note, the reserve guarantees the scroll room mVCP needs to do so.
+                // Mirrors the DM ChatScreen's anchoring half. We deliberately do NOT take
+                // ChatScreen's `initialScrollAtEnd` / `alignItemsAtEnd` / `maintainScrollAtEnd`:
+                // a thread anchors on the tapped note via `initialScrollIndex` and must never
+                // auto-pin to the bottom like a chat.
+                maintainVisibleContentPosition
+                onScroll={(e: { nativeEvent: { contentOffset: { y: number } } }) => {
+                  const y = e.nativeEvent.contentOffset.y;
+                  if (imageOverlay?.scrollOffsetY != null) imageOverlay.scrollOffsetY.value = y;
+                  if (embed) embed.scrollY.value = y;
+                  remeasureVisualLayoutScope(threadVisualScope, 'scroll', {
+                    minIntervalMs: 500,
+                    maxItems: 32,
+                    extra: { eventId, scrollY: Math.round(y), replySort },
+                  });
+                }}
+                scrollEventThrottle={16}
+                scrollEnabled={embed ? embed.listScrollEnabled : undefined}
+                initialScrollIndex={!isLoading && listTargetIndex > 0 ? listTargetIndex : undefined}
+              />
+            </Animated.View>
           </ThreadEmbedSheet>
           {embed && targetEvent ? (
             <EmbedActionBar
@@ -851,6 +893,9 @@ export const ThreadView = React.memo(ThreadViewWithEmbed);
 
 const styles = StyleSheet.create({
   container: {
+    flex: 1,
+  },
+  listWrap: {
     flex: 1,
   },
   centerContent: {

--- a/features/feed/components/ThreadView.tsx
+++ b/features/feed/components/ThreadView.tsx
@@ -7,7 +7,14 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { StyleSheet, useWindowDimensions } from 'react-native';
-import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
+import Animated, {
+  FadeIn,
+  FadeOut,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
 import {
   LegendList,
   type LegendListRef,
@@ -298,39 +305,67 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
   const targetIndexRef = useRef(-1);
   const readerMovedRef = useRef(false);
 
-  // Direct swap after settle. We render TWO lists: a seed list (tapped note +
-  // replies, no parents) the reader sees immediately, and the real list (full
-  // thread) that resolves OFF-SCREEN. Once the parents above the note have stopped
-  // resizing, we land the note authoritatively and swap to the real list INSTANTLY —
-  // no fade, because the resolved view is a pixel match for the seed (same note at
-  // top, parents scrolled off above). `revealed`/`revealedRef` = real list is shown.
+  // Resolve off-screen, then crossfade. Two lists: a seed list (tapped note + reply
+  // SKELETONS, no parents) the reader sees immediately, and the real list (full
+  // thread) that resolves OFF-SCREEN — parents settle AND replies measure + load their
+  // images there. Once the on-screen rows stop changing size (debounced, with an
+  // absolute cap), we land the note authoritatively (`scrollToIndex`) and crossfade
+  // the settled real list in over the seed: the note is a pixel match (looks static),
+  // and the reply skeletons fade to ALREADY-SETTLED real replies — so nothing reshifts
+  // after they appear. `revealed`/`revealedRef` = real list is taking over.
   const [revealed, setRevealed] = useState(false);
   const revealedRef = useRef(false);
+  const [seedHidden, setSeedHidden] = useState(false);
+  const listOpacity = useSharedValue(0);
+  const realListStyle = useAnimatedStyle(() => ({ opacity: listOpacity.value }));
   const settleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const capTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Fire once the parents go quiet: put the note at the top with a single
-  // authoritative `scrollToIndex` (correct for ANY number of parents — far more
-  // robust than summing per-row counter-scroll deltas, which undershoot when several
-  // parents measure in a burst), then reveal next frame so the scroll has applied
-  // while still hidden.
-  const scheduleReveal = useCallback((delayMs: number) => {
+  // Land the note at the top with one authoritative `scrollToIndex` (correct for ANY
+  // number of parents — robust where summing per-row deltas undershoots), then reveal
+  // next frame so the scroll has applied while still hidden.
+  const fireReveal = useCallback(() => {
+    if (revealedRef.current) return;
     if (settleTimerRef.current) clearTimeout(settleTimerRef.current);
-    settleTimerRef.current = setTimeout(() => {
-      revealedRef.current = true;
-      const idx = targetIndexRef.current;
-      if (idx > 0) {
-        void listRef.current?.scrollToIndex({ index: idx, viewPosition: 0, animated: false });
-      }
-      requestAnimationFrame(() => setRevealed(true));
-    }, delayMs);
+    if (capTimerRef.current) clearTimeout(capTimerRef.current);
+    capTimerRef.current = null;
+    revealedRef.current = true;
+    const idx = targetIndexRef.current;
+    if (idx > 0) {
+      void listRef.current?.scrollToIndex({ index: idx, viewPosition: 0, animated: false });
+    }
+    requestAnimationFrame(() => setRevealed(true));
   }, []);
+
+  // Debounced "rows have gone quiet" timer — reset by each on-screen size change so the
+  // reveal waits until parents AND the first replies have settled.
+  const scheduleReveal = useCallback(
+    (delayMs: number) => {
+      if (revealedRef.current) return;
+      if (settleTimerRef.current) clearTimeout(settleTimerRef.current);
+      settleTimerRef.current = setTimeout(fireReveal, delayMs);
+    },
+    [fireReveal]
+  );
+
+  // Crossfade the real list in once it's the authoritative view, then drop the seed.
+  useEffect(() => {
+    if (!revealed) return;
+    listOpacity.value = withTiming(1, { duration: 200 }, (finished) => {
+      if (finished) runOnJS(setSeedHidden)(true);
+    });
+  }, [revealed, listOpacity]);
 
   useEffect(() => {
     setRevealed(false);
     revealedRef.current = false;
     readerMovedRef.current = false;
+    setSeedHidden(false);
+    listOpacity.value = 0;
     if (settleTimerRef.current) clearTimeout(settleTimerRef.current);
-  }, [eventId]);
+    if (capTimerRef.current) clearTimeout(capTimerRef.current);
+    capTimerRef.current = null;
+  }, [eventId, listOpacity]);
 
   const targetItem = useMemo(() => items.find((item) => item.type === 'target'), [items]);
   const hasParents = useMemo(() => items.some((i) => i.type === 'parent'), [items]);
@@ -367,20 +402,16 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
     return withReplySortTabs([...items, ...createReplySkeletonItems(skeletonCount)]);
   }, [isFetching, isLoading, items, metricsRef]);
 
-  // Real reply CONTENT is withheld until the list is revealed. While the real list
-  // resolves off-screen we don't want replies rendering/loading there — they'd reach
-  // a half-loaded state and be shown un-settled at the swap, their skeleton→real fade
-  // already spent while invisible. So pre-reveal both lists show reply SKELETONS; the
-  // real reply rows mount only once the list is visible, where `REPLY_FADE_IN` plays
-  // as designed. (Parents are unaffected — they still settle off-screen.)
+  // The seed (visible until the crossfade) shows the note + reply SKELETONS, no
+  // parents. The real list renders the FULL thread the whole time, including replies,
+  // so the replies measure and load their images OFF-SCREEN and are already settled by
+  // the time the crossfade reveals them — that's what stops the post-appearance
+  // reshift. (Only the real list renders real replies, so images aren't double-loaded.)
   const seedData = useMemo<ThreadListItem[]>(
     () => displayItems.filter((i) => i.type !== 'parent' && i.type !== 'reply'),
     [displayItems]
   );
-  const realData = useMemo<ThreadListItem[]>(
-    () => (revealed ? displayItems : displayItems.filter((i) => i.type !== 'reply')),
-    [revealed, displayItems]
-  );
+  const realData = displayItems;
   // The note's index in the real list (parents precede it; replies/skeletons follow,
   // so the index is the same gated or not) — for the focus reserve and the landing.
   const fullTargetIndex = useMemo(
@@ -389,22 +420,18 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
   );
   targetIndexRef.current = fullTargetIndex;
 
-  // Once the full thread is fetched, decide when to swap to the real list. With no
-  // parents there's no prepend, so swap immediately. With parents, arm a generous
-  // fallback (long enough for a fast/cached parent image to load + reshape
-  // off-screen, so the swap shows it already settled); the size-change handler
-  // shortens it as each above-note row goes quiet. Stragglers (slow network images)
-  // load post-swap and are absorbed by the counter-scroll.
+  // Once the full thread is fetched, wait for the on-screen rows (parents above AND
+  // the first replies below) to settle off-screen, then crossfade. Arm the debounced
+  // quiet timer (the size-change handler resets it as rows settle) plus an absolute
+  // cap so a slow network image can't hold the seed indefinitely — anything still
+  // loading past the cap finishes after the crossfade (counter-scroll absorbs an
+  // above-note straggler; a below-note straggler is past the focus and rare).
   const fullReady = !isLoading && !isFetching && !!targetItem;
   useEffect(() => {
     if (!fullReady || revealed) return;
-    if (!hasParents) {
-      revealedRef.current = true;
-      setRevealed(true);
-      return;
-    }
-    scheduleReveal(900);
-  }, [fullReady, revealed, hasParents, scheduleReveal]);
+    scheduleReveal(220);
+    if (!capTimerRef.current) capTimerRef.current = setTimeout(fireReveal, 1000);
+  }, [fullReady, revealed, scheduleReveal, fireReveal]);
 
   // Focus reserve: extra bottom space so the tapped reply can always be scrolled
   // to (and held at) the top of the viewport, even when little content sits below
@@ -464,16 +491,15 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
     getListState: () => listRef.current?.getState() ?? null,
   });
 
-  // Above-note size changes (parents measuring / late media reshaping) are what
-  // would move the focused note. Two regimes, split on `revealed`:
-  //  - BEFORE the swap (off-screen): don't counter-scroll per row — summing many
-  //    deltas in a burst undershoots with multiple parents. Just keep pushing the
-  //    swap out until the parents go quiet; `scheduleReveal` then lands the note with
-  //    one authoritative `scrollToIndex`.
-  //  - AFTER the swap: a late parent image (no imeta dims, slow to load) can still
-  //    reshape; the parent is off-screen above the note, so counter-scroll by its
-  //    exact delta to absorb the growth and keep the note fixed. One change at a time
-  //    here, so no burst/undershoot. (mVCP runs `size:false` → we're the sole owner.)
+  // Two regimes, split on `revealed`:
+  //  - BEFORE the crossfade (off-screen): ANY rendered row still changing size — a
+  //    parent measuring, a reply measuring or its image loading — keeps the reveal
+  //    waiting (`scheduleReveal` resets) so we crossfade a fully-settled list. No
+  //    per-row counter-scroll here: `scrollToIndex` (in `fireReveal`) lands the note
+  //    authoritatively, which is robust where summing many deltas would undershoot.
+  //  - AFTER the crossfade: a slow parent image (no imeta dims) can still reshape;
+  //    it's off-screen above the note, so counter-scroll by its exact delta to absorb
+  //    the growth and keep the note fixed. One change at a time → no burst.
   const handleItemSizeChanged = useCallback(
     (info: {
       size: number;
@@ -485,11 +511,12 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
       visualList.onItemSizeChanged?.(info);
       if (readerMovedRef.current) return;
       const tIndex = targetIndexRef.current;
-      if (tIndex <= 0 || info.index >= tIndex) return;
+      if (tIndex < 0) return;
       if (!revealedRef.current) {
-        scheduleReveal(150);
+        scheduleReveal(180);
         return;
       }
+      if (info.index >= tIndex) return;
       const delta = info.size - info.previous;
       if (delta === 0) return;
       const current = listRef.current?.getState()?.scroll ?? 0;
@@ -786,9 +813,11 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
               />
             }>
             <View style={styles.listWrap}>
-              {/* Real list — full thread; resolves off-screen, shown once settled. */}
-              <View
-                style={[StyleSheet.absoluteFill, revealed ? undefined : styles.hiddenList]}
+              {/* Real list — full thread; resolves off-screen (opacity 0), then
+                  crossfades in over the seed once the rows have settled. zIndex keeps
+                  it above the seed regardless of mount order. */}
+              <Animated.View
+                style={[StyleSheet.absoluteFill, styles.realLayer, realListStyle]}
                 pointerEvents={revealed ? 'auto' : 'none'}>
                 <LegendList
                   ref={listRef}
@@ -869,11 +898,11 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
                     !isLoading && fullTargetIndex > 0 ? fullTargetIndex : undefined
                   }
                 />
-              </View>
-              {/* Seed list — tapped note + replies (no parents), shown until the real
-                  list resolves. Pixel-matches the real list's visible region, so the
-                  swap is invisible. Display-only (no scroll, no handlers). */}
-              {revealed ? null : (
+              </Animated.View>
+              {/* Seed — tapped note + reply skeletons (no parents), shown underneath
+                  until the real list has crossfaded in. Display-only (no scroll, no
+                  handlers); kept mounted through the fade, then dropped. */}
+              {seedHidden ? null : (
                 <View style={StyleSheet.absoluteFill} pointerEvents="none">
                   <LegendList
                     data={seedData}
@@ -937,8 +966,8 @@ const styles = StyleSheet.create({
   flexOne: {
     flex: 1,
   },
-  hiddenList: {
-    opacity: 0,
+  realLayer: {
+    zIndex: 1,
   },
   centerContent: {
     justifyContent: 'center',

--- a/features/feed/components/ThreadView.tsx
+++ b/features/feed/components/ThreadView.tsx
@@ -714,6 +714,18 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
                 paddingBottom: (replyBarHeight || 80) + 16,
               }}
               showsVerticalScrollIndicator={false}
+              // Anchor-on-the-tapped-note stability. Bare `maintainVisibleContentPosition`
+              // normalizes to `{ data: true, size: true }` in @legendapp/list v3:
+              //  - `data: true`  → when the parent chain prepends above the focused note
+              //    (the T1 full-thread update), LegendList compensates contentOffset so the
+              //    note does NOT drop. This is OFF by default (`{ data: false }`); omitting
+              //    the prop is exactly why the note used to shift when parents loaded in.
+              //  - `size: true`  → absorbs the estimate→measured reconciliation of rows.
+              // Mirrors the DM ChatScreen's anchoring half. We deliberately do NOT take
+              // ChatScreen's `initialScrollAtEnd` / `alignItemsAtEnd` / `maintainScrollAtEnd`:
+              // a thread anchors on the tapped note via `initialScrollIndex` and must never
+              // auto-pin to the bottom like a chat.
+              maintainVisibleContentPosition
               onScroll={(e: { nativeEvent: { contentOffset: { y: number } } }) => {
                 const y = e.nativeEvent.contentOffset.y;
                 if (imageOverlay?.scrollOffsetY != null) imageOverlay.scrollOffsetY.value = y;

--- a/features/feed/components/ThreadView.tsx
+++ b/features/feed/components/ThreadView.tsx
@@ -286,6 +286,17 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
 
   const listRef = useRef<LegendListRef>(null);
 
+  // Anchor compensation for the parent prepend. `maintainVisibleContentPosition`
+  // scrolls to hold the focused note when the parent prepends, but it anchors
+  // against the parent's *estimate* (`estimatedItemSize`) and never reconciles the
+  // gap once the parent measures to its real height — leaving the note off by
+  // exactly (estimate − measured) px (verified in the shift log: 200 vs 145 → the
+  // note jumped up 55px). We own that one reconciliation: when a row ABOVE the
+  // note changes size before the reader has scrolled, counter-scroll by the delta
+  // so the note stays put. Read via refs so the size-change callback is stable.
+  const targetIndexRef = useRef(-1);
+  const readerMovedRef = useRef(false);
+
   // The sort-tabs ("Relevant") row and the replies sit below the target, so their
   // on-screen position is whatever LegendList computes for the target — which
   // starts at `estimatedItemSize` and snaps to the real measured height a frame
@@ -309,9 +320,11 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
   useEffect(() => {
     revealedRef.current = false;
     revealOpacity.value = 0;
+    readerMovedRef.current = false;
   }, [eventId, revealOpacity]);
 
   const targetIndex = useMemo(() => items.findIndex((item) => item.type === 'target'), [items]);
+  targetIndexRef.current = targetIndex;
   const targetItem = useMemo(() => items.find((item) => item.type === 'target'), [items]);
   const hasParents = useMemo(() => items.some((i) => i.type === 'parent'), [items]);
 
@@ -404,6 +417,29 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
     }),
     getListState: () => listRef.current?.getState() ?? null,
   });
+
+  // Keep the visual-shift logging, then reconcile the parent prepend (see the
+  // `targetIndexRef`/`readerMovedRef` note above). Only rows above the focused
+  // note shift it, and only until the reader takes over scrolling.
+  const handleItemSizeChanged = useCallback(
+    (info: {
+      size: number;
+      previous: number;
+      index: number;
+      itemKey: string;
+      itemData: ThreadListItem;
+    }) => {
+      visualList.onItemSizeChanged?.(info);
+      if (readerMovedRef.current) return;
+      const tIndex = targetIndexRef.current;
+      if (tIndex <= 0 || info.index >= tIndex) return;
+      const delta = info.size - info.previous;
+      if (delta === 0) return;
+      const current = listRef.current?.getState()?.scroll ?? 0;
+      void listRef.current?.scrollToOffset({ offset: current + delta, animated: false });
+    },
+    [visualList]
+  );
 
   const threadVisualState = useMemo(() => {
     let skeletons = 0;
@@ -732,7 +768,10 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
               }
               onEndReached={handleEndReached}
               onEndReachedThreshold={0.4}
-              onItemSizeChanged={visualList.onItemSizeChanged}
+              onItemSizeChanged={handleItemSizeChanged}
+              onScrollBeginDrag={() => {
+                readerMovedRef.current = true;
+              }}
               onLoad={visualList.onLoad}
               onMetricsChange={visualList.onMetricsChange}
               onStickyHeaderChange={visualList.onStickyHeaderChange}

--- a/features/feed/components/ThreadView.tsx
+++ b/features/feed/components/ThreadView.tsx
@@ -7,14 +7,7 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { StyleSheet, useWindowDimensions } from 'react-native';
-import Animated, {
-  FadeIn,
-  FadeOut,
-  runOnJS,
-  useAnimatedStyle,
-  useSharedValue,
-  withTiming,
-} from 'react-native-reanimated';
+import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
 import {
   LegendList,
   type LegendListRef,
@@ -298,41 +291,31 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
   const targetIndexRef = useRef(-1);
   const readerMovedRef = useRef(false);
 
-  // Crossfade-after-settle. The parent chain prepends into the list and reconciles
-  // (mVCP + our counter-scroll) over several frames; played out on screen that
-  // reconciliation reads as jitter. So we hold the parents OUT of the list and show
-  // only the seed (tapped note + skeletons) at full opacity. When the full thread is
-  // ready we fade the list out, inject the parents while hidden, let the scroll
-  // settle, then fade back in. The reader sees the tapped note → a brief crossfade →
-  // the settled thread, never the reconciliation. `listData`/`listTargetIndex` (below)
-  // are the gated data the list actually renders.
-  const listOpacity = useSharedValue(1);
-  const listAnimatedStyle = useAnimatedStyle(() => ({ opacity: listOpacity.value }));
-  const [showParents, setShowParents] = useState(false);
+  // Direct swap after settle. The parent prepend reconciles (mVCP + our
+  // counter-scroll) over several frames; shown, that reads as jitter. So we render
+  // TWO lists: a seed list (tapped note + replies, no parents) the reader sees
+  // immediately, and the real list (full thread) that resolves OFF-SCREEN. Once the
+  // real list has settled at the focused note we swap to it INSTANTLY — no fade,
+  // because the resolved view is a pixel match for the seed (same note at top, same
+  // replies below; the parents are just scrolled off above). `revealed` = real list
+  // is shown.
+  const [revealed, setRevealed] = useState(false);
   const settleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Each above-note row is reconciled once (no oscillation); also tracks which rows
-  // have settled so the crossfade reveals only after they're quiet.
+  // Reconcile each above-note row once (no oscillation); resets the reveal timer so
+  // the swap waits until those rows stop changing size.
   const correctedKeysRef = useRef<Set<string>>(new Set());
 
-  // Reveal once the post-inject reconcile goes quiet: each above-note correction
-  // pushes this out; with no corrections the fallback delay reveals anyway.
-  const scheduleSettleReveal = useCallback(
-    (delayMs: number) => {
-      if (settleTimerRef.current) clearTimeout(settleTimerRef.current);
-      settleTimerRef.current = setTimeout(() => {
-        listOpacity.value = withTiming(1, { duration: 180 });
-      }, delayMs);
-    },
-    [listOpacity]
-  );
+  const scheduleReveal = useCallback((delayMs: number) => {
+    if (settleTimerRef.current) clearTimeout(settleTimerRef.current);
+    settleTimerRef.current = setTimeout(() => setRevealed(true), delayMs);
+  }, []);
 
   useEffect(() => {
-    setShowParents(false);
-    listOpacity.value = 1;
+    setRevealed(false);
     readerMovedRef.current = false;
     correctedKeysRef.current = new Set();
     if (settleTimerRef.current) clearTimeout(settleTimerRef.current);
-  }, [eventId, listOpacity]);
+  }, [eventId]);
 
   const targetItem = useMemo(() => items.find((item) => item.type === 'target'), [items]);
   const hasParents = useMemo(() => items.some((i) => i.type === 'parent'), [items]);
@@ -369,35 +352,33 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
     return withReplySortTabs([...items, ...createReplySkeletonItems(skeletonCount)]);
   }, [isFetching, isLoading, items, metricsRef]);
 
-  // Gated data the list renders: parents are withheld until `showParents` flips
-  // (after the fade-out), so the prepend never reconciles on screen.
-  const listData = useMemo<ThreadListItem[]>(
-    () => (showParents ? displayItems : displayItems.filter((i) => i.type !== 'parent')),
-    [showParents, displayItems]
+  // Seed list data (what the reader sees until the swap): the full thread minus the
+  // parents, so the tapped note sits at the top with its replies below — exactly the
+  // visible region the resolved real list will show.
+  const seedData = useMemo<ThreadListItem[]>(
+    () => displayItems.filter((i) => i.type !== 'parent'),
+    [displayItems]
   );
-  const listTargetIndex = useMemo(() => listData.findIndex((i) => i.type === 'target'), [listData]);
-  targetIndexRef.current = listTargetIndex;
+  // The real (hidden) list renders the full `displayItems`; this is the note's index
+  // there, for the counter-scroll, focus reserve, and initial landing.
+  const fullTargetIndex = useMemo(
+    () => displayItems.findIndex((i) => i.type === 'target'),
+    [displayItems]
+  );
+  targetIndexRef.current = fullTargetIndex;
 
-  // Drive the crossfade. Once the full thread is fetched: if it has parents, fade
-  // out → inject them (hidden) → settle → fade in; if not, just show (no prepend,
-  // no jitter).
+  // Once the full thread is fetched, decide when to swap to the real list. With no
+  // parents there's no prepend, so swap immediately. With parents, arm a generous
+  // fallback; the size-change handler shortens it as each above-note row settles.
   const fullReady = !isLoading && !isFetching && !!targetItem;
   useEffect(() => {
-    if (!fullReady || showParents) return;
+    if (!fullReady || revealed) return;
     if (!hasParents) {
-      setShowParents(true);
+      setRevealed(true);
       return;
     }
-    listOpacity.value = withTiming(0, { duration: 120 }, (finished) => {
-      if (finished) runOnJS(setShowParents)(true);
-    });
-  }, [fullReady, showParents, hasParents, listOpacity]);
-
-  // Parents are now injected (hidden). Arm the reveal with a generous fallback; the
-  // size-change handler shortens it as each above-note row settles.
-  useEffect(() => {
-    if (showParents && hasParents) scheduleSettleReveal(600);
-  }, [showParents, hasParents, scheduleSettleReveal]);
+    scheduleReveal(600);
+  }, [fullReady, revealed, hasParents, scheduleReveal]);
 
   // Focus reserve: extra bottom space so the tapped reply can always be scrolled
   // to (and held at) the top of the viewport, even when little content sits below
@@ -411,22 +392,22 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
   // logged. `targetIndex` indexes `displayItems` too — the sort-tabs row is
   // inserted after the target and skeletons are appended last.
   const focusReserve = useMemo(() => {
-    if (listTargetIndex <= 0) return 0;
+    if (fullTargetIndex <= 0) return 0;
     const listViewport = Math.max(0, windowHeight - headerHeight - (replyBarHeight || 80));
-    const belowCount = Math.max(0, listData.length - 1 - listTargetIndex);
+    const belowCount = Math.max(0, displayItems.length - 1 - fullTargetIndex);
     return Math.max(0, listViewport - belowCount * FOCUS_RESERVE_ROW_APPROX);
-  }, [listTargetIndex, windowHeight, headerHeight, replyBarHeight, listData.length]);
+  }, [fullTargetIndex, windowHeight, headerHeight, replyBarHeight, displayItems.length]);
 
   useEffect(() => {
     if (focusReserve <= 0) return;
     feedLog.info('thread.reserve', {
       eventId,
-      targetIndex: listTargetIndex,
-      rows: listData.length,
+      targetIndex: fullTargetIndex,
+      rows: displayItems.length,
       focusReserve: Math.round(focusReserve),
       windowHeight: Math.round(windowHeight),
     });
-  }, [focusReserve, eventId, listTargetIndex, listData.length, windowHeight]);
+  }, [focusReserve, eventId, fullTargetIndex, displayItems.length, windowHeight]);
 
   const threadPhase =
     isLoading && items.length === 0
@@ -480,11 +461,11 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
       correctedKeysRef.current.add(info.itemKey);
       const current = listRef.current?.getState()?.scroll ?? 0;
       void listRef.current?.scrollToOffset({ offset: current + delta, animated: false });
-      // This correction happens while hidden — push the crossfade reveal until the
-      // above-note rows stop changing size.
-      scheduleSettleReveal(120);
+      // This correction happens off-screen (real list hidden) — push the swap until
+      // the above-note rows stop changing size, so we reveal a settled list.
+      scheduleReveal(120);
     },
-    [visualList, scheduleSettleReveal]
+    [visualList, scheduleReveal]
   );
 
   const threadVisualState = useMemo(() => {
@@ -774,91 +755,122 @@ function ThreadViewInner({ eventId }: ThreadViewProps) {
                 onHeightChange={setReplyBarHeight}
               />
             }>
-            <Animated.View style={[styles.listWrap, listAnimatedStyle]}>
-              <LegendList
-                ref={listRef}
-                data={listData}
-                keyExtractor={threadKeyExtractor}
-                getItemType={threadItemType}
-                getFixedItemSize={threadFixedItemSize}
-                estimatedItemSize={200}
-                drawDistance={500}
-                renderItem={renderItem}
-                extraData={[
-                  dataVersion,
-                  engagementRevision,
-                  isFetching ? 1 : 0,
-                  isLoadingMoreReplies ? 1 : 0,
-                  hasMoreReplies ? 1 : 0,
-                  replySort,
-                ].join(':')}
-                recycleItems
-                ListFooterComponent={
-                  isLoadingMoreReplies ? (
-                    <View style={styles.hiddenReplyFooter}>
-                      <Spinner size={18} color={opacity(foreground, 0.45)} />
-                    </View>
-                  ) : hiddenReplyCount > 0 && !isFetching && !hasMoreReplies ? (
-                    <View style={styles.hiddenReplyFooter}>
-                      <Text size={13} style={{ color: opacity(foreground, 0.4) }}>
-                        {hiddenReplyCount} more {hiddenReplyCount === 1 ? 'reply' : 'replies'} not
-                        loaded
-                      </Text>
-                    </View>
-                  ) : null
-                }
-                onEndReached={handleEndReached}
-                onEndReachedThreshold={0.4}
-                onItemSizeChanged={handleItemSizeChanged}
-                onScrollBeginDrag={() => {
-                  readerMovedRef.current = true;
-                }}
-                onLoad={visualList.onLoad}
-                onMetricsChange={visualList.onMetricsChange}
-                onStickyHeaderChange={visualList.onStickyHeaderChange}
-                onViewableItemsChanged={visualList.onViewableItemsChanged}
-                viewabilityConfig={VISUAL_LIST_VIEWABILITY_CONFIG}
-                style={{ flex: 1 }}
-                contentContainerStyle={{
-                  // The embed sheet is positioned starting just below the header
-                  // (`expandedOffset`), so the list itself no longer pads the top.
-                  paddingTop: 0,
-                  // replyBarHeight already includes the bottom safe-area inset (the
-                  // bar's opaque container reaches the screen bottom), so the inset
-                  // is not added again here. `focusReserve` adds room below the note
-                  // so it can be scrolled to the top (see its definition above).
-                  paddingBottom: (replyBarHeight || 80) + 16 + focusReserve,
-                }}
-                showsVerticalScrollIndicator={false}
-                // Anchor-on-the-tapped-note stability. Bare `maintainVisibleContentPosition`
-                // normalizes to `{ data: true, size: true }` in @legendapp/list v3:
-                //  - `data: true`  → when the parent chain prepends above the focused note
-                //    (the T1 full-thread update), LegendList compensates contentOffset so the
-                //    note does NOT drop. This is OFF by default (`{ data: false }`); omitting
-                //    the prop is exactly why the note used to shift when parents loaded in.
-                //  - `size: true`  → absorbs the estimate→measured reconciliation of rows.
-                // Works together with `focusReserve` (the bottom padding): mVCP holds the
-                // note, the reserve guarantees the scroll room mVCP needs to do so.
-                // Mirrors the DM ChatScreen's anchoring half. We deliberately do NOT take
-                // ChatScreen's `initialScrollAtEnd` / `alignItemsAtEnd` / `maintainScrollAtEnd`:
-                // a thread anchors on the tapped note via `initialScrollIndex` and must never
-                // auto-pin to the bottom like a chat.
-                maintainVisibleContentPosition
-                onScroll={(e: { nativeEvent: { contentOffset: { y: number } } }) => {
-                  const y = e.nativeEvent.contentOffset.y;
-                  if (imageOverlay?.scrollOffsetY != null) imageOverlay.scrollOffsetY.value = y;
-                  if (embed) embed.scrollY.value = y;
-                  remeasureVisualLayoutScope(threadVisualScope, 'scroll', {
-                    minIntervalMs: 500,
-                    maxItems: 32,
-                    extra: { eventId, scrollY: Math.round(y), replySort },
-                  });
-                }}
-                scrollEventThrottle={16}
-                scrollEnabled={embed ? embed.listScrollEnabled : undefined}
-                initialScrollIndex={!isLoading && listTargetIndex > 0 ? listTargetIndex : undefined}
-              />
-            </Animated.View>
+            <View style={styles.listWrap}>
+              {/* Real list — full thread; resolves off-screen, shown once settled. */}
+              <View
+                style={[StyleSheet.absoluteFill, revealed ? undefined : styles.hiddenList]}
+                pointerEvents={revealed ? 'auto' : 'none'}>
+                <LegendList
+                  ref={listRef}
+                  data={displayItems}
+                  keyExtractor={threadKeyExtractor}
+                  getItemType={threadItemType}
+                  getFixedItemSize={threadFixedItemSize}
+                  estimatedItemSize={200}
+                  drawDistance={500}
+                  renderItem={renderItem}
+                  extraData={[
+                    dataVersion,
+                    engagementRevision,
+                    isFetching ? 1 : 0,
+                    isLoadingMoreReplies ? 1 : 0,
+                    hasMoreReplies ? 1 : 0,
+                    replySort,
+                  ].join(':')}
+                  recycleItems
+                  ListFooterComponent={
+                    isLoadingMoreReplies ? (
+                      <View style={styles.hiddenReplyFooter}>
+                        <Spinner size={18} color={opacity(foreground, 0.45)} />
+                      </View>
+                    ) : hiddenReplyCount > 0 && !isFetching && !hasMoreReplies ? (
+                      <View style={styles.hiddenReplyFooter}>
+                        <Text size={13} style={{ color: opacity(foreground, 0.4) }}>
+                          {hiddenReplyCount} more {hiddenReplyCount === 1 ? 'reply' : 'replies'} not
+                          loaded
+                        </Text>
+                      </View>
+                    ) : null
+                  }
+                  onEndReached={handleEndReached}
+                  onEndReachedThreshold={0.4}
+                  onItemSizeChanged={handleItemSizeChanged}
+                  onScrollBeginDrag={() => {
+                    readerMovedRef.current = true;
+                  }}
+                  onLoad={visualList.onLoad}
+                  onMetricsChange={visualList.onMetricsChange}
+                  onStickyHeaderChange={visualList.onStickyHeaderChange}
+                  onViewableItemsChanged={visualList.onViewableItemsChanged}
+                  viewabilityConfig={VISUAL_LIST_VIEWABILITY_CONFIG}
+                  style={{ flex: 1 }}
+                  contentContainerStyle={{
+                    // The embed sheet is positioned starting just below the header
+                    // (`expandedOffset`), so the list itself no longer pads the top.
+                    paddingTop: 0,
+                    // replyBarHeight already includes the bottom safe-area inset (the
+                    // bar's opaque container reaches the screen bottom), so the inset
+                    // is not added again here. `focusReserve` adds room below the note
+                    // so it can be scrolled to the top (see its definition above).
+                    paddingBottom: (replyBarHeight || 80) + 16 + focusReserve,
+                  }}
+                  showsVerticalScrollIndicator={false}
+                  // Anchor-on-the-tapped-note stability. Bare `maintainVisibleContentPosition`
+                  // normalizes to `{ data: true, size: true }` in @legendapp/list v3:
+                  //  - `data: true`  → when the parent chain prepends above the focused note
+                  //    (the T1 full-thread update), LegendList compensates contentOffset so the
+                  //    note does NOT drop. This is OFF by default (`{ data: false }`); omitting
+                  //    the prop is exactly why the note used to shift when parents loaded in.
+                  //  - `size: true`  → absorbs the estimate→measured reconciliation of rows.
+                  // Works together with `focusReserve` (the bottom padding): mVCP holds the
+                  // note, the reserve guarantees the scroll room mVCP needs to do so.
+                  // Mirrors the DM ChatScreen's anchoring half. We deliberately do NOT take
+                  // ChatScreen's `initialScrollAtEnd` / `alignItemsAtEnd` / `maintainScrollAtEnd`:
+                  // a thread anchors on the tapped note via `initialScrollIndex` and must never
+                  // auto-pin to the bottom like a chat.
+                  maintainVisibleContentPosition
+                  onScroll={(e: { nativeEvent: { contentOffset: { y: number } } }) => {
+                    const y = e.nativeEvent.contentOffset.y;
+                    if (imageOverlay?.scrollOffsetY != null) imageOverlay.scrollOffsetY.value = y;
+                    if (embed) embed.scrollY.value = y;
+                    remeasureVisualLayoutScope(threadVisualScope, 'scroll', {
+                      minIntervalMs: 500,
+                      maxItems: 32,
+                      extra: { eventId, scrollY: Math.round(y), replySort },
+                    });
+                  }}
+                  scrollEventThrottle={16}
+                  scrollEnabled={embed ? embed.listScrollEnabled : undefined}
+                  initialScrollIndex={
+                    !isLoading && fullTargetIndex > 0 ? fullTargetIndex : undefined
+                  }
+                />
+              </View>
+              {/* Seed list — tapped note + replies (no parents), shown until the real
+                  list resolves. Pixel-matches the real list's visible region, so the
+                  swap is invisible. Display-only (no scroll, no handlers). */}
+              {revealed ? null : (
+                <View style={StyleSheet.absoluteFill} pointerEvents="none">
+                  <LegendList
+                    data={seedData}
+                    keyExtractor={threadKeyExtractor}
+                    getItemType={threadItemType}
+                    getFixedItemSize={threadFixedItemSize}
+                    estimatedItemSize={200}
+                    drawDistance={500}
+                    renderItem={renderItem}
+                    recycleItems
+                    scrollEnabled={false}
+                    showsVerticalScrollIndicator={false}
+                    style={styles.flexOne}
+                    contentContainerStyle={{
+                      paddingTop: 0,
+                      paddingBottom: (replyBarHeight || 80) + 16,
+                    }}
+                  />
+                </View>
+              )}
+            </View>
           </ThreadEmbedSheet>
           {embed && targetEvent ? (
             <EmbedActionBar
@@ -897,6 +909,12 @@ const styles = StyleSheet.create({
   },
   listWrap: {
     flex: 1,
+  },
+  flexOne: {
+    flex: 1,
+  },
+  hiddenList: {
+    opacity: 0,
   },
   centerContent: {
     justifyContent: 'center',

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@gandlaf21/bolt11-decode": "^3.1.1",
     "@gorhom/bottom-sheet": "5.2.9",
     "@internet-privacy/marmot-ts": "file:./vendor/marmot-ts",
-    "@legendapp/list": "3.0.0",
+    "@legendapp/list": "3.0.6",
     "@mealection/react-native-boring-avatars": "1.1.2",
     "@monicon/metro": "^2.0.7",
     "@monicon/native": "^1.2.2",


### PR DESCRIPTION
## Why

Opening a thread on a reply lands on that note, then the note **drops** when the parent/ancestor chain loads in above it. Root cause, verified against the installed `@legendapp/list@3.0.0` source:

- The thread `LegendList` omitted `maintainVisibleContentPosition`. v3's `normalizeMaintainVisibleContentPosition` resolves an omitted prop to `{ data: false, size: true }`.
- The prepend offset-compensation is gated on `.data` (`if (dataChanged && doMVCP && mvcp.data && …)`), so with `data:false` it never runs.
- `useThread` delivers the thread in two passes — T0 seed shows the target (stable key `t_${id}`), **T1 prepends the entire parent chain above it in one update**. With no data-anchoring, `contentOffset` isn't compensated and the focused note falls by the parent chain's measured height.

## What

- Add bare `maintainVisibleContentPosition` (→ `{ data: true, size: true }`) to the thread list. `data` compensates the parent prepend; `size` absorbs estimate→measured reconciliation. Mirrors the DM `ChatScreen`'s anchoring.
- Keep `initialScrollIndex` (land on the tapped note).
- **Deliberately omit** `initialScrollAtEnd` / `alignItemsAtEnd` / `maintainScrollAtEnd` — the thread anchors on the note and must never auto-pin to bottom like a chat.

Replaces the manual `scrollToIndex` re-pin approach (PR #225), which raced the library's own anchoring and still shifted ("don't fight the library's correction").

## Verification

- `tsc` clean; `eslint` 0 errors (pre-existing `react-perf` warnings only); `knip` clear for touched files; thread unit tests pass.
- The 20 `naggFeedClient*` test failures are **pre-existing on the base `feat/nostr-data-layer` branch** (confirmed identical with this change stashed) — not introduced here.
- Native `ScrollView` mVCP can't be exercised in jest; the behavioral proof is **on-device**: open a thread on a reply — the focused note must stay fixed as parents load above and replies load below, with no auto-scroll to bottom.

## Notes

- Based on `feat/nostr-data-layer` (#224), per request, so it ships alongside the facade/ADR-0003 thread work.
- Docs: `docs/adr/0004-thread-list-anchoring.md` + `CONTEXT.md` "Thread anchor" glossary term.
- Out of scope (kept surgical): the opacity reveal-hack stays (it handles *below-target* settle, orthogonal to the parent-prepend shift); `estimatedItemSize` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)