### PR TITLE
fix(mint): match Add Mints search skeleton to real result rows

### DIFF
--- a/__tests__/contactRowLoadingReservation.test.tsx
+++ b/__tests__/contactRowLoadingReservation.test.tsx
@@ -1,0 +1,254 @@
+/**
+ * @jest-environment node
+ *
+ * ContactRow loading-state height reservation. A loading row must reserve every
+ * layout box the loaded row will show, or the row grows when data arrives
+ * (content shift). These tests pin the two reservations the Add Mints skeleton
+ * relies on — the inline stats accent and the selection checkbox — and the gate
+ * that keeps the accent reservation off plain (non-mint) skeletons.
+ */
+
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+
+import { ContactRow, mintIdentity, nostrIdentity } from '@/shared/ui/composed/ContactRow';
+import { ListRow } from '@/shared/ui/composed/ListRow';
+import { RowStatsAccent, RowStatsAccentSkeleton } from '@/shared/ui/composed/RowStatsAccent';
+import { SelectableCheck } from '@/shared/ui/primitives/SelectableCheck';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock('@/shared/hooks/useThemeColor', () => ({
+  useThemeColor: (tokens: string | readonly string[]) =>
+    Array.isArray(tokens) ? tokens.map((token) => `theme-${token}`) : 'theme-single',
+}));
+
+jest.mock('hex-color-opacity', () => jest.fn(() => 'rgba(0,0,0,0.12)'));
+
+jest.mock('@/shared/lib/date', () => ({
+  formatRelative: jest.fn(() => 'recently'),
+}));
+
+jest.mock('@/shared/stores/global/settingsStore', () => {
+  const state = {
+    language: 'en',
+    avatarFallbackVariant: 'beam',
+    getDisplayBtc: () => 'sats',
+  };
+  const useSettingsStore = Object.assign(
+    jest.fn((selector?: (value: typeof state) => unknown) => (selector ? selector(state) : state)),
+    {
+      getState: () => state,
+      subscribe: jest.fn(() => jest.fn()),
+    }
+  );
+
+  return { useSettingsStore };
+});
+
+jest.mock('@/shared/ui/composed/ListRow', () => {
+  const ReactActual = jest.requireActual<typeof import('react')>('react');
+  const { View } = jest.requireActual<typeof import('react-native')>('react-native');
+
+  return {
+    __esModule: true,
+    ListRow: jest.fn((props: Record<string, unknown>) =>
+      ReactActual.createElement(View, { testID: 'list-row', ...props })
+    ),
+  };
+});
+
+jest.mock('@/shared/ui/composed/MintIcon', () => ({
+  MintIcon: () => null,
+}));
+
+jest.mock('@/shared/ui/primitives/Avatar', () => {
+  const ReactActual = jest.requireActual<typeof import('react')>('react');
+  const { View } = jest.requireActual<typeof import('react-native')>('react-native');
+
+  return {
+    __esModule: true,
+    Avatar: (props: Record<string, unknown>) =>
+      ReactActual.createElement(View, { testID: 'avatar', ...props }),
+  };
+});
+
+jest.mock('@/shared/ui/primitives/Text', () => {
+  const ReactActual = jest.requireActual<typeof import('react')>('react');
+  const { Text } = jest.requireActual<typeof import('react-native')>('react-native');
+
+  return {
+    __esModule: true,
+    Text: ({ children, ...props }: { children?: React.ReactNode }) =>
+      ReactActual.createElement(Text, props, children),
+  };
+});
+
+jest.mock('@/shared/ui/primitives/Pressable', () => {
+  const ReactActual = jest.requireActual<typeof import('react')>('react');
+  const { View } = jest.requireActual<typeof import('react-native')>('react-native');
+
+  return {
+    __esModule: true,
+    Pressable: ({ children, ...props }: { children?: React.ReactNode }) =>
+      ReactActual.createElement(View, props, children),
+  };
+});
+
+jest.mock('@/shared/ui/primitives/Spinner', () => ({
+  Spinner: () => null,
+}));
+
+jest.mock('@/shared/ui/primitives/View/HStack', () => {
+  const ReactActual = jest.requireActual<typeof import('react')>('react');
+  const { View } = jest.requireActual<typeof import('react-native')>('react-native');
+
+  return {
+    __esModule: true,
+    HStack: ({ children, ...props }: { children?: React.ReactNode }) =>
+      ReactActual.createElement(View, props, children),
+  };
+});
+
+jest.mock('@/shared/ui/primitives/View/View', () => {
+  const { View } = jest.requireActual<typeof import('react-native')>('react-native');
+
+  return {
+    __esModule: true,
+    View,
+  };
+});
+
+// Identifiable stand-ins so we can assert which selection/accent node ContactRow
+// hands to ListRow without rendering their internals.
+jest.mock('@/shared/ui/primitives/SelectableCheck', () => ({
+  SelectableCheck: function SelectableCheck() {
+    return null;
+  },
+}));
+
+jest.mock('@/shared/ui/composed/AmountFormatter', () => ({
+  AmountFormatter: () => null,
+}));
+
+jest.mock('@/shared/ui/composed/RowStatsAccent', () => ({
+  RowStatsAccent: function RowStatsAccent() {
+    return null;
+  },
+  RowStatsAccentSkeleton: function RowStatsAccentSkeleton() {
+    return null;
+  },
+  STAT_ICONS: {
+    score: 'score',
+    audit: 'audit',
+    reputation: 'reputation',
+    followers: 'followers',
+    offline: 'offline',
+  },
+  STAT_COLOR_SOCIAL: 'social',
+  STAT_COLOR_ERROR: 'error',
+}));
+
+jest.mock(
+  'assets/icons',
+  () => ({
+    __esModule: true,
+    default: ({ name, ...props }: { name: string }) => {
+      const ReactActual = jest.requireActual<typeof import('react')>('react');
+      const { View } = jest.requireActual<typeof import('react-native')>('react-native');
+      return ReactActual.createElement(View, { testID: `icon-${name}`, ...props });
+    },
+  }),
+  { virtual: true }
+);
+
+let consoleErrorSpy: jest.SpyInstance;
+let consoleWarnSpy: jest.SpyInstance;
+
+function renderRow(element: React.ReactElement) {
+  let renderer: TestRenderer.ReactTestRenderer;
+  act(() => {
+    renderer = TestRenderer.create(element);
+  });
+  const listRowProps = jest.mocked(ListRow).mock.calls[0]?.[0];
+  act(() => {
+    renderer.unmount();
+  });
+  return listRowProps;
+}
+
+describe('ContactRow loading reservation', () => {
+  beforeEach(() => {
+    jest.mocked(ListRow).mockClear();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      if (String(args[0]).includes('react-test-renderer is deprecated')) return;
+      throw new Error(`Unexpected console.error: ${args.map(String).join(' ')}`);
+    });
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+      if (String(args[0]).includes('props.pointerEvents is deprecated')) return;
+      throw new Error(`Unexpected console.warn: ${args.map(String).join(' ')}`);
+    });
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('reserves the stats accent and an inert 24px checkbox while a mint row loads', () => {
+    const listRowProps = renderRow(
+      <ContactRow
+        loading
+        identity={mintIdentity({
+          mintUrl: 'https://mint.example.com',
+          displayName: 'Example Mint',
+        })}
+        subtitle="mint.example.com"
+        selectable
+        selectionVariant="checkbox"
+        disabled
+      />
+    );
+
+    // Accent reserved: the skeleton placeholder, not the real (null) accent.
+    expect(listRowProps?.accent).toBeTruthy();
+    expect((listRowProps?.accent as React.ReactElement).type).toBe(RowStatsAccentSkeleton);
+
+    // Checkbox reserved as an inert 24x24 box (no live SelectableCheck flash).
+    const trailing = listRowProps?.trailing as React.ReactElement<{ style?: unknown }>;
+    expect(trailing.type).not.toBe(SelectableCheck);
+    expect(trailing.props.style).toEqual({ width: 24, height: 24 });
+
+    expect(listRowProps?.loading).toBe(true);
+  });
+
+  it('does NOT reserve the accent for a loading nostr (non-mint) row', () => {
+    const listRowProps = renderRow(
+      <ContactRow loading identity={nostrIdentity('pubkey-loading', undefined)} />
+    );
+
+    // Gate proof: nostr rows route to the real RowStatsAccent (which renders
+    // nothing when there are no stats), so contact skeletons keep their height.
+    expect((listRowProps?.accent as React.ReactElement).type).toBe(RowStatsAccent);
+    expect(listRowProps?.loading).toBe(true);
+  });
+
+  it('renders the live checkbox and real accent once a selectable mint row is loaded', () => {
+    const listRowProps = renderRow(
+      <ContactRow
+        identity={mintIdentity({
+          mintUrl: 'https://mint.example.com',
+          displayName: 'Example Mint',
+          stats: { kymScore: 4.5, reviewCount: 12 },
+        })}
+        subtitle="mint.example.com"
+        selectable
+        selectionVariant="checkbox"
+      />
+    );
+
+    expect((listRowProps?.accent as React.ReactElement).type).toBe(RowStatsAccent);
+    expect((listRowProps?.trailing as React.ReactElement).type).toBe(SelectableCheck);
+    expect(listRowProps?.loading).toBeFalsy();
+  });
+});

--- a/features/mint/screens/MintAddScreen.tsx
+++ b/features/mint/screens/MintAddScreen.tsx
@@ -9,7 +9,6 @@ import {
 import { useSharedValue } from 'react-native-reanimated';
 import { Stack } from 'expo-router';
 import { guardedRouter as router } from '@/shared/hooks/useGuardedRouter';
-import { VStack } from '@/shared/ui/primitives/View/VStack';
 import { View } from '@/shared/ui/primitives/View/View';
 import { Spacer } from '@/shared/ui/primitives/View/Spacer';
 import { Text } from '@/shared/ui/primitives/Text';
@@ -32,7 +31,6 @@ import { staticPopup, paramPopup } from '@/shared/lib/popup';
 import { BottomButtons } from '@/shared/ui/composed/BottomButtons';
 import { ButtonHandler } from '@/shared/ui/composed/ButtonHandler';
 import { ContactRow, mintIdentity } from '@/shared/ui/composed/ContactRow';
-import { Skeleton } from '@/shared/ui/primitives/Skeleton';
 import { List } from '@/shared/ui/composed/List';
 import { Screen } from '@/shared/ui/composed/Screen';
 import { LoadingIndicator } from '@/shared/blocks/status';
@@ -63,6 +61,26 @@ interface PseudoMint {
   name?: string;
 }
 
+/**
+ * Placeholder fed to the result `List` while the first search is in flight. It
+ * flows through the same `MintItem` → `ContactRow` path as real rows (in loading
+ * mode), so the skeleton can't drift from real-row height. The `url` is a stable
+ * synthetic key that also seeds the deterministic placeholder widths.
+ */
+interface SkeletonMint {
+  url: string;
+  isSkeleton: true;
+}
+
+const noop = () => {};
+
+/** Stable placeholder rows for the initial-search loading state. Fixed identity
+ *  so FlashList keys are stable and each row's seeded placeholder width holds. */
+const SKELETON_MINTS: SkeletonMint[] = Array.from({ length: 5 }, (_, i) => ({
+  url: `skeleton-${i}`,
+  isSkeleton: true,
+}));
+
 interface DisplayMint {
   url: string;
   name: string;
@@ -85,7 +103,7 @@ interface DisplayMint {
   reviewCount?: number;
 }
 
-type SearchableMint = DisplayMint | PseudoMint;
+type SearchableMint = DisplayMint | PseudoMint | SkeletonMint;
 
 function adaptSearchResult(result: MintSearchResult): DisplayMint {
   const profile = useMintProfileStore.getState().getCached(result.url);
@@ -202,88 +220,29 @@ const FallbackSearchHeader = memo(function FallbackSearchHeader({
   );
 });
 
-// Loading skeleton
-const LoadingMintsList = memo(function LoadingMintsList({ count = 5 }: { count?: number }) {
-  return (
-    <VStack spacing={0}>
-      {Array.from({ length: count }).map((_, index) => (
-        <View key={index} className="bg-surface mb-1 rounded-2xl p-4">
-          <VStack gap={12}>
-            <View className="flex-row items-center gap-3">
-              <Skeleton
-                className="bg-surface-tertiary h-[42px] w-[42px]"
-                style={{ borderRadius: 42 * 0.25 }}
-                visualScope="mint.add.loading"
-                visualKey={`avatar:${index}`}
-                visualSurface="mint"
-                visualComponent="MintAddLoadingSkeleton"
-                visualExtra={{ rowIndex: index, part: 'avatar' }}
-              />
-              <VStack flex={1} gap={8}>
-                <Skeleton
-                  className="bg-surface-tertiary h-[16px]"
-                  style={{ width: 150 }}
-                  visualScope="mint.add.loading"
-                  visualKey={`name:${index}`}
-                  visualSurface="mint"
-                  visualComponent="MintAddLoadingSkeleton"
-                  visualExtra={{ rowIndex: index, part: 'name' }}
-                />
-                <Skeleton
-                  className="bg-surface-tertiary h-[20px] rounded-full"
-                  style={{ width: 80 }}
-                  visualScope="mint.add.loading"
-                  visualKey={`badge:${index}`}
-                  visualSurface="mint"
-                  visualComponent="MintAddLoadingSkeleton"
-                  visualExtra={{ rowIndex: index, part: 'badge' }}
-                />
-              </VStack>
-            </View>
-            <View className="flex-row gap-2">
-              <Skeleton
-                className="bg-surface-tertiary h-[24px] rounded-full"
-                style={{ width: 56 }}
-                visualScope="mint.add.loading"
-                visualKey={`metric-a:${index}`}
-                visualSurface="mint"
-                visualComponent="MintAddLoadingSkeleton"
-                visualExtra={{ rowIndex: index, part: 'metric-a' }}
-              />
-              <Skeleton
-                className="bg-surface-tertiary h-[24px] rounded-full"
-                style={{ width: 60 }}
-                visualScope="mint.add.loading"
-                visualKey={`metric-b:${index}`}
-                visualSurface="mint"
-                visualComponent="MintAddLoadingSkeleton"
-                visualExtra={{ rowIndex: index, part: 'metric-b' }}
-              />
-            </View>
-          </VStack>
-        </View>
-      ))}
-    </VStack>
-  );
-});
-
 // Pre-baked mint row — deferred to the shared `ContactRow` so search results
 // here visually match the mint list, contacts tab, and split-bill picker.
+//
+// `loading` renders the row in skeleton mode through the SAME `ContactRow`, so
+// the loading placeholder and the real row share every layout box (avatar,
+// title, subtitle, stats accent, checkbox) and can't drift in height. The mint
+// fields are read defensively because skeleton items carry only a synthetic
+// `url`; their values are never shown (loading swaps in placeholder bars).
 const MintItem = memo(function MintItem({
   mint,
   selected,
   onToggle,
   globalLoading,
+  loading,
 }: {
   mint: SearchableMint;
   selected: boolean;
   onToggle: (url: string) => void;
   globalLoading: boolean;
+  loading?: boolean;
 }) {
-  const displayName = useMemo(
-    () => getMintDisplayName(mint.url, mint.mintInfo),
-    [mint.url, mint.mintInfo]
-  );
+  const mintInfo = 'mintInfo' in mint ? mint.mintInfo : undefined;
+  const displayName = useMemo(() => getMintDisplayName(mint.url, mintInfo), [mint.url, mintInfo]);
 
   // Search-result preview only: the search endpoint returns `serverStats`
   // (`n_mints`/`n_melts`/`n_errors`) without the per-swap array, so we can't
@@ -307,10 +266,11 @@ const MintItem = memo(function MintItem({
 
   return (
     <ContactRow
+      loading={loading}
       identity={mintIdentity({
         mintUrl: mint.url,
         displayName,
-        iconUrl: mint.mintInfo?.icon_url ?? undefined,
+        iconUrl: mintInfo?.icon_url ?? undefined,
         stats: {
           kymScore:
             'reviewScore' in mint && typeof mint.reviewScore === 'number'
@@ -333,7 +293,7 @@ const MintItem = memo(function MintItem({
       onToggle={() => onToggle(mint.url)}
       selectionVariant="checkbox"
       disabled={globalLoading}
-      testID={`contact-row:mint:${mint.url}`}
+      testID={loading ? `contact-row:mint-skeleton:${mint.url}` : `contact-row:mint:${mint.url}`}
     />
   );
 });
@@ -469,7 +429,8 @@ export function MintAddScreen() {
   // pubkey in NUT-06 contact info. Results land in `useMintProfileStore`
   // and the memo above re-runs once they arrive.
   const profileFetchInputs = useMemo(
-    () => displayMints.map((m) => ({ url: m.url, mintInfo: m.mintInfo })),
+    () =>
+      displayMints.map((m) => ({ url: m.url, mintInfo: 'mintInfo' in m ? m.mintInfo : undefined })),
     [displayMints]
   );
   useMintProfiles(profileFetchInputs);
@@ -614,15 +575,28 @@ export function MintAddScreen() {
   const keyExtractor = useCallback((item: SearchableMint) => item.url, []);
   const showContent = !searchLoading || displayMints.length > 0;
 
+  // Feed the result List skeleton placeholders during the first search so the
+  // loading rows render through the SAME List + ContactRow path as real rows —
+  // identical container chrome, no content shift on the data swap.
+  const isInitialLoading = searchLoading && displayMints.length === 0;
+  const listData: SearchableMint[] = isInitialLoading ? SKELETON_MINTS : displayMints;
+  const getItemType = useCallback(
+    (item: SearchableMint) => ('isSkeleton' in item ? 'skeleton' : 'mint'),
+    []
+  );
+
   const renderItem = useCallback(
-    ({ item }: { item: SearchableMint }) => (
-      <MintItem
-        mint={item}
-        selected={selectedMints.has(item.url)}
-        onToggle={handleToggleMint}
-        globalLoading={isAdding}
-      />
-    ),
+    ({ item }: { item: SearchableMint }) =>
+      'isSkeleton' in item ? (
+        <MintItem mint={item} selected={false} onToggle={noop} globalLoading loading />
+      ) : (
+        <MintItem
+          mint={item}
+          selected={selectedMints.has(item.url)}
+          onToggle={handleToggleMint}
+          globalLoading={isAdding}
+        />
+      ),
     [handleToggleMint, isAdding, selectedMints]
   );
 
@@ -786,25 +760,21 @@ export function MintAddScreen() {
       deferContent={false}>
       <Stack.Screen options={screenOptions} />
       <Spacer size={16} />
-      {!showContent ? (
-        <View className="flex-1 px-4" style={{ paddingTop: totalHeaderHeight }}>
-          <LoadingMintsList />
-        </View>
-      ) : (
-        <List
-          data={displayMints}
-          renderItem={renderItem}
-          keyExtractor={keyExtractor}
-          extraData={selectedMints}
-          drawDistance={300}
-          style={{ flex: 1, height: 0 }}
-          contentContainerStyle={{ paddingBottom: 120 }}
-          ListHeaderComponent={listHeader}
-          ListEmptyComponent={emptyComponent}
-          onScroll={handleScroll}
-          scrollEventThrottle={16}
-        />
-      )}
+      <List
+        data={listData}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        getItemType={getItemType}
+        extraData={selectedMints}
+        drawDistance={300}
+        style={{ flex: 1, height: 0 }}
+        contentContainerStyle={{ paddingBottom: 120 }}
+        ListHeaderComponent={listHeader}
+        // Skeleton data is non-empty, so the empty state can't flash mid-load.
+        ListEmptyComponent={isInitialLoading ? undefined : emptyComponent}
+        onScroll={handleScroll}
+        scrollEventThrottle={16}
+      />
     </Screen>
   );
 }

--- a/shared/ui/composed/ContactRow.tsx
+++ b/shared/ui/composed/ContactRow.tsx
@@ -35,6 +35,7 @@ import { AmountFormatter } from '@/shared/ui/composed/AmountFormatter';
 import { MintIcon } from '@/shared/ui/composed/MintIcon';
 import {
   RowStatsAccent,
+  RowStatsAccentSkeleton,
   STAT_ICONS,
   STAT_COLOR_SOCIAL,
   STAT_COLOR_ERROR,
@@ -776,26 +777,47 @@ export function ContactRow({
   const statList: RowStat[] =
     hideMetadata || resolvedLoading ? [] : buildStats(identities, statKeys, { warning, success });
 
+  // While loading, a row that will show an inline stats accent once loaded must
+  // reserve that line's height or the row grows when the pills arrive. Gate to
+  // mint rows (which reliably show a score/audit pill) and callers that asked
+  // for explicit stats — nostr rows often have no accent, so reserving theirs
+  // would over-shoot and shift the other way. Plain contact/ble/geohash
+  // skeletons are unaffected.
+  const reserveAccent =
+    resolvedLoading &&
+    !hideMetadata &&
+    (!!mint || (statsOverride != null && statsOverride.length > 0));
+
   const nip05 =
     showNip05 && !hideMetadata && !resolvedLoading && nostr?.profile?.nip05
       ? { handle: nostr.profile.nip05 }
       : undefined;
   const hasNip05 = !!nip05;
 
-  const accentNode = <RowStatsAccent stats={statList} note={disabledReason} nip05={nip05} />;
+  const accentNode = reserveAccent ? (
+    <RowStatsAccentSkeleton seed={seed} />
+  ) : (
+    <RowStatsAccent stats={statList} note={disabledReason} nip05={nip05} />
+  );
 
   // ---- Trailing ---------------------------------------------------------
 
   const chevronNode = <Icon name="mdi:chevron-right" size={24} color={opacity(foreground, 0.25)} />;
 
   const selectionNode = selectable ? (
-    <SelectableCheck
-      style={selectionVariant === 'checkbox' ? 'square' : 'circle'}
-      selected={selected ?? false}
-      onChange={selectionVariant === 'checkbox' ? () => onToggle?.() : undefined}
-      size={24}
-      variant="success"
-    />
+    resolvedLoading ? (
+      // Reserve the control's exact 24px slot while loading without flashing an
+      // interactive checkbox (mirrors PostCardGutterHeader's empty-box approach).
+      <View style={{ width: 24, height: 24 }} />
+    ) : (
+      <SelectableCheck
+        style={selectionVariant === 'checkbox' ? 'square' : 'circle'}
+        selected={selected ?? false}
+        onChange={selectionVariant === 'checkbox' ? () => onToggle?.() : undefined}
+        size={24}
+        variant="success"
+      />
+    )
   ) : null;
 
   const logMintInteraction = (

--- a/shared/ui/composed/RowStatsAccent.tsx
+++ b/shared/ui/composed/RowStatsAccent.tsx
@@ -28,6 +28,7 @@ import opacity from 'hex-color-opacity';
 import Icon from 'assets/icons';
 import { Text } from '@/shared/ui/primitives/Text';
 import { HStack } from '@/shared/ui/primitives/View/HStack';
+import { Skeleton } from '@/shared/ui/primitives/Skeleton';
 import { useThemeColor } from '@/shared/hooks/useThemeColor';
 
 /** Canonical iconify glyphs for row-accent stats. Use these names so a star
@@ -159,5 +160,33 @@ export function RowStatsAccent({ stats, note, noteColor, nip05 }: RowStatsAccent
         </Text>
       ) : null}
     </>
+  );
+}
+
+/**
+ * Loading placeholder for the accent line. Rendered by `ContactRow` while a
+ * stats-bearing row (e.g. a mint result) is loading, so the accent's height is
+ * reserved and the row doesn't grow when the real `RowStatsAccent` pills arrive.
+ *
+ * Co-located with `RowStatsAccent` so the geometry stays in one file: the same
+ * outer `HStack` (`gap: 4, marginTop: 2`) wraps two pill placeholders sized like
+ * the real `★ 4.5` / `85%` stats (12px icon + 12px text ≈ a 14px bar).
+ */
+export function RowStatsAccentSkeleton({ seed }: { seed?: string }) {
+  return (
+    <HStack align="center" style={{ gap: 4, marginTop: 2 }}>
+      <Skeleton
+        className="bg-skeleton rounded-full"
+        style={{ width: 44, height: 14 }}
+        visualKey={`accent:${seed ?? 'x'}`}
+        visualComponent="RowStatsAccentSkeleton"
+      />
+      <Skeleton
+        className="bg-skeleton rounded-full"
+        style={{ width: 52, height: 14 }}
+        visualKey={`accent2:${seed ?? 'x'}`}
+        visualComponent="RowStatsAccentSkeleton"
+      />
+    </HStack>
   );
 }

--- a/shared/ui/composed/RowStatsAccent.tsx
+++ b/shared/ui/composed/RowStatsAccent.tsx
@@ -168,25 +168,27 @@ export function RowStatsAccent({ stats, note, noteColor, nip05 }: RowStatsAccent
  * stats-bearing row (e.g. a mint result) is loading, so the accent's height is
  * reserved and the row doesn't grow when the real `RowStatsAccent` pills arrive.
  *
- * Co-located with `RowStatsAccent` so the geometry stays in one file: the same
- * outer `HStack` (`gap: 4, marginTop: 2`) wraps two pill placeholders sized like
- * the real `★ 4.5` / `85%` stats (12px icon + 12px text ≈ a 14px bar).
+ * Co-located with `RowStatsAccent` so the geometry can't drift: it mirrors the
+ * real pill's structure exactly — the same outer `HStack` (`gap: 4, marginTop:
+ * 2`) and per-pill `HStack` (`gap: 3`) of a 12px icon box + a `Text` at the
+ * same `size`/`bold`. The `Text loading` bar self-sizes to the real 12px line
+ * box, so the accent line is the same height whether loading or loaded (a fixed
+ * pixel bar previously under-shot the text line height by a couple of pixels).
  */
 export function RowStatsAccentSkeleton({ seed }: { seed?: string }) {
   return (
     <HStack align="center" style={{ gap: 4, marginTop: 2 }}>
-      <Skeleton
-        className="bg-skeleton rounded-full"
-        style={{ width: 44, height: 14 }}
-        visualKey={`accent:${seed ?? 'x'}`}
-        visualComponent="RowStatsAccentSkeleton"
-      />
-      <Skeleton
-        className="bg-skeleton rounded-full"
-        style={{ width: 52, height: 14 }}
-        visualKey={`accent2:${seed ?? 'x'}`}
-        visualComponent="RowStatsAccentSkeleton"
-      />
+      {[`accent:${seed ?? 'x'}`, `accent2:${seed ?? 'x'}`].map((key, i) => (
+        <HStack key={key} align="center" style={{ gap: 3 }}>
+          <Skeleton
+            className="bg-skeleton rounded-full"
+            style={{ width: 12, height: 12 }}
+            visualKey={key}
+            visualComponent="RowStatsAccentSkeleton"
+          />
+          <Text size={12} bold loading placeholder={i === 0 ? '4.5' : '98%'} />
+        </HStack>
+      ))}
     </HStack>
   );
 }


### PR DESCRIPTION
## Why

The **Add Mints** search (`features/mint/screens/MintAddScreen.tsx`) showed a loading skeleton that looked nothing like the real result row, and the height difference made content jump when search data arrived. The skeleton was a **hand-rolled** `LoadingMintsList` that had drifted from the real `MintItem` → `ContactRow` row: a `rounded-2xl` card the real row doesn't have, avatar 42 vs 44, padding 16 vs 20h/12v, and missing the domain subtitle, the inline stats accent, and the checkbox.

This is the drift-from-duplicated-chrome anti-pattern. The fix follows the established **"share the chrome"** convention (`PostCardGutterHeader`): render skeleton and real states from the **same component** so heights can't diverge.

## What

- **MintAddScreen** — delete `LoadingMintsList`; feed the result `List` skeleton placeholders during the initial search and render them through the same `MintItem` → `ContactRow` path in loading mode. One `List`, so the header spacer / padding / container chrome are shared for free. `getItemType` keeps skeleton and real rows in separate recycle pools.
- **ContactRow** — close the one real height gap in its loading state: reserve the inline **stats accent** (gated to mint / explicit-stats rows, so contact/ble/geohash skeletons are untouched) and render an inert **24px box** for the checkbox slot instead of flashing a live control.
- **RowStatsAccent** — add a co-located `RowStatsAccentSkeleton` so the accent's geometry lives in one file and can't drift between loading and loaded.
- **Tests** — new `__tests__/contactRowLoadingReservation.test.tsx`: accent reserved for loading mint rows, **not** for loading nostr rows (gate proof), and the inert-checkbox/live-checkbox swap.

## Height parity

Every height-contributing element of the real row is now reserved at the same dimensions by the same component (avatar 44, title bar, subtitle bar, accent pill row, 24px checkbox). The only previously-lost contributor was the accent; it's now reserved.

## Notes

- **Base branch:** stacks on `spike/flashlist-v2-thread` (PR #227 / FlashList), which is where the screen uses the shared `<List>` seam. Merge after #227.
- **Blast radius:** the ContactRow change is gated — accent reservation fires only for mint/explicit-stats rows, the inert checkbox only for `selectable + loading`. No-op for plain contact skeletons; `SearchResultRows` is unaffected.
- **Device verification pending:** confirm zero `.shift.` events on the load→data swap and tune the skeleton pill height to the measured real-accent height via `npx tsx codereview/log-doctor/index.ts timeline --event 'visual\.layout|\.shift\.' --latest`.

## Gates

`tsc` clean · eslint 0 errors on changed files · `npx jest contactRow` 4/4 pass · knip flags no new dead exports.