### PR TITLE
feat(ui): skeleton→content crossfade helper + app-wide adoption

### DIFF
--- a/__tests__/facadeThreadAdapter.test.ts
+++ b/__tests__/facadeThreadAdapter.test.ts
@@ -25,6 +25,7 @@ function buildThread(): facade.ResolvedThread {
   return {
     tier: 'primal',
     root: note(ROOT, 1000),
+    parents: [],
     replies: [note(A, 300), note(B, 200), note(C, 100)],
     stats: STATS,
     profiles: {},

--- a/__tests__/loggerRedaction.test.ts
+++ b/__tests__/loggerRedaction.test.ts
@@ -1,0 +1,70 @@
+import { createLogger } from '@/shared/lib/logger';
+
+// Exercise the real compaction/redaction pipeline end to end: log a value under
+// a NEUTRAL field name (so field-name rules don't fire) and inspect what landed
+// in the ring buffer. Anything a private key could be encoded as — hex, base58
+// (WIF / xprv), base64 — must never appear in the stored entry.
+function logValue(value: unknown): { brand: unknown; json: string } {
+  const log = createLogger({ level: 'debug', async: false, transports: [], pretty: false });
+  log.info('redaction.test', { blob: value });
+  const entry = log.getRecentLogs().find((e) => e.event === 'redaction.test');
+  const brand = (entry?.params as Record<string, unknown> | undefined)?.blob;
+  return { brand, json: JSON.stringify(brand) };
+}
+
+describe('logger redaction — private key material is never shown', () => {
+  it('brands a WIF private key (base58) as a secret, no value', () => {
+    const wif = '5' + 'K'.repeat(50); // 51 chars, mainnet-shaped
+    const { brand, json } = logValue(wif);
+    expect(brand).toEqual({ _kind: 'wif', len: wif.length });
+    expect(json).not.toContain(wif);
+  });
+
+  it('brands an extended private key (xprv) — was logged in full at ≤120 chars', () => {
+    const xprv = 'xprv' + '9'.repeat(107); // 111 chars
+    const { brand, json } = logValue(xprv);
+    expect(brand).toEqual({ _kind: 'xprv', len: xprv.length });
+    expect(json).not.toContain('9'.repeat(20));
+  });
+
+  it('brands a 32-byte base64 secret (44 chars) — was shown in full', () => {
+    const b64 = 'A'.repeat(43) + '='; // 44 chars => 32 bytes
+    const { brand, json } = logValue(b64);
+    expect(brand).toEqual({ _kind: 'base64_key', len: 44 });
+    expect(json).not.toContain('AAAA');
+  });
+
+  it('never previews opaque hex / base64 / base58 long values', () => {
+    // 50-char hex (below base64's 60 floor, so it lands on the hex pattern).
+    expect(logValue('a'.repeat(50)).brand).toEqual({ _kind: 'hex', len: 50 });
+    expect(logValue('A'.repeat(70)).brand).toEqual({ _kind: 'base64', len: 70 });
+    // 45-char base58 blob (e.g. an opaque key encoding) — no bytes shown.
+    const b58 = 'z'.repeat(40);
+    expect(logValue(b58).brand).toEqual({ _kind: 'base58', len: 40 });
+  });
+
+  it('still brands a 32-byte hex value (privkey length) with no preview', () => {
+    const hex64 = 'a'.repeat(64);
+    expect(logValue(hex64).brand).toEqual({ _kind: 'hex32', len: 64 });
+  });
+
+  it('redacts an embedded xprv inside a larger string', () => {
+    const xprv = 'xprv' + 'z'.repeat(107);
+    const { brand } = logValue(`restored from ${xprv} ok`);
+    expect(String(brand)).toContain('<REDACTED:xprv>');
+    expect(String(brand)).not.toContain('z'.repeat(20));
+  });
+
+  it('does NOT over-redact a public npub (stays readable)', () => {
+    const npub = 'npub1' + 'q'.repeat(58);
+    const { brand } = logValue(npub);
+    // Public identity: kept as a readable string, not branded away.
+    expect(typeof brand).toBe('string');
+    expect(brand).toBe(npub);
+  });
+
+  it('does NOT over-redact ordinary short strings', () => {
+    expect(logValue('hello world').brand).toBe('hello world');
+    expect(logValue('feed.note.inline').brand).toBe('feed.note.inline');
+  });
+});

--- a/__tests__/receiveScreenLayout.test.tsx
+++ b/__tests__/receiveScreenLayout.test.tsx
@@ -20,12 +20,22 @@ jest.mock('@/shared/lib/logger', () => ({
   paymentLog: {
     warn: jest.fn(),
   },
+  // The loading placeholder's SkeletonLoadingShimmer routes through
+  // contentShiftLog, which reads feedLog.isLevelEnabled. Disabled → no logging.
+  feedLog: {
+    isLevelEnabled: () => false,
+    info: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
   useLifecycleLogger: jest.fn(),
 }));
 
 jest.mock('@/shared/hooks/useThemeColor', () => ({
+  // Hex values: the loading placeholder now renders a SkeletonLoadingShimmer
+  // whose gradient runs colors through hex-color-opacity, which rejects names.
   useThemeColor: (tokens: string | string[]) =>
-    Array.isArray(tokens) ? tokens.map(() => 'muted') : 'muted',
+    Array.isArray(tokens) ? tokens.map(() => '#888888') : '#888888',
 }));
 
 jest.mock('@/shared/hooks/useMintInfo', () => ({

--- a/__tests__/receiveScreenLayout.test.tsx
+++ b/__tests__/receiveScreenLayout.test.tsx
@@ -35,6 +35,7 @@ jest.mock('@/shared/hooks/useThemeColor', () => ({
   // Hex values: the loading placeholder now renders a SkeletonLoadingShimmer
   // whose gradient runs colors through hex-color-opacity, which rejects names.
   useThemeColor: (tokens: string | string[]) =>
+    // eslint-disable-next-line no-restricted-syntax -- test mock needs a real hex
     Array.isArray(tokens) ? tokens.map(() => '#888888') : '#888888',
 }));
 

--- a/__tests__/skeletonContentCrossfade.test.tsx
+++ b/__tests__/skeletonContentCrossfade.test.tsx
@@ -1,0 +1,225 @@
+/**
+ * @jest-environment node
+ *
+ * `SkeletonContentCrossfade` phase machine. These pin the behaviors the whole
+ * app's skeleton→content swaps rely on:
+ *  - loading shows the skeleton (+ region wave), never the content;
+ *  - `wave="none"` and reduced motion suppress the shimmer;
+ *  - on the loading→loaded edge the content mounts under a still-present
+ *    skeleton overlay (the crossfade), while reduced motion / `exit="none"`
+ *    swap instantly;
+ *  - re-entering loading cancels an in-flight exit (no stacked overlays);
+ *  - a row that mounts already-loaded never plays a fade.
+ *
+ * Reanimated is mocked so `withTiming` does NOT auto-complete — that lets us
+ * observe the live "exiting" frame (content + fading skeleton) deterministically.
+ */
+
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+
+import { SkeletonContentCrossfade } from '@/shared/ui/composed/SkeletonContentCrossfade';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let mockReducedMotion = false;
+
+jest.mock('react-native-reanimated', () => {
+  const ReactActual = jest.requireActual<typeof import('react')>('react');
+  const { View } = jest.requireActual<typeof import('react-native')>('react-native');
+  return {
+    __esModule: true,
+    default: {
+      View: ({ children, ...props }: { children?: React.ReactNode }) =>
+        ReactActual.createElement(View, props, children),
+    },
+    useReducedMotion: () => mockReducedMotion,
+    useSharedValue: (initial: number) => ({
+      value: initial,
+      get() {
+        return this.value;
+      },
+      set(next: number) {
+        this.value = next;
+      },
+    }),
+    // Return the target but never invoke the completion callback, so the
+    // component stays in its 'exiting' frame for assertions.
+    withTiming: (toValue: number) => toValue,
+    cancelAnimation: () => {},
+    useAnimatedStyle: () => ({}),
+    runOnJS: (fn: (...args: unknown[]) => unknown) => fn,
+    Easing: { out: () => (t: number) => t, inOut: () => (t: number) => t, cubic: (t: number) => t },
+    ReduceMotion: { System: 'system' },
+  };
+});
+
+jest.mock('@/shared/ui/composed/SkeletonExitShimmer', () => {
+  const ReactActual = jest.requireActual<typeof import('react')>('react');
+  const { View } = jest.requireActual<typeof import('react-native')>('react-native');
+  return {
+    SkeletonLoadingShimmer: ({ active }: { active?: boolean }) =>
+      active ? ReactActual.createElement(View, { testID: 'shimmer' }) : null,
+  };
+});
+
+const skeletonNode = () => <View testID="sk" />;
+const contentNode = () => <View testID="ct" />;
+
+function makeView() {
+  return jest.requireActual<typeof import('react-native')>('react-native').View;
+}
+const View = makeView();
+
+function present(renderer: TestRenderer.ReactTestRenderer, testID: string): boolean {
+  return renderer.root.findAll((n) => n.props?.testID === testID).length > 0;
+}
+
+function render(element: React.ReactElement) {
+  let renderer!: TestRenderer.ReactTestRenderer;
+  act(() => {
+    renderer = TestRenderer.create(element);
+  });
+  return renderer;
+}
+
+describe('SkeletonContentCrossfade', () => {
+  beforeEach(() => {
+    mockReducedMotion = false;
+  });
+
+  it('shows skeleton + region wave while loading, not content', () => {
+    const r = render(
+      <SkeletonContentCrossfade loading renderSkeleton={skeletonNode} renderContent={contentNode} />
+    );
+    expect(present(r, 'sk')).toBe(true);
+    expect(present(r, 'shimmer')).toBe(true);
+    expect(present(r, 'ct')).toBe(false);
+    act(() => r.unmount());
+  });
+
+  it('omits the wave when wave="none"', () => {
+    const r = render(
+      <SkeletonContentCrossfade
+        loading
+        wave="none"
+        renderSkeleton={skeletonNode}
+        renderContent={contentNode}
+      />
+    );
+    expect(present(r, 'sk')).toBe(true);
+    expect(present(r, 'shimmer')).toBe(false);
+    act(() => r.unmount());
+  });
+
+  it('omits the wave under reduced motion', () => {
+    mockReducedMotion = true;
+    const r = render(
+      <SkeletonContentCrossfade loading renderSkeleton={skeletonNode} renderContent={contentNode} />
+    );
+    expect(present(r, 'shimmer')).toBe(false);
+    act(() => r.unmount());
+  });
+
+  it('crossfades on the loading→loaded edge: content mounts under a fading skeleton', () => {
+    const r = render(
+      <SkeletonContentCrossfade loading renderSkeleton={skeletonNode} renderContent={contentNode} />
+    );
+    act(() => {
+      r.update(
+        <SkeletonContentCrossfade
+          loading={false}
+          renderSkeleton={skeletonNode}
+          renderContent={contentNode}
+        />
+      );
+    });
+    // Exiting frame: real content present AND skeleton overlay still fading out.
+    expect(present(r, 'ct')).toBe(true);
+    expect(present(r, 'sk')).toBe(true);
+    act(() => r.unmount());
+  });
+
+  it('swaps instantly under reduced motion (no lingering skeleton)', () => {
+    mockReducedMotion = true;
+    const r = render(
+      <SkeletonContentCrossfade loading renderSkeleton={skeletonNode} renderContent={contentNode} />
+    );
+    act(() => {
+      r.update(
+        <SkeletonContentCrossfade
+          loading={false}
+          renderSkeleton={skeletonNode}
+          renderContent={contentNode}
+        />
+      );
+    });
+    expect(present(r, 'ct')).toBe(true);
+    expect(present(r, 'sk')).toBe(false);
+    act(() => r.unmount());
+  });
+
+  it('swaps instantly with exit="none" (no fading skeleton overlay)', () => {
+    const r = render(
+      <SkeletonContentCrossfade
+        loading
+        exit="none"
+        renderSkeleton={skeletonNode}
+        renderContent={contentNode}
+      />
+    );
+    act(() => {
+      r.update(
+        <SkeletonContentCrossfade
+          loading={false}
+          exit="none"
+          renderSkeleton={skeletonNode}
+          renderContent={contentNode}
+        />
+      );
+    });
+    expect(present(r, 'ct')).toBe(true);
+    expect(present(r, 'sk')).toBe(false);
+    act(() => r.unmount());
+  });
+
+  it('re-entering loading cancels the exit: skeleton returns, content gone (no stacked overlay)', () => {
+    const r = render(
+      <SkeletonContentCrossfade loading renderSkeleton={skeletonNode} renderContent={contentNode} />
+    );
+    act(() => {
+      r.update(
+        <SkeletonContentCrossfade
+          loading={false}
+          renderSkeleton={skeletonNode}
+          renderContent={contentNode}
+        />
+      );
+    });
+    act(() => {
+      r.update(
+        <SkeletonContentCrossfade
+          loading
+          renderSkeleton={skeletonNode}
+          renderContent={contentNode}
+        />
+      );
+    });
+    expect(present(r, 'sk')).toBe(true);
+    expect(present(r, 'ct')).toBe(false);
+    act(() => r.unmount());
+  });
+
+  it('a row mounted already-loaded shows content with no skeleton (no spurious fade)', () => {
+    const r = render(
+      <SkeletonContentCrossfade
+        loading={false}
+        renderSkeleton={skeletonNode}
+        renderContent={contentNode}
+      />
+    );
+    expect(present(r, 'ct')).toBe(true);
+    expect(present(r, 'sk')).toBe(false);
+    act(() => r.unmount());
+  });
+});

--- a/__tests__/skeletonContentCrossfade.test.tsx
+++ b/__tests__/skeletonContentCrossfade.test.tsx
@@ -49,10 +49,24 @@ jest.mock('react-native-reanimated', () => {
     cancelAnimation: () => {},
     useAnimatedStyle: () => ({}),
     runOnJS: (fn: (...args: unknown[]) => unknown) => fn,
-    Easing: { out: () => (t: number) => t, inOut: () => (t: number) => t, cubic: (t: number) => t },
+    interpolate: () => 0,
+    Extrapolation: { CLAMP: 'clamp' },
+    Easing: {
+      out: () => (t: number) => t,
+      inOut: () => (t: number) => t,
+      cubic: (t: number) => t,
+      quad: (t: number) => t,
+    },
     ReduceMotion: { System: 'system' },
   };
 });
+
+jest.mock('@/shared/hooks/useThemeColor', () => ({
+  // SkeletonLoadingShimmer is mocked here, so the value is never run through
+  // hex-color-opacity — a plain token string is fine.
+  useThemeColor: (tokens: string | readonly string[]) =>
+    Array.isArray(tokens) ? tokens.map(() => 'theme-surface') : 'theme-surface',
+}));
 
 jest.mock('@/shared/ui/composed/SkeletonExitShimmer', () => {
   const ReactActual = jest.requireActual<typeof import('react')>('react');

--- a/__tests__/threadItems.test.ts
+++ b/__tests__/threadItems.test.ts
@@ -173,4 +173,34 @@ describe('thread item builders', () => {
       built?.items.filter((item) => item.type === 'reply').map((item) => item.event.id)
     ).toEqual(['seeded-reply', 'next-reply']);
   });
+
+  it('initial fetch keeps the seeded reply order as a stable prefix (no reshuffle)', () => {
+    const root = note({ id: 'root', content: 'root', tags: [], createdAt: 100 });
+    const seededReply = note({
+      id: 'seeded-reply', content: 'seeded', tags: [['e', 'root', '', 'reply']], createdAt: 101,
+    });
+    const rankedFirst = note({
+      id: 'ranked-first', content: 'ranked higher by the server', tags: [['e', 'root', '', 'reply']], createdAt: 102,
+    });
+    const result: ThreadResult = {
+      allEvents: mapEvents([root, seededReply, rankedFirst]),
+      profiles: new Map(),
+      metrics: new Map(),
+      quotedEvents: new Map(),
+      thread: { parents: [], target: root, replies: [seededReply, rankedFirst] },
+      // The server ranks rankedFirst ABOVE the already-on-screen seeded reply.
+      replyPageEventIds: ['ranked-first', 'seeded-reply'],
+      replyPageSize: 10,
+      loadedReplyCount: 2,
+      hasMoreReplies: false,
+    };
+
+    // The seeded reply (already painted) stays first; the ranked delta appends.
+    const orderedIds = orderedReplyIdsForThreadResult(result, 'initial', ['seeded-reply']);
+    expect(orderedIds).toEqual(['seeded-reply', 'ranked-first']);
+
+    // With no seed, the server order is used as-is.
+    const cold = orderedReplyIdsForThreadResult(result, 'initial', []);
+    expect(cold).toEqual(['ranked-first', 'seeded-reply']);
+  });
 });

--- a/app/(settings-flow)/_layout.tsx
+++ b/app/(settings-flow)/_layout.tsx
@@ -26,6 +26,7 @@ const DESIGN_SYSTEM_LOADING_OPTIONS = { title: 'Loading indicator' };
 const DESIGN_SYSTEM_SEGMENTED_OPTIONS = { title: 'Segmented progress' };
 const DESIGN_SYSTEM_TIMELINE_OPTIONS = { title: 'Timeline' };
 const DESIGN_SYSTEM_EMPTY_STATES_OPTIONS = { title: 'Empty states' };
+const DESIGN_SYSTEM_SKELETON_CROSSFADE_OPTIONS = { title: 'Skeleton crossfade' };
 const RECOVERY_OPTIONS = { title: 'Recover wallet' };
 const DELETE_OPTIONS = { title: 'Delete account' };
 
@@ -55,6 +56,10 @@ export default function SettingsFlowLayout() {
       <Stack.Screen
         name="design-system-empty-states"
         options={DESIGN_SYSTEM_EMPTY_STATES_OPTIONS}
+      />
+      <Stack.Screen
+        name="design-system-skeleton-crossfade"
+        options={DESIGN_SYSTEM_SKELETON_CROSSFADE_OPTIONS}
       />
       <Stack.Screen name="recovery" options={RECOVERY_OPTIONS} />
       <Stack.Screen name="delete" options={DELETE_OPTIONS} />

--- a/app/(settings-flow)/design-system-skeleton-crossfade.tsx
+++ b/app/(settings-flow)/design-system-skeleton-crossfade.tsx
@@ -1,0 +1,5 @@
+import { SettingsDesignSystemSkeletonCrossfadeScreen } from '@/features/settings';
+
+export default function DesignSystemSkeletonCrossfadeRoute() {
+  return <SettingsDesignSystemSkeletonCrossfadeScreen />;
+}

--- a/codereview/README.md
+++ b/codereview/README.md
@@ -170,8 +170,10 @@ a typical session — your numbers will differ.
 | `startup`          | ~5K            | Initialization waterfall, gate sequence  |
 | `full --format md` | ~6K            | Pipe-delimited dense summary             |
 | `slow`             | ~18K           | Operations exceeding threshold           |
+| `perf`             | varies         | Per-event latency p50/p95/p99 + sparkline |
+| `redaction`        | ~1K            | Secret-redaction audit (brands + un-redacted flags) |
 | `screens`          | ~70K           | Screen flow + content snapshots          |
-| `errors`           | ~90K           | Errors with full context                 |
+| `errors`           | clustered      | Errors collapsed to exemplars (`--all` = full context) |
 
 ### Recipes
 

--- a/codereview/log-doctor/OVERVIEW.md
+++ b/codereview/log-doctor/OVERVIEW.md
@@ -1,0 +1,273 @@
+# log-doctor — overview
+
+A CLI that turns a raw Sovran session log into compact, LLM-readable summaries.
+You capture structured logs from a dev session, then ask log-doctor focused
+questions ("what broke?", "why is startup slow?", "where did layout shift?")
+instead of scrolling through 20k log lines.
+
+- **Tool:** `sovran-app/codereview/log-doctor/index.ts` (run with `bun run`)
+- **Input:** a `log.txt` in `sovran-app/` (or piped on stdin)
+- **Output:** dense text/markdown/json, sized to fit an LLM context window
+
+---
+
+## 1. How we write logs in the app
+
+All logging goes through the scoped logger barrel at
+`shared/lib/logger.ts`. You never `console.log`.
+
+### The logger API
+
+```ts
+import { paymentLog, feedLog, log } from 'shared/lib/logger';
+
+paymentLog.info('payment.send.start', { mintUrl, amount });
+feedLog.debug('feed.shift.note.height', { key, deltaHeight });
+log.error('nostr.relay.connect.failed', { relay, reason });
+```
+
+- Five levels: `debug` / `info` / `warn` / `error` / `fatal`.
+- Every call takes a **dot-separated event name** (`payment.send.start`) plus a
+  flat **params** object. The event name is the queryable key — log-doctor
+  filters and groups on it.
+- **Pre-made child loggers** carry a module tag so events sort cleanly:
+  `nfcLog, cashuLog, nostrLog, walletLog, paymentLog, feedLog, apiLog,
+  storeLog, aiLog, chatLog, bitchatLog, wnLog, popupLog, mapLog`. Make your own
+  with `log.child({ module: 'x' })`.
+
+### Timing & spans
+
+```ts
+await log.timed('coco.recovery', () => recover(), { warnThresholdMs: 1000 });
+
+const span = paymentLog.startSpan('payment.melt', { mint }, { warnAtMs: 2000 });
+span.end({ ok: true }); // logs payment.melt.end with duration_ms
+```
+
+`timed`/`startSpan` auto-emit `.start`/`.end` entries with `duration_ms` and
+**auto-escalate** to WARN/ERROR when an op runs slow (defaults 1s/5s). This is
+what feeds the `slow` mode.
+
+### What each entry looks like
+
+Entries are structured JSON (`LogEntry` in `loggerCore.ts`):
+
+```jsonc
+{
+  "ts": "...",            // ISO timestamp
+  "_t": 4611.2,           // monotonic ms since app start (skew-free; subtract two to get a gap)
+  "level": "warn",
+  "event": "perf.js_thread_blocked",
+  "src": { "file": "...", "func": "...", "line": 42 },
+  "params": { "blocked_ms": 2702.7 },
+  "duration_ms": 51.5,    // present on span ends
+  "device": { "platform": "ios", "logSessionId": "..." }
+}
+```
+
+### Secret redaction (automatic)
+
+The logger compacts and redacts before anything is written, so dumps are safe
+to paste into an LLM:
+
+- Fields named like secrets (`*nsec`, `*privateKey`, `mnemonic`, `seed`,
+  `*token`, `password`, `authorization`, …) are replaced with
+  `{ _kind, len }` — never the value.
+- Values matching secret patterns (nsec, cashu token, JWT, PEM, 32-byte hex)
+  are branded by kind, not printed.
+- Embedded secrets inside larger strings are scrubbed (you'll see `[mint_url]`,
+  `[error]` placeholders in real output).
+- Long strings are truncated to a short preview.
+
+**Rules when adding logs:**
+- Use scoped loggers from `shared/lib/logger`; never `console.log`.
+- Event names are queryable prefixes: `payment.*`, `nostr.*`, `wallet.*`,
+  `perf.*`, `theme.*`, `feed.*`, `visual.*`.
+- Never log raw secrets, raw ecash tokens, full invoices, or imported nsecs.
+- Narrow unknown errors with `redactError(e)`; don't dump arbitrary nested objects.
+
+### Getting logs out of the app
+
+The console transport prints JSON; an on-device **file transport** mirrors every
+entry to `log.txt` so logs survive dev-server disconnects
+(`applyFileLogging`, `exportLogFile`, `getLogFileInfo` in `loggerFile.ts`). You
+can also call `log.dumpForLLM({ format: 'md' })` to flush the in-memory ring
+buffer to a paste-ready string.
+
+To feed log-doctor: capture a dev session's stdout to `sovran-app/log.txt`
+(e.g. `expo start 2>&1 | tee log.txt`), or paste a `dumpForLLM()` dump into that
+file. log-doctor reads `log.txt` by default, or stdin when piped.
+
+---
+
+## 2. Running log-doctor
+
+```bash
+cd sovran-app
+
+bun run codereview/log-doctor/index.ts <mode> [options]   # reads ./log.txt
+cat some-logs.jsonl | bun run codereview/log-doctor/index.ts stats
+```
+
+> `npm run log-doctor -- <mode>` is the documented alias, but in this repo the
+> npm/npx path currently hits a dependency-override error, so use `bun run`.
+
+**`--latest` is the flag you'll use most** — it keeps only the most recent app
+session (it detects restarts via `_t` resets), so you're not mixing three runs.
+
+---
+
+## 3. The modes
+
+24 modes. They fall into a few families.
+
+### Triage / overview
+| Mode | Tokens | What it shows |
+|------|--------|----------------|
+| `budget` | tiny | Token cost of every mode for *this* log + what fits in which context window. Run it first. |
+| `stats` | ~1K | Event frequency, slowest ops, error rate, timing gaps, noise/duplicate detection. |
+| `devices` | small | Device/session labels in a mixed-device log file. |
+| `timeline` | ~5K | One line per entry with delta timing. Pair with `--event`. |
+| `full` | ~5–23K | All entries, deduped/trimmed. `--format md` is ~40% cheaper than json. |
+| `diff` | varies | Compares latest session vs previous to isolate failure-specific entries. |
+
+### Failure & performance
+| Mode | Tokens | What it shows |
+|------|--------|----------------|
+| `errors` | large | warn/error/fatal entries. **Clustered by default** — near-identical errors collapse to exemplar + count + first/last; `--all`/`--no-cluster` restores the full per-entry listing with `--context N`. |
+| `slow` | ~5–18K | Gaps between consecutive entries exceeding `--threshold` ms (default 500). Note: measures *log-line gaps*, not op durations — use `perf` for durations. |
+| `startup` | ~1.5–5K | Init waterfall, stage timing, gate sequence. |
+| `gc` | varies | Hermes memory trend, GC pressure, JS-thread blocks, leak detection. |
+| `perf` | varies | Per-event latency distribution (**p50/p95/p99 + sparkline**) from `params.ms` / `_perf`-tagged ops, plus slow-op and network/compute breakdowns. |
+| `renders` | ~200 | Re-render counts + why-did-update hints. |
+
+### Domain-specific
+| Mode | What it shows |
+|------|----------------|
+| `coco` | Coco/Colada wallet module breakdown, issues, mint requests. |
+| `payment` | Payment/receive/redeem timeline grouped by operation id. |
+| `toasts` | Toast lifecycle grouped by toast/payment id. |
+| `crypto` | Crypto/cashu amount + proof operations. |
+| `network` | Request/response pairs with latency. |
+| `ws` | WebSocket health, subscription analysis, message rates. |
+| `feed` | Feed/thread GraphQL, page mapping, reply seed/render flow. |
+| `flows` | Reconstruct cross-async traces via `flowId` in ctx. |
+| `ops` | General operation/span breakdown. |
+| `screens` | Screen navigation flow + content snapshots + durations. |
+| `redaction` | Read-side secret-redaction audit: counts `{_kind}` brands + `<REDACTED:…>` markers, and heuristically flags raw values that look **un-redacted** (high-signal: nsec/xprv/cashu-token/jwt/email; low-signal: npub/note/64-hex). Reports event names, never values. |
+
+### Visual / content-shift (the big one for UI jank)
+`visual` reads layout telemetry — row rects, item-size changes, virtual-position
+snapshots, overlaps, container-boundary violations, sticky-header markers, large
+jumps — and flags content-shift bugs. Narrow it with `--scope`, `--component`,
+`--key`, `--item-type`.
+
+```bash
+bun run codereview/log-doctor/index.ts visual --latest
+bun run codereview/log-doctor/index.ts visual --latest --scope 'thread\.'
+bun run codereview/log-doctor/index.ts visual --latest --component PostComposerToolbar
+bun run codereview/log-doctor/index.ts timeline --event 'visual\.layout|\.shift\.' --latest
+```
+
+### Device control (separate tool)
+`phone` drives a real iPhone over WebDriverAgent (`tap`, `tap-id`, `tree`,
+`shot`, `swipe`, plus a `phone test` DSL runner). Not a log analyzer — it's how
+you *generate* a fresh session to then inspect.
+
+---
+
+## 4. Key options
+
+| Flag | Effect |
+|------|--------|
+| `--latest` | Most recent session only. Use almost always. |
+| `--event <pattern>` | Filter to events matching substring/regex. |
+| `--threshold <ms>` | Duration cutoff for `slow` (default 500). |
+| `--context <n>` | Entries around each error in `--all` mode (default 3). |
+| `--all` / `--no-cluster` | `errors` mode: list every entry instead of clustering. |
+| `--token-budget <n>` | Auto-prune output to fit N tokens. |
+| `--since/--until <ms>` | Time-window filter on `_t`. |
+| `--limit/--offset` | Paginate huge sessions. |
+| `--format json\|yaml\|md` | Output format for `full`. |
+| `--no-inst` | Strip instrumentation (render.count, state.change). |
+| `--device/--platform/--session` | Filter a mixed log. |
+| `--scope/--component/--key/--item-type` | Narrow `visual`. |
+
+---
+
+## 5. Worked examples (real output)
+
+### `budget` — what's affordable on this session
+```
+TOKEN BUDGET ANALYSIS:
+  Total entries: 19939
+
+MODE TOKEN COSTS (approximate):
+  renders     162 tokens  █
+  stats      1035 tokens  █
+  startup    1452 tokens  █
+  ...
+  screens   25207 tokens  ████████
+  errors   124694 tokens  ████████████████████████████████████████
+
+FITS IN CONTEXT WINDOW:
+  Small prompt (8K): renders, stats, startup, network, slow, timeline, coco, full (md), feed
+```
+*Takeaway: `errors` is huge here — narrow it before reaching for it.*
+
+### `stats --latest` — frequency + timing snapshot
+```
+=== LOG SESSION STATISTICS ===
+Device: {"platform":"ios","appVersion":"0.1.0","osVersion":"26.1",...}
+Entries: 19939   Time span: 55.3s
+BY LEVEL: DEBUG 14076  INFO 4769  WARN 1087  ERROR 7
+
+TOP APP EVENTS:
+   1744x  visual.layout.measure
+   1392x  history.filters.matchesFilters
+    980x  init.timing
+TIMING: Largest gap 33860ms ; Median gap 0ms
+```
+*Takeaway: `history.filters.*` fires ~1.4k times — a re-computation hotspot.*
+
+### `errors --latest --context 1` — what went wrong, with neighbours
+```
+>>> WARN transactions.filter.slow      duration_ms=51.56 input=82 output=75
+>>> WARN perf.js_thread_blocked        blocked_ms=2702.7 expected_ms=200 actual_ms=2902.7
+>>> WARN coco...failed_to_check_inflight_proofs_for_mint  mintUrl=[mint_url] error=[error]
+    DEBUG coco...mint_response_error    status=429 errorData="Rate limit exceeded."
+```
+*Takeaway: a 2.7s JS-thread block + mint 429s. Note `[mint_url]`/`[error]` are
+redacted automatically.*
+
+### `startup --latest` — init waterfall
+```
+STARTUP WATERFALL:
+   1786ms ████████████████ updateStage (18.3s)
+   3559ms █████ SplashMorph (2.4s)
+   6211ms ██████████ Coco-bg.receiveRecovery (13.9s)
+MILESTONES:  App ready: 1818ms   Total init span: 18323ms
+```
+*Takeaway: `receiveRecovery` dominates init — the place to optimize.*
+
+---
+
+## 6. Typical workflows
+
+**Audit-prep sweep (fits < 30K tokens together):**
+```bash
+bun run codereview/log-doctor/index.ts stats  --latest
+bun run codereview/log-doctor/index.ts errors --latest --context 5
+bun run codereview/log-doctor/index.ts slow   --latest --threshold 200
+bun run codereview/log-doctor/index.ts coco   --latest
+```
+
+**The loop (from the `sovran-quality` skill):**
+1. Find the relevant event namespace / symptom.
+2. Run the **narrowest** query first (`--event`, `--scope`, `--latest`).
+3. Correlate output with code paths and store/request state.
+4. Add scoped logs only if they make future diagnosis cheaper.
+5. Remove noisy or secret-risk logs before shipping.
+
+See also: `skills/sovran-quality/references/log-doctor.md` and
+`codereview/README.md` for token budgets and audit.md/fix.md integration.

--- a/codereview/log-doctor/__tests__/analysis.test.ts
+++ b/codereview/log-doctor/__tests__/analysis.test.ts
@@ -1,0 +1,163 @@
+import {
+  clusterErrorEntries,
+  errorClusterKey,
+  normalizeErrorText,
+  percentile,
+  scanRedactionAudit,
+  sparkline,
+  summarizeDurations,
+  type AnalyzableEntry,
+} from '../analysis';
+
+describe('percentile / summarizeDurations', () => {
+  const samples = [100, 300, 500, 800, 1000];
+
+  it('computes nearest-rank percentiles', () => {
+    expect(percentile(samples, 50)).toBe(500);
+    expect(percentile(samples, 95)).toBe(1000);
+    expect(percentile(samples, 99)).toBe(1000);
+    expect(percentile(samples, 0)).toBe(100);
+  });
+
+  it('is order-independent', () => {
+    expect(percentile([1000, 100, 500, 300, 800], 50)).toBe(500);
+  });
+
+  it('handles the empty sample', () => {
+    expect(percentile([], 50)).toBe(0);
+    expect(summarizeDurations([])).toEqual({
+      count: 0,
+      min: 0,
+      max: 0,
+      avg: 0,
+      p50: 0,
+      p95: 0,
+      p99: 0,
+    });
+  });
+
+  it('summarizes min/max/avg/percentiles', () => {
+    const d = summarizeDurations(samples);
+    expect(d.count).toBe(5);
+    expect(d.min).toBe(100);
+    expect(d.max).toBe(1000);
+    expect(d.avg).toBe(540);
+    expect(d.p50).toBe(500);
+  });
+});
+
+describe('sparkline', () => {
+  it('returns empty for no samples', () => {
+    expect(sparkline([])).toBe('');
+  });
+
+  it('collapses a uniform sample', () => {
+    expect(sparkline([5, 5, 5])).toContain('all 5ms');
+  });
+
+  it('renders a min–max legend for a varied sample', () => {
+    expect(sparkline([1, 2, 3, 100])).toContain('(1–100ms)');
+  });
+});
+
+describe('normalizeErrorText', () => {
+  it('collapses urls, uuids, hex and numbers', () => {
+    expect(normalizeErrorText('connect to https://relay.example.com/ws failed')).toBe(
+      'connect to <url> failed'
+    );
+    expect(normalizeErrorText('job 550e8400-e29b-41d4-a716-446655440000 stalled')).toBe(
+      'job <uuid> stalled'
+    );
+    expect(normalizeErrorText('key abcdef0123456789 rejected')).toBe('key <hex> rejected');
+    expect(normalizeErrorText('retry 42 of 99')).toBe('retry <n> of <n>');
+  });
+});
+
+describe('error clustering', () => {
+  const mk = (
+    over: Partial<AnalyzableEntry> & { error?: AnalyzableEntry['error'] }
+  ): AnalyzableEntry => ({
+    level: 'error',
+    event: 'net.fail',
+    _t: 0,
+    ...over,
+  });
+
+  it('gives two errors that differ only by ids the same cluster key', () => {
+    const a = mk({
+      error: { name: 'TimeoutError', message: 'timeout after 1200 ms', stack: [] },
+      params: { url: 'https://a.com/1' },
+    });
+    const b = mk({
+      error: { name: 'TimeoutError', message: 'timeout after 3400 ms', stack: [] },
+      params: { url: 'https://a.com/2' },
+    });
+    expect(errorClusterKey(a)).toBe(errorClusterKey(b));
+  });
+
+  it('separates a genuinely different error', () => {
+    const a = mk({ error: { name: 'TimeoutError', message: 'x', stack: [] } });
+    const c = mk({ error: { name: 'NetworkError', message: 'x', stack: [] } });
+    expect(errorClusterKey(a)).not.toBe(errorClusterKey(c));
+  });
+
+  it('clusters with counts, exemplar and time span', () => {
+    const entries: AnalyzableEntry[] = [
+      mk({
+        _t: 10,
+        error: { name: 'TimeoutError', message: 'timeout after 1 ms', stack: [] },
+        params: { url: 'https://a.com/1' },
+      }),
+      mk({
+        _t: 50,
+        error: { name: 'TimeoutError', message: 'timeout after 9 ms', stack: [] },
+        params: { url: 'https://a.com/2' },
+      }),
+      mk({ _t: 30, error: { name: 'NetworkError', message: 'down', stack: [] } }),
+    ];
+    const clusters = clusterErrorEntries(entries.map((entry, index) => ({ entry, index })));
+    expect(clusters).toHaveLength(2);
+    expect(clusters[0].count).toBe(2); // sorted by count desc
+    expect(clusters[0].firstT).toBe(10);
+    expect(clusters[0].lastT).toBe(50);
+    expect(clusters[0].exemplarIndex).toBe(0);
+  });
+});
+
+describe('scanRedactionAudit', () => {
+  it('counts brands, inline markers, and flags un-redacted secrets by tier', () => {
+    const entries: AnalyzableEntry[] = [
+      { level: 'info', event: 'auth.login', params: { key: { _kind: 'nsec', len: 63 } } },
+      { level: 'info', event: 'wallet.recv', params: { msg: 'got <REDACTED:cashu-token> ok' } },
+      {
+        level: 'warn',
+        event: 'profile.import',
+        params: { leaked: 'nsec1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq' },
+      },
+      { level: 'debug', event: 'nostr.event', params: { pubkey: 'a'.repeat(64) } },
+    ];
+    const audit = scanRedactionAudit(entries);
+
+    expect(audit.brandCounts.nsec).toBe(1);
+    expect(audit.redactedSubstrCounts['cashu-token']).toBe(1);
+    expect(audit.totalRedactions).toBe(2);
+
+    const nsec = audit.suspicious.find((s) => s.category === 'nsec');
+    expect(nsec?.highSignal).toBe(true);
+    expect(nsec?.sampleEvents).toContain('profile.import');
+
+    const hex64 = audit.suspicious.find((s) => s.category === 'hex64');
+    expect(hex64?.highSignal).toBe(false);
+
+    // high-signal findings sort ahead of low-signal ones
+    expect(audit.suspicious[0].highSignal).toBe(true);
+  });
+
+  it('does not flag a value once the logger has branded it', () => {
+    const audit = scanRedactionAudit([
+      { level: 'info', event: 'x', params: { sk: { _kind: 'private_key', len: 64 } } },
+    ]);
+    expect(audit.suspicious).toHaveLength(0);
+    expect(audit.brandCounts.private_key).toBe(1);
+  });
+});

--- a/codereview/log-doctor/analysis.ts
+++ b/codereview/log-doctor/analysis.ts
@@ -1,0 +1,287 @@
+// Pure, dependency-free deterministic log analysis for log-doctor.
+//
+// Kept separate from index.ts (the CLI entrypoint, which pulls in WDA +
+// test-dsl) so these functions can be unit-tested in isolation without loading
+// the whole tool. The index.ts modes consume them. Everything here is a pure
+// function of its inputs — no I/O, no globals — which is what makes
+// __tests__/analysis.test.ts cheap and deterministic.
+
+/** The structural subset of a log entry the analysis needs. index.ts's
+ *  richer LogEntry is assignable to this. */
+export interface AnalyzableEntry {
+  level: string;
+  event: string;
+  _t?: number;
+  params?: Record<string, unknown>;
+  ctx?: Record<string, unknown>;
+  error?: { name: string; message: string; stack: string[] };
+}
+
+// ─── Percentiles, distribution summary, sparkline ────────────────────────────
+
+function percentileSorted(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  if (p <= 0) return sorted[0];
+  if (p >= 100) return sorted[sorted.length - 1];
+  // Nearest-rank: simple, exact, no interpolation surprises.
+  const rank = Math.ceil((p / 100) * sorted.length);
+  return sorted[Math.min(sorted.length - 1, Math.max(0, rank - 1))];
+}
+
+/** Nearest-rank percentile over an unsorted sample. */
+export function percentile(samples: number[], p: number): number {
+  return percentileSorted(
+    [...samples].sort((a, b) => a - b),
+    p
+  );
+}
+
+export interface DurationSummary {
+  count: number;
+  min: number;
+  max: number;
+  avg: number;
+  p50: number;
+  p95: number;
+  p99: number;
+}
+
+export function summarizeDurations(samples: number[]): DurationSummary {
+  if (samples.length === 0) return { count: 0, min: 0, max: 0, avg: 0, p50: 0, p95: 0, p99: 0 };
+  const sorted = [...samples].sort((a, b) => a - b);
+  const sum = sorted.reduce((a, b) => a + b, 0);
+  return {
+    count: sorted.length,
+    min: sorted[0],
+    max: sorted[sorted.length - 1],
+    avg: sum / sorted.length,
+    p50: percentileSorted(sorted, 50),
+    p95: percentileSorted(sorted, 95),
+    p99: percentileSorted(sorted, 99),
+  };
+}
+
+const SPARK_BLOCKS = '▁▂▃▄▅▆▇█';
+
+/** Compact, token-cheap distribution of `samples` across `buckets` linear bins,
+ *  with a min–max legend. Returns '' for an empty sample. */
+export function sparkline(samples: number[], buckets = 8): string {
+  if (samples.length === 0) return '';
+  const min = Math.min(...samples);
+  const max = Math.max(...samples);
+  if (max === min) return `${SPARK_BLOCKS[0].repeat(buckets)} (all ${min.toFixed(0)}ms)`;
+  const counts = new Array<number>(buckets).fill(0);
+  for (const s of samples) {
+    const idx = Math.min(buckets - 1, Math.floor(((s - min) / (max - min)) * buckets));
+    counts[idx]++;
+  }
+  const maxCount = Math.max(...counts);
+  const spark = counts
+    .map((c) => SPARK_BLOCKS[Math.round((c / maxCount) * (SPARK_BLOCKS.length - 1))])
+    .join('');
+  return `${spark} (${min.toFixed(0)}–${max.toFixed(0)}ms)`;
+}
+
+// ─── Error clustering ────────────────────────────────────────────────────────
+
+const URL_RE = /\bhttps?:\/\/[^\s"]+/gi;
+const UUID_RE = /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
+const HEX_RE = /\b[0-9a-f]{8,}\b/gi;
+const NUM_RE = /\b\d[\d.,_]*\b/g;
+
+/** Collapse the varying parts of a string (urls, uuids, long hex, numbers) so
+ *  that two errors differing only by ids/amounts share a normalized form. */
+export function normalizeErrorText(value: unknown): string {
+  let s = typeof value === 'string' ? value : JSON.stringify(value ?? '');
+  // Order matters: url, then uuid (before bare hex eats its segments), then hex, then numbers.
+  s = s
+    .replace(URL_RE, '<url>')
+    .replace(UUID_RE, '<uuid>')
+    .replace(HEX_RE, '<hex>')
+    .replace(NUM_RE, '<n>');
+  return s.slice(0, 200);
+}
+
+/** Normalize params into a deterministic template: sorted keys (so serialization
+ *  order can't split a cluster), underscore-prefixed keys dropped, values
+ *  collapsed via normalizeErrorText. */
+function normalizeParams(params: Record<string, unknown> | undefined): string {
+  if (!params) return '';
+  return Object.keys(params)
+    .filter((k) => !k.startsWith('_'))
+    .sort()
+    .map((k) => `${k}=${normalizeErrorText(params[k])}`)
+    .join('&');
+}
+
+function topStackFrame(entry: AnalyzableEntry): string {
+  const frame = entry.error?.stack?.[0];
+  return frame ? normalizeErrorText(frame) : '';
+}
+
+/** The stable identity an error clusters by: level + event + error name +
+ *  normalized message + normalized params + normalized top stack frame. */
+export function errorClusterKey(entry: AnalyzableEntry): string {
+  return [
+    entry.level,
+    entry.event,
+    entry.error?.name ?? '',
+    normalizeErrorText(entry.error?.message ?? ''),
+    normalizeParams(entry.params),
+    topStackFrame(entry),
+  ].join('|');
+}
+
+export interface ErrorCluster<T> {
+  key: string;
+  count: number;
+  exemplar: T;
+  exemplarIndex: number;
+  firstT: number;
+  lastT: number;
+}
+
+/** Group error entries by errorClusterKey, keeping the first-seen entry as the
+ *  exemplar. Sorted by count desc, then earliest occurrence. */
+export function clusterErrorEntries<T extends AnalyzableEntry>(
+  items: Array<{ entry: T; index: number }>
+): ErrorCluster<T>[] {
+  const map = new Map<string, ErrorCluster<T>>();
+  for (const { entry, index } of items) {
+    const key = errorClusterKey(entry);
+    const t = entry._t ?? 0;
+    const existing = map.get(key);
+    if (!existing) {
+      map.set(key, { key, count: 1, exemplar: entry, exemplarIndex: index, firstT: t, lastT: t });
+    } else {
+      existing.count++;
+      existing.firstT = Math.min(existing.firstT, t);
+      existing.lastT = Math.max(existing.lastT, t);
+    }
+  }
+  return [...map.values()].sort((a, b) => b.count - a.count || a.firstT - b.firstT);
+}
+
+// ─── Redaction audit (read-side) ─────────────────────────────────────────────
+
+interface SuspiciousPattern {
+  category: string;
+  re: RegExp;
+  /** true = almost certainly a secret/PII that should have been redacted;
+   *  false = usually a PUBLIC id (npub/event/pubkey hash) — low signal. */
+  highSignal: boolean;
+}
+
+const SUSPICIOUS_PATTERNS: SuspiciousPattern[] = [
+  { category: 'nsec', re: /\bnsec1[0-9a-z]{20,}\b/i, highSignal: true },
+  { category: 'xprv', re: /\bxprv[0-9a-zA-Z]{20,}\b/, highSignal: true },
+  { category: 'cashu-token', re: /\bcashu[AB][A-Za-z0-9_-]{20,}\b/, highSignal: true },
+  {
+    category: 'jwt',
+    re: /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/,
+    highSignal: true,
+  },
+  {
+    category: 'email',
+    re: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/,
+    highSignal: true,
+  },
+  { category: 'npub', re: /\bnpub1[0-9a-z]{20,}\b/i, highSignal: false },
+  { category: 'note', re: /\bnote1[0-9a-z]{20,}\b/i, highSignal: false },
+  { category: 'hex64', re: /\b[0-9a-f]{64}\b/i, highSignal: false },
+];
+
+const REDACTED_SUBSTR_RE = /<REDACTED:([^>]+)>/g;
+const MAX_DEPTH = 8;
+
+export interface SuspiciousFinding {
+  category: string;
+  count: number;
+  highSignal: boolean;
+  sampleEvents: string[];
+}
+
+export interface RedactionAudit {
+  /** {_kind} brand objects the logger emits for stripped secrets, by kind. */
+  brandCounts: Record<string, number>;
+  /** Inline <REDACTED:label> substrings, by label. */
+  redactedSubstrCounts: Record<string, number>;
+  /** brandCounts + redactedSubstrCounts totals — confirmed redactions. */
+  totalRedactions: number;
+  /** Raw values that look UN-redacted (heuristic). Never includes the values. */
+  suspicious: SuspiciousFinding[];
+}
+
+/** Scan already-parsed (already-redacted) entries: count confirmed redactions
+ *  and heuristically flag any raw values that look like un-redacted secrets/PII.
+ *  Pure and read-only — it changes nothing about how the app logs. */
+export function scanRedactionAudit(entries: AnalyzableEntry[]): RedactionAudit {
+  const brandCounts: Record<string, number> = {};
+  const redactedSubstrCounts: Record<string, number> = {};
+  const suspMap = new Map<string, { count: number; events: Set<string>; highSignal: boolean }>();
+
+  const note = (pattern: SuspiciousPattern, event: string): void => {
+    let s = suspMap.get(pattern.category);
+    if (!s) {
+      s = { count: 0, events: new Set(), highSignal: pattern.highSignal };
+      suspMap.set(pattern.category, s);
+    }
+    s.count++;
+    if (s.events.size < 5) s.events.add(event);
+  };
+
+  const walk = (value: unknown, event: string, depth: number): void => {
+    if (value == null || depth > MAX_DEPTH) return;
+    if (typeof value === 'string') {
+      let m: RegExpExecArray | null;
+      REDACTED_SUBSTR_RE.lastIndex = 0;
+      while ((m = REDACTED_SUBSTR_RE.exec(value)) !== null) {
+        redactedSubstrCounts[m[1]] = (redactedSubstrCounts[m[1]] ?? 0) + 1;
+      }
+      for (const pattern of SUSPICIOUS_PATTERNS) {
+        if (pattern.re.test(value)) note(pattern, event);
+      }
+      return;
+    }
+    if (typeof value !== 'object') return;
+    if (Array.isArray(value)) {
+      for (const v of value) walk(v, event, depth + 1);
+      return;
+    }
+    const obj = value as Record<string, unknown>;
+    // A {_kind: ...} brand means the logger already stripped the value — count
+    // it and stop; the raw secret is gone, so don't recurse or flag.
+    if (typeof obj._kind === 'string') {
+      brandCounts[obj._kind] = (brandCounts[obj._kind] ?? 0) + 1;
+      return;
+    }
+    for (const v of Object.values(obj)) walk(v, event, depth + 1);
+  };
+
+  for (const e of entries) {
+    walk(e.params, e.event, 0);
+    walk(e.ctx, e.event, 0);
+    if (e.error) {
+      walk(e.error.message, e.event, 0);
+      walk(e.error.stack, e.event, 0);
+    }
+  }
+
+  const totalBrands = Object.values(brandCounts).reduce((a, b) => a + b, 0);
+  const totalSubstr = Object.values(redactedSubstrCounts).reduce((a, b) => a + b, 0);
+  const suspicious: SuspiciousFinding[] = [...suspMap.entries()]
+    .map(([category, s]) => ({
+      category,
+      count: s.count,
+      highSignal: s.highSignal,
+      sampleEvents: [...s.events],
+    }))
+    .sort((a, b) => Number(b.highSignal) - Number(a.highSignal) || b.count - a.count);
+
+  return {
+    brandCounts,
+    redactedSubstrCounts,
+    totalRedactions: totalBrands + totalSubstr,
+    suspicious,
+  };
+}

--- a/codereview/log-doctor/index.ts
+++ b/codereview/log-doctor/index.ts
@@ -42,12 +42,17 @@
  *   flows        Reconstruct cross-async traces using flowId in ctx
  *   ws           WebSocket connection health, subscription analysis, message rates
  *   gc           Hermes memory trend, GC pressure, JS thread blocks, leak detection
+ *   crypto       Crypto/cashu amount + proof operation breakdown
+ *   ops          Operation/span breakdown
+ *   perf         Per-event latency distribution (p50/p95/p99 + histogram) from params.ms
+ *   redaction    Read-side redaction audit: confirms secrets stripped, flags raw un-redacted values
  *   budget       Token cost meta-analysis — shows which modes fit in which context windows
  *   phone        Drive a real iPhone via WebDriverAgent (subcommands: tap, tap-id, tree, shot, …)
  *
  * OPTIONS:
  *   --threshold <ms>    Duration threshold for 'slow' mode (default: 500)
  *   --context <n>       Number of entries before/after errors (default: 3)
+ *   --all, --no-cluster errors mode: list every entry with context instead of clustering
  *   --limit <n>         Page size (default: 200)
  *   --offset <n>        Skip first N entries for pagination (default: 0)
  *   --no-device         Omit device info block
@@ -105,6 +110,17 @@ import {
   wdaRequest,
 } from './wda';
 
+// Pure deterministic analysis (clustering, percentiles, redaction audit). Lives
+// in its own module so it can be unit-tested without loading the CLI/WDA stack.
+import {
+  clusterErrorEntries,
+  percentile,
+  scanRedactionAudit,
+  sparkline,
+  summarizeDurations,
+  type RedactionAudit,
+} from './analysis';
+
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 interface LogEntry {
@@ -142,6 +158,9 @@ interface Options {
   format: 'json' | 'yaml' | 'md';
   /** Max approximate token budget. Output is pruned to fit. null = unlimited. */
   tokenBudget: number | null;
+  /** errors mode: cluster near-identical errors into exemplars (default true).
+   *  Set false via --all / --no-cluster to list every entry with context. */
+  clusterErrors: boolean;
   /** Positional args after the mode name. Used by `phone` mode for subcommands. */
   restArgs: string[];
 }
@@ -171,6 +190,7 @@ export function parseArgs(argv: string[]): Options {
     latest: false,
     format: 'json',
     tokenBudget: null,
+    clusterErrors: true,
     restArgs: [],
   };
 
@@ -220,6 +240,9 @@ export function parseArgs(argv: string[]): Options {
       if (f === 'yaml' || f === 'md' || f === 'json') opts.format = f;
     } else if (arg === '--token-budget' && args[i + 1]) {
       opts.tokenBudget = parseInt(args[++i], 10);
+    } else if (arg === '--all' || arg === '--no-cluster') {
+      // errors mode: expand every entry with context instead of clustering.
+      opts.clusterErrors = false;
     } else {
       // Unknown flag — pass through to subcommand-style modes (phone test ...).
       opts.restArgs.push(arg);
@@ -619,7 +642,8 @@ function modeStats(entries: LogEntry[], opts: Options): string {
         .map((g) => Math.round(g) + 'ms')
         .join(', ')}`
     );
-    lines.push(`  Median gap: ${Math.round(gaps[Math.floor(gaps.length / 2)])}ms`);
+    lines.push(`  Median gap: ${Math.round(percentile(gaps, 50))}ms`);
+    lines.push(`  p95 gap: ${Math.round(percentile(gaps, 95))}ms`);
     lines.push('');
   }
 
@@ -735,6 +759,22 @@ function modeStats(entries: LogEntry[], opts: Options): string {
     if (highFreqTemplates.length > 15) lines.push(`  ... +${highFreqTemplates.length - 15} more`);
   } else {
     lines.push('  No events with 3+ occurrences.');
+  }
+
+  // Redaction at a glance — full breakdown lives in the `redaction` mode.
+  const audit = scanRedactionAudit(entries);
+  const brandTotal = Object.values(audit.brandCounts).reduce((a, b) => a + b, 0);
+  const highSignal = audit.suspicious.filter((s) => s.highSignal);
+  lines.push('');
+  lines.push('REDACTION:');
+  lines.push(
+    `  ${audit.totalRedactions} redacted values (${brandTotal} branded, ${audit.totalRedactions - brandTotal} inline)`
+  );
+  if (highSignal.length > 0) {
+    const total = highSignal.reduce((a, s) => a + s.count, 0);
+    lines.push(`  ⚠ ${total} possible un-redacted secret(s) — run "redaction" mode`);
+  } else {
+    lines.push('  No un-redacted high-signal secrets detected.');
   }
 
   return lines.join('\n');
@@ -1004,6 +1044,57 @@ function modeErrors(entries: LogEntry[], opts: Options): string {
 
   if (errorIndices.length === 0) return 'No warnings, errors, or fatal entries found.';
 
+  return opts.clusterErrors
+    ? renderErrorClusters(entries, errorIndices, opts)
+    : renderErrorEntriesWithContext(entries, errorIndices, opts);
+}
+
+// Default errors view: collapse near-identical errors to exemplars + counts.
+// Attacks the biggest token consumer; `--all` restores the full listing below.
+function renderErrorClusters(entries: LogEntry[], errorIndices: number[], opts: Options): string {
+  const clusters = clusterErrorEntries(
+    errorIndices.map((index) => ({ entry: entries[index], index }))
+  );
+  const lines: string[] = [];
+  lines.push(
+    `Found ${errorIndices.length} warning/error/fatal entries in ${clusters.length} cluster(s). ` +
+      `Showing exemplars — re-run with --all for every entry with context.\n`
+  );
+
+  const { page, footer } = paginate(clusters, opts);
+  for (const c of page) {
+    const e = c.exemplar;
+    lines.push(
+      `>>> ${String(c.count).padStart(4)}x ${levelIcon(e.level)} ${e.event}  ${shortParams(e.params)}`
+    );
+    const span =
+      c.lastT > c.firstT
+        ? `first +${(c.firstT / 1000).toFixed(1)}s, last +${(c.lastT / 1000).toFixed(1)}s`
+        : `at +${(c.firstT / 1000).toFixed(1)}s`;
+    lines.push(`       ${span}`);
+    if (e.error) {
+      lines.push(`       ERROR: ${e.error.name}: ${e.error.message}`);
+      if (e.error.stack?.length > 0) {
+        lines.push(`       STACK: ${e.error.stack.slice(0, 3).join(' -> ')}`);
+      }
+    }
+    lines.push('');
+  }
+
+  const suppressed = errorIndices.length - clusters.length;
+  lines.push(
+    `Clustered ${errorIndices.length} entries into ${clusters.length} exemplar(s) ` +
+      `(${suppressed} duplicate(s) suppressed; --all to expand).`
+  );
+  lines.push(footer);
+  return lines.join('\n');
+}
+
+function renderErrorEntriesWithContext(
+  entries: LogEntry[],
+  errorIndices: number[],
+  opts: Options
+): string {
   const lines: string[] = [];
   lines.push(`Found ${errorIndices.length} warning/error/fatal entries:\n`);
 
@@ -3478,17 +3569,22 @@ function modePerf(entries: LogEntry[], _opts: Options): string {
   lines.push('BOTTLENECK RANKING (by total time):');
   lines.push('');
   lines.push(
-    '  Event                                  Count   Total ms   Avg ms   Min ms   Max ms   P95 ms'
+    '  Event                                  Count   Total ms   Avg ms   P50 ms   P95 ms   P99 ms'
   );
   lines.push('  ' + '-'.repeat(100));
 
   for (const [event, stats] of sorted) {
-    const avg = stats.totalMs / stats.count;
-    const sorted95 = [...stats.samples].sort((a, b) => a - b);
-    const p95 = sorted95[Math.floor(sorted95.length * 0.95)] ?? stats.maxMs;
+    const d = summarizeDurations(stats.samples);
     lines.push(
-      `  ${event.padEnd(40).slice(0, 40)} ${String(stats.count).padStart(5)}   ${stats.totalMs.toFixed(1).padStart(8)}   ${avg.toFixed(1).padStart(6)}   ${stats.minMs.toFixed(1).padStart(6)}   ${stats.maxMs.toFixed(1).padStart(6)}   ${p95.toFixed(1).padStart(6)}`
+      `  ${event.padEnd(40).slice(0, 40)} ${String(stats.count).padStart(5)}   ${stats.totalMs.toFixed(1).padStart(8)}   ${d.avg.toFixed(1).padStart(6)}   ${d.p50.toFixed(1).padStart(6)}   ${d.p95.toFixed(1).padStart(6)}   ${d.p99.toFixed(1).padStart(6)}`
     );
+  }
+  lines.push('');
+
+  // Per-event latency distribution for the worst offenders (token-cheap sparkline).
+  lines.push('LATENCY DISTRIBUTION (top 5 by total time):');
+  for (const [event, stats] of sorted.slice(0, 5)) {
+    lines.push(`  ${event.slice(0, 40).padEnd(40)} ${sparkline(stats.samples)}`);
   }
   lines.push('');
 
@@ -3541,6 +3637,65 @@ function modePerf(entries: LogEntry[], _opts: Options): string {
 // ─── Mode: budget ───────────────────────────────────────────────────────────
 // Meta-analysis: shows token cost of each mode to help pick the right one.
 
+// ─── Mode: redaction ─────────────────────────────────────────────────────────
+// Read-side audit of an ALREADY-redacted log: confirms the logger stripped
+// secrets, and flags raw values that look un-redacted. Heuristic; never prints
+// values. Changes nothing about how the app logs.
+
+function renderRedactionAudit(audit: RedactionAudit): string[] {
+  const lines: string[] = [];
+
+  const brands = Object.entries(audit.brandCounts).sort((a, b) => b[1] - a[1]);
+  const brandTotal = brands.reduce((a, [, c]) => a + c, 0);
+  lines.push(`REDACTED SECRET BRANDS ({_kind}): ${brandTotal} total`);
+  if (brands.length === 0) lines.push('  none');
+  else for (const [kind, count] of brands) lines.push(`  ${String(count).padStart(5)}x  ${kind}`);
+  lines.push('');
+
+  const substr = Object.entries(audit.redactedSubstrCounts).sort((a, b) => b[1] - a[1]);
+  if (substr.length > 0) {
+    lines.push('INLINE <REDACTED:…> MARKERS:');
+    for (const [label, count] of substr) lines.push(`  ${String(count).padStart(5)}x  ${label}`);
+    lines.push('');
+  }
+
+  const high = audit.suspicious.filter((s) => s.highSignal);
+  const low = audit.suspicious.filter((s) => !s.highSignal);
+  lines.push('SUSPICIOUS RAW VALUES (heuristic — events named, values never shown):');
+  if (high.length > 0) {
+    lines.push('  ⚠ HIGH SIGNAL — likely secrets/PII that should have been redacted:');
+    for (const s of high) {
+      lines.push(
+        `     ${String(s.count).padStart(5)}x  ${s.category}  (events: ${s.sampleEvents.join(', ')})`
+      );
+    }
+  } else {
+    lines.push('  ⚠ HIGH SIGNAL: none — no raw nsec/xprv/cashu-token/jwt/email detected.');
+  }
+  if (low.length > 0) {
+    lines.push('  · LOW SIGNAL — usually public ids (npub/note/64-hex); investigate only if unexpected:');
+    for (const s of low) {
+      lines.push(
+        `     ${String(s.count).padStart(5)}x  ${s.category}  (events: ${s.sampleEvents.join(', ')})`
+      );
+    }
+  }
+
+  return lines;
+}
+
+function modeRedaction(entries: LogEntry[], _opts: Options): string {
+  const audit = scanRedactionAudit(entries);
+  const lines: string[] = [];
+  lines.push('=== REDACTION AUDIT ===');
+  lines.push('');
+  lines.push('Read-side scan of an already-redacted log. Confirms the logger stripped');
+  lines.push('secrets and flags raw values that look un-redacted. Heuristic; values never shown.');
+  lines.push('');
+  lines.push(...renderRedactionAudit(audit));
+  return lines.join('\n');
+}
+
 function modeBudget(entries: LogEntry[], opts: Options): string {
   const lines: string[] = [];
 
@@ -3557,6 +3712,7 @@ function modeBudget(entries: LogEntry[], opts: Options): string {
     { name: 'network', fn: modeNetwork },
     { name: 'feed', fn: modeFeed },
     { name: 'visual', fn: modeVisual },
+    { name: 'redaction', fn: modeRedaction },
     { name: 'full (json)', fn: (e, o) => modeFull(e, { ...o, format: 'json' }) },
     { name: 'full (md)', fn: (e, o) => modeFull(e, { ...o, format: 'md' }) },
     { name: 'full (yaml)', fn: (e, o) => modeFull(e, { ...o, format: 'yaml' }) },
@@ -4149,7 +4305,7 @@ async function main() {
     console.error('  2. Pipe logs: cat logs.jsonl | npm run log-doctor -- stats');
     console.error('');
     console.error(
-      'Modes: stats, timeline, errors, slow, renders, screens, startup, coco, network, feed, visual, full, diff, devices, payment, toasts, flows, ws, gc, budget, phone'
+      'Modes: stats, timeline, errors, slow, renders, screens, startup, coco, network, feed, visual, full, diff, devices, payment, toasts, flows, ws, gc, budget, crypto, ops, perf, redaction, phone'
     );
     process.exit(1);
   }
@@ -4245,10 +4401,13 @@ async function main() {
     case 'perf':
       output = modePerf(entries, opts);
       break;
+    case 'redaction':
+      output = modeRedaction(entries, opts);
+      break;
     default:
       console.error(`Unknown mode: ${opts.mode}`);
       console.error(
-        'Valid modes: stats, timeline, errors, slow, renders, screens, startup, coco, network, feed, visual, full, diff, devices, payment, toasts, flows, ws, gc, budget, crypto, ops, perf, phone'
+        'Valid modes: stats, timeline, errors, slow, renders, screens, startup, coco, network, feed, visual, full, diff, devices, payment, toasts, flows, ws, gc, budget, crypto, ops, perf, redaction, phone'
       );
       process.exit(1);
   }

--- a/features/feed/components/nostr/PostCard.tsx
+++ b/features/feed/components/nostr/PostCard.tsx
@@ -28,6 +28,7 @@ import { formatDate, formatRelative } from '@/shared/lib/date';
 import { tryNpubEncode } from './feedParse';
 import { useQuotePost } from '@/features/feed/lib/useQuotePost';
 import { NoteContent, NOTE_CONTENT_FONT_SIZE, NOTE_CONTENT_LINE_HEIGHT } from './NoteContent';
+import { useProfile } from '@/shared/lib/nostr/useEntityCache';
 import { MetricsFooter, POST_ACTION_ICON_SIZES } from './MetricsFooter';
 import {
   SkeletonExitReveal,
@@ -234,7 +235,12 @@ export const PostCard = React.memo(function PostCard({
 }: PostCardProps) {
   const [foreground, defaultColor] = useThemeColor(['foreground', 'default'] as const);
 
-  const profile = profiles.get(event.pubkey);
+  // Author identity comes from the authoritative entity cache, reactively: the
+  // row re-renders in place when this pubkey's profile arrives (no manual re-key),
+  // and any surface that saw this author renders it here too. `status` tells a
+  // genuine loading skeleton apart from a fallback. (`profiles` is still passed to
+  // NoteContent for inline mention chips.)
+  const { profile, status: authorStatus } = useProfile(event.pubkey);
   // Real display name only. The abbreviated npub fallback is passed as Text's
   // `fallback` prop so the name never flashes through a pubkey placeholder.
   const displayName = profile?.name;
@@ -351,7 +357,9 @@ export const PostCard = React.memo(function PostCard({
               onPress={navigateToProfile}>
               <HStack align="center" gap={10} style={sharedStyles.mb6}>
                 <Avatar
-                  state={profile?.picture ? 'image' : 'fallback'}
+                  state={
+                    profile?.picture ? 'image' : authorStatus === 'loading' ? 'loading' : 'fallback'
+                  }
                   picture={profile?.picture}
                   seed={event.pubkey}
                   size={AVATAR_SIZE}

--- a/features/feed/data/facadeFeedClient.ts
+++ b/features/feed/data/facadeFeedClient.ts
@@ -1,3 +1,6 @@
+import { facade } from '@sovranbitcoin/nagg-ts';
+
+import type { FeedEvent, FeedItem } from '@/features/feed/components/nostr/feedTypes';
 import { feedLog } from '@/shared/lib/logger';
 import { buildNostrDataLayer } from '@/shared/lib/nostr/buildNostrDataLayer';
 import { getNostrTierConfig } from '@/shared/lib/nostr/nostrTierConfig';
@@ -17,7 +20,53 @@ import {
   type FeedNotificationsResult,
   type FeedParseResult,
   type ThreadResult,
+  type ThreadSeedBuckets,
 } from './feedClient';
+
+// ---------------------------------------------------------------------------
+// Cache bridge: the nagg GraphQL fast-paths (thread, user feeds, posts-by-pubkey)
+// return app-shaped results WITHOUT writing to the shared entity cache the way
+// the facade reads do. These helpers write those results back into the singleton
+// cache, tagged 'nagg' (the source that served them), so a later read — opening a
+// reply as its own thread, revisiting a profile — serves them instantly. The
+// for-you/notifications facade paths already ingest; this closes the gap.
+// ---------------------------------------------------------------------------
+
+function eventsFromAppFeedItem(item: FeedItem): FeedEvent[] {
+  const out: FeedEvent[] = [];
+  if (item.type === 'note') {
+    out.push(item.event);
+    if (item.rootEvent) out.push(item.rootEvent);
+    if (item.replyPreviewEvents) out.push(...item.replyPreviewEvents);
+  } else {
+    out.push(item.repostEvent);
+    if (item.originalEvent) out.push(item.originalEvent);
+    if (item.rootEvent) out.push(item.rootEvent);
+    if (item.reposters) for (const reposter of item.reposters) out.push(reposter.event);
+  }
+  return out;
+}
+
+/** Write a thread result's notes/profiles/metrics into the shared cache. */
+function ingestThreadIntoCache(result: ThreadSeedBuckets): void {
+  const cache = buildNostrDataLayer()?.cache;
+  if (!cache) return;
+  cache.ingestNotes([...result.allEvents.values(), ...result.quotedEvents.values()]);
+  cache.ingestProfileInfos(Object.fromEntries(result.profiles), 'nagg');
+  cache.ingestNoteStats(facade.statsFromMetrics(Object.fromEntries(result.metrics)), 'nagg');
+}
+
+/** Write a parsed feed/user-feed page's notes/profiles/metrics into the shared cache. */
+function ingestFeedPageIntoCache(result: FeedParseResult): void {
+  const cache = buildNostrDataLayer()?.cache;
+  if (!cache) return;
+  const events: FeedEvent[] = [];
+  for (const item of result.orderedFeedItems) events.push(...eventsFromAppFeedItem(item));
+  events.push(...result.quotedEventsMap.values());
+  cache.ingestNotes(events);
+  cache.ingestProfileInfos(Object.fromEntries(result.profilesMap), 'nagg');
+  cache.ingestNoteStats(facade.statsFromMetrics(Object.fromEntries(result.metricsMap)), 'nagg');
+}
 
 // ---------------------------------------------------------------------------
 // Facade-backed feed client (local-dev tier validation).
@@ -37,7 +86,11 @@ export function createFacadeFeedClient(fallback: FeedClient): FeedClient {
     ...fallback,
     async getFeed(request): Promise<FeedParseResult> {
       const spec = mapAppSpecToFeedSpec(request.spec, request.userPubkey);
-      if (!spec) return fallback.getFeed(request);
+      if (!spec) {
+        const result = await fallback.getFeed(request);
+        ingestFeedPageIntoCache(result);
+        return result;
+      }
 
       const layer = buildNostrDataLayer();
       if (!layer) {
@@ -70,7 +123,11 @@ export function createFacadeFeedClient(fallback: FeedClient): FeedClient {
       // tier — can't reproduce that ranking. So keep the GraphQL path whenever
       // nagg is enabled, and only route threads through the facade (Primal →
       // relay) when nagg is toggled off, so the cache/relay tiers can serve them.
-      if (getNostrTierConfig().nagg.enabled) return fallback.getThread(request);
+      if (getNostrTierConfig().nagg.enabled) {
+        const result = await fallback.getThread(request);
+        ingestThreadIntoCache(result);
+        return result;
+      }
 
       // Never throw: useThread's seeded-error path keeps isLoading=true on a
       // throw (so a transient nagg error doesn't clobber a seeded render), which
@@ -96,6 +153,18 @@ export function createFacadeFeedClient(fallback: FeedClient): FeedClient {
         });
         return emptyThreadResult(request);
       }
+    },
+
+    async getUserFeed(request): Promise<FeedParseResult> {
+      const result = await fallback.getUserFeed(request);
+      ingestFeedPageIntoCache(result);
+      return result;
+    },
+
+    async getPostsByPubkeys(request): Promise<FeedParseResult> {
+      const result = await fallback.getPostsByPubkeys(request);
+      ingestFeedPageIntoCache(result);
+      return result;
     },
 
     async getNotifications(request): Promise<FeedNotificationsResult> {

--- a/features/feed/data/facadeThreadAdapter.ts
+++ b/features/feed/data/facadeThreadAdapter.ts
@@ -93,6 +93,12 @@ export function resolvedThreadToResult(
 
   const root = feedItemEvent(thread.root);
   if (root) allEvents.set(root.id, root);
+  // Ancestors go into allEvents (NOT the reply list) so buildThreadStructure
+  // renders the parent chain — the relay/primal floor now fetches it.
+  for (const item of thread.parents) {
+    const event = feedItemEvent(item);
+    if (event) allEvents.set(event.id, event);
+  }
   for (const item of thread.replies) {
     const event = feedItemEvent(item);
     if (!event) continue;

--- a/features/feed/hooks/useThread.ts
+++ b/features/feed/hooks/useThread.ts
@@ -13,6 +13,7 @@ import type {
 } from '@/features/feed/data/feedClient';
 import { getFeedClient } from '@/features/feed/data/useFeedClient';
 import { consumeThreadSeed, type ThreadSeed } from '@/features/feed/lib/threadSeedCache';
+import { buildNostrDataLayer } from '@/shared/lib/nostr/buildNostrDataLayer';
 import {
   bucketsFromThreadResult,
   buildThreadItemsFromResult,
@@ -38,6 +39,42 @@ function ownContentSeed(eventId: string, viewerPubkey: string | undefined): Thre
     profiles: new Map(),
     metrics: new Map(),
     quotedEvents: new Map(),
+  };
+}
+
+/**
+ * First-frame seed projected from the shared nagg-ts entity cache (populated by
+ * every feed/notifications read). When the tapped note was already seen, this
+ * paints the post + its cached ancestor chain + author profiles/metrics with NO
+ * network — covering deep links and reply-taps that carry no nav snapshot. The
+ * cache only walks ANCESTORS, so a feed nav seed (which also carries reply
+ * previews) is preferred when present; this fills the gap otherwise.
+ */
+function cachedThreadSeed(eventId: string): ThreadSeed | undefined {
+  const layer = buildNostrDataLayer();
+  if (!layer) return undefined;
+  const view = layer.readThread(eventId);
+  if (!view.root) return undefined; // not cached — no instant frame available
+
+  const allEvents = new Map<string, FeedEvent>();
+  allEvents.set(view.root.id, view.root);
+  for (const note of view.relatedNotes) allEvents.set(note.id, note);
+
+  const metrics = new Map<string, NoteMetrics>();
+  for (const [id, stats] of Object.entries(view.stats)) {
+    metrics.set(id, {
+      likeCount: stats.likes,
+      repostCount: stats.reposts,
+      replyCount: stats.replies,
+      satsZapped: stats.satsZapped,
+    });
+  }
+
+  return {
+    allEvents,
+    profiles: new Map<string, ProfileInfo>(Object.entries(view.profiles)),
+    metrics,
+    quotedEvents: new Map<string, FeedEvent>(Object.entries(view.quoted)),
   };
 }
 
@@ -228,6 +265,7 @@ export function useThread(eventId: string): UseThreadResult {
 
     const seed =
       (eventChanged ? consumeThreadSeed(eventId) : (preservedSeed ?? consumeThreadSeed(eventId))) ??
+      cachedThreadSeed(eventId) ??
       ownContentSeed(eventId, viewerPubkey);
     if (seed) {
       threadSeedRef.current = seed;

--- a/features/feed/hooks/useThread.ts
+++ b/features/feed/hooks/useThread.ts
@@ -12,7 +12,7 @@ import type {
   ThreadSeedBuckets,
 } from '@/features/feed/data/feedClient';
 import { getFeedClient } from '@/features/feed/data/useFeedClient';
-import { consumeThreadSeed, type ThreadSeed } from '@/features/feed/lib/threadSeedCache';
+import { consumeThreadSeed } from '@/features/feed/lib/threadSeedCache';
 import { buildNostrDataLayer } from '@/shared/lib/nostr/buildNostrDataLayer';
 import {
   bucketsFromThreadResult,
@@ -31,7 +31,10 @@ import { ingestOwnContent, useOwnContentStore } from '@/shared/stores/profile/ow
  * posted (or other-client) note opens its thread instantly even before it has
  * round-tripped through relays/nagg. Scoped to the active viewer.
  */
-function ownContentSeed(eventId: string, viewerPubkey: string | undefined): ThreadSeed | undefined {
+function ownContentSeed(
+  eventId: string,
+  viewerPubkey: string | undefined
+): ThreadSeedBuckets | undefined {
   const entry = useOwnContentStore.getState().getOwn(eventId, viewerPubkey);
   if (!entry) return undefined;
   return {
@@ -46,11 +49,12 @@ function ownContentSeed(eventId: string, viewerPubkey: string | undefined): Thre
  * First-frame seed projected from the shared nagg-ts entity cache (populated by
  * every feed/notifications read). When the tapped note was already seen, this
  * paints the post + its cached ancestor chain + author profiles/metrics with NO
- * network — covering deep links and reply-taps that carry no nav snapshot. The
- * cache only walks ANCESTORS, so a feed nav seed (which also carries reply
- * previews) is preferred when present; this fills the gap otherwise.
+ * network. It carries the post + its cached ancestor chain + cached direct reply
+ * previews + author profiles/metrics, fully replacing the old transient nav
+ * snapshot. Returns undefined when the tapped note isn't cached (e.g. a cold deep
+ * link), so the network fetch drives the first frame instead.
  */
-function cachedThreadSeed(eventId: string): ThreadSeed | undefined {
+function cachedThreadSeed(eventId: string): ThreadSeedBuckets | undefined {
   const layer = buildNostrDataLayer();
   if (!layer) return undefined;
   const view = layer.readThread(eventId);
@@ -124,7 +128,6 @@ export function useThread(eventId: string): UseThreadResult {
   const hasMoreRepliesRef = useRef(false);
   const isInitialFetchingRef = useRef(false);
   const isLoadingMoreRepliesRef = useRef(false);
-  const currentEventIdRef = useRef<string | null>(null);
   const requestGenerationRef = useRef(0);
   const loadMoreAbortControllerRef = useRef<AbortController | null>(null);
 
@@ -244,9 +247,6 @@ export function useThread(eventId: string): UseThreadResult {
     if (!eventId) return;
 
     let cancelled = false;
-    const preservedSeed = threadSeedRef.current;
-    const eventChanged = currentEventIdRef.current !== eventId;
-    currentEventIdRef.current = eventId;
     const generation = requestGenerationRef.current + 1;
     requestGenerationRef.current = generation;
     const controller = new AbortController();
@@ -263,9 +263,12 @@ export function useThread(eventId: string): UseThreadResult {
     setIsLoadingMoreReplies(false);
     setHasMoreReplies(false);
 
+    // Cache first (authoritative, complete via readThread's ancestor walk + reply
+    // scan); the transient nav snapshot is a safety net for anything not yet
+    // ingested; own-content covers a just-posted note not yet round-tripped.
     const seed =
-      (eventChanged ? consumeThreadSeed(eventId) : (preservedSeed ?? consumeThreadSeed(eventId))) ??
       cachedThreadSeed(eventId) ??
+      consumeThreadSeed(eventId) ??
       ownContentSeed(eventId, viewerPubkey);
     if (seed) {
       threadSeedRef.current = seed;

--- a/features/feed/lib/threadItems.ts
+++ b/features/feed/lib/threadItems.ts
@@ -79,7 +79,12 @@ export function orderedReplyIdsForThreadResult(
     return [...existingOrder, ...nextPageReplyIds.filter((id) => !existingOrderSet.has(id))];
   }
 
-  return pageReplyIds.length > 0 ? pageReplyIds : fallbackReplyIds;
+  // Initial fetch: keep whatever was already on screen (the cache-seeded previews)
+  // as a stable prefix and APPEND the ranked delta, instead of replacing the order
+  // outright — so the replies don't visibly reshuffle when the network result lands.
+  // With no seed, existingOrder is empty and this is just the server's order.
+  const initialReplyIds = pageReplyIds.length > 0 ? pageReplyIds : fallbackReplyIds;
+  return [...existingOrder, ...initialReplyIds.filter((id) => !existingOrderSet.has(id))];
 }
 
 export function buildThreadItemsFromSeed(

--- a/features/mint/screens/MintAddScreen.tsx
+++ b/features/mint/screens/MintAddScreen.tsx
@@ -32,6 +32,7 @@ import { BottomButtons } from '@/shared/ui/composed/BottomButtons';
 import { ButtonHandler } from '@/shared/ui/composed/ButtonHandler';
 import { ContactRow, mintIdentity } from '@/shared/ui/composed/ContactRow';
 import { List } from '@/shared/ui/composed/List';
+import { SkeletonContentCrossfade } from '@/shared/ui/composed/SkeletonContentCrossfade';
 import { Screen } from '@/shared/ui/composed/Screen';
 import { LoadingIndicator } from '@/shared/blocks/status';
 import { MintCurrencyTabs } from '@/features/mint/components/MintCurrencyTabs';
@@ -579,7 +580,6 @@ export function MintAddScreen() {
   // loading rows render through the SAME List + ContactRow path as real rows —
   // identical container chrome, no content shift on the data swap.
   const isInitialLoading = searchLoading && displayMints.length === 0;
-  const listData: SearchableMint[] = isInitialLoading ? SKELETON_MINTS : displayMints;
   const getItemType = useCallback(
     (item: SearchableMint) => ('isSkeleton' in item ? 'skeleton' : 'mint'),
     []
@@ -745,6 +745,39 @@ export function MintAddScreen() {
     [searchQuery, selectedCurrency]
   );
 
+  // One List renderer for both crossfade branches: the skeleton branch and the
+  // real branch render the SAME List + ContactRow path, so the swap shifts
+  // nothing. Two List instances coexist only for the ~220ms fade.
+  const renderResultList = useCallback(
+    (data: SearchableMint[]) => (
+      <List
+        data={data}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        getItemType={getItemType}
+        extraData={selectedMints}
+        drawDistance={300}
+        style={{ flex: 1, height: 0 }}
+        contentContainerStyle={{ paddingBottom: 120 }}
+        ListHeaderComponent={listHeader}
+        // Skeleton data is non-empty, so the empty state can't flash mid-load.
+        ListEmptyComponent={isInitialLoading ? undefined : emptyComponent}
+        onScroll={handleScroll}
+        scrollEventThrottle={16}
+      />
+    ),
+    [
+      renderItem,
+      keyExtractor,
+      getItemType,
+      selectedMints,
+      listHeader,
+      isInitialLoading,
+      emptyComponent,
+      handleScroll,
+    ]
+  );
+
   return (
     <Screen
       name="MintAddScreen"
@@ -760,20 +793,13 @@ export function MintAddScreen() {
       deferContent={false}>
       <Stack.Screen options={screenOptions} />
       <Spacer size={16} />
-      <List
-        data={listData}
-        renderItem={renderItem}
-        keyExtractor={keyExtractor}
-        getItemType={getItemType}
-        extraData={selectedMints}
-        drawDistance={300}
-        style={{ flex: 1, height: 0 }}
-        contentContainerStyle={{ paddingBottom: 120 }}
-        ListHeaderComponent={listHeader}
-        // Skeleton data is non-empty, so the empty state can't flash mid-load.
-        ListEmptyComponent={isInitialLoading ? undefined : emptyComponent}
-        onScroll={handleScroll}
-        scrollEventThrottle={16}
+      <SkeletonContentCrossfade
+        loading={isInitialLoading}
+        style={{ flex: 1 }}
+        visualKey="mint-add-results"
+        visualSurface="mint-add"
+        renderSkeleton={() => renderResultList(SKELETON_MINTS)}
+        renderContent={() => renderResultList(displayMints)}
       />
     </Screen>
   );

--- a/features/mint/screens/MintInfoScreen.tsx
+++ b/features/mint/screens/MintInfoScreen.tsx
@@ -24,6 +24,7 @@ import { ScreenHeaderAction } from '@/shared/ui/composed/ScreenHeaderAction';
 import Icon from 'assets/icons';
 import { Badge } from '@/shared/ui/primitives/Badge';
 import { MintIcon } from '@/shared/ui/composed/MintIcon';
+import { SkeletonContentCrossfade } from '@/shared/ui/composed/SkeletonContentCrossfade';
 import { Avatar } from '@/shared/ui/primitives/Avatar';
 import * as Clipboard from 'expo-clipboard';
 import { Skeleton } from '@/shared/ui/primitives/Skeleton';
@@ -273,7 +274,9 @@ function StatsGridComponent({
 
   const showSkeleton = !hasValidData;
 
-  return (
+  // Same grid chrome for both branches (only the `loading` bars differ), so the
+  // crossfade swaps content under a fading skeleton with zero shift.
+  const renderGrid = (loading: boolean) => (
     <View style={styles.statsGrid}>
       {[0, 2].map((rowStart) => (
         <View key={rowStart} style={styles.statsRow}>
@@ -290,7 +293,7 @@ function StatsGridComponent({
                     },
                   ]}>
                   <Text
-                    loading={showSkeleton}
+                    loading={loading}
                     placeholder="SUCCESS RATE"
                     bold
                     size={12}
@@ -298,7 +301,7 @@ function StatsGridComponent({
                     {stat.label.toUpperCase()}
                   </Text>
                   <Text
-                    loading={showSkeleton}
+                    loading={loading}
                     placeholder="100%"
                     bold
                     size={stat.accent ? 24 : 20}
@@ -306,7 +309,7 @@ function StatsGridComponent({
                     {stat.value}
                   </Text>
                   <Text
-                    loading={showSkeleton}
+                    loading={loading}
                     placeholder="Completion rate"
                     bold
                     size={12}
@@ -320,6 +323,16 @@ function StatsGridComponent({
         </View>
       ))}
     </View>
+  );
+
+  return (
+    <SkeletonContentCrossfade
+      loading={showSkeleton}
+      visualKey="mint-info-stats"
+      visualSurface="mint-info"
+      renderSkeleton={() => renderGrid(true)}
+      renderContent={() => renderGrid(false)}
+    />
   );
 }
 const StatsGrid = React.memo(StatsGridComponent);
@@ -370,33 +383,31 @@ function RatingBarChartComponent({ score }: { score: number }) {
     }
   }, [isValidScore, goldPercentage, fadeAnim, barScaleAnim]);
 
-  if (showSkeleton) {
-    return (
-      <HStack align="center" gap={16} className="w-full self-stretch px-4">
-        <VStack align="center" className="shrink-0">
-          <Skeleton className="bg-surface-tertiary h-8 w-12 rounded" />
-          <Skeleton className="bg-surface-tertiary mt-2 h-3.5 w-10 rounded" />
-        </VStack>
-        <VStack gap={4} className="min-w-0 flex-1" style={{ flex: 1 }}>
-          {[5, 4, 3, 2, 1].map((stars) => (
-            <HStack key={stars} align="center" gap={2} className="w-full min-w-0">
-              <HStack gap={2} className="shrink-0">
-                {Array.from({ length: stars }).map((_, i) => (
-                  <Icon key={i} name="ic:round-star" size={12} color={defaultColor} />
-                ))}
-              </HStack>
-              <View
-                className="bg-surface-tertiary min-w-0 flex-1 rounded"
-                style={{ height: 8, minWidth: 24 }}
-              />
+  const renderSkeleton = () => (
+    <HStack align="center" gap={16} className="w-full self-stretch px-4">
+      <VStack align="center" className="shrink-0">
+        <Skeleton className="bg-surface-tertiary h-8 w-12 rounded" />
+        <Skeleton className="bg-surface-tertiary mt-2 h-3.5 w-10 rounded" />
+      </VStack>
+      <VStack gap={4} className="min-w-0 flex-1" style={{ flex: 1 }}>
+        {[5, 4, 3, 2, 1].map((stars) => (
+          <HStack key={stars} align="center" gap={2} className="w-full min-w-0">
+            <HStack gap={2} className="shrink-0">
+              {Array.from({ length: stars }).map((_, i) => (
+                <Icon key={i} name="ic:round-star" size={12} color={defaultColor} />
+              ))}
             </HStack>
-          ))}
-        </VStack>
-      </HStack>
-    );
-  }
+            <View
+              className="bg-surface-tertiary min-w-0 flex-1 rounded"
+              style={{ height: 8, minWidth: 24 }}
+            />
+          </HStack>
+        ))}
+      </VStack>
+    </HStack>
+  );
 
-  return (
+  const renderContent = () => (
     <HStack align="center" gap={16} className="w-full self-stretch px-4">
       <VStack align="center" className="shrink-0">
         <Animated.View style={fadeStyle}>
@@ -444,6 +455,16 @@ function RatingBarChartComponent({ score }: { score: number }) {
         })}
       </VStack>
     </HStack>
+  );
+
+  return (
+    <SkeletonContentCrossfade
+      loading={showSkeleton}
+      visualKey="mint-info-rating"
+      visualSurface="mint-info"
+      renderSkeleton={renderSkeleton}
+      renderContent={renderContent}
+    />
   );
 }
 const RatingBarChart = React.memo(RatingBarChartComponent);

--- a/features/mint/screens/MintInfoScreen.tsx
+++ b/features/mint/screens/MintInfoScreen.tsx
@@ -328,6 +328,7 @@ function StatsGridComponent({
   return (
     <SkeletonContentCrossfade
       loading={showSkeleton}
+      surfaceColor={surfaceSecondary}
       visualKey="mint-info-stats"
       visualSurface="mint-info"
       renderSkeleton={() => renderGrid(true)}

--- a/features/mint/screens/MintReviewsScreen.tsx
+++ b/features/mint/screens/MintReviewsScreen.tsx
@@ -18,6 +18,7 @@ import { reviewMint, type MintRecommendation } from '@/shared/lib/apiClient';
 import { useKYMMintStore } from '@/shared/stores/global/kymMintStore';
 import { useIdentityName } from '@/shared/hooks/useIdentityName';
 import { Skeleton } from '@/shared/ui/primitives/Skeleton';
+import { SkeletonContentCrossfade } from '@/shared/ui/composed/SkeletonContentCrossfade';
 import { BottomButtons } from '@/shared/ui/composed/BottomButtons';
 import { ButtonHandler } from '@/shared/ui/composed/ButtonHandler';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -412,12 +413,24 @@ export function MintReviewsScreen() {
   const ListFooter = useMemo(() => {
     if (!isLoading) return null;
     const skeletonCount = reviews.length > 0 ? 2 : 3;
+    // Footer-only skeletons: the real reviews populate the list body, so there's
+    // no in-place content to fade into. Route through the canonical helper for
+    // the region wave; `exit="none"` lets them unmount as the list fills.
     return (
-      <View>
-        {Array.from({ length: skeletonCount }).map((_, i) => (
-          <ReviewSkeleton key={`skeleton-${i}`} isLast={i === skeletonCount - 1} />
-        ))}
-      </View>
+      <SkeletonContentCrossfade
+        loading
+        exit="none"
+        visualKey="mint-reviews-list"
+        visualSurface="mint-reviews"
+        renderSkeleton={() => (
+          <View>
+            {Array.from({ length: skeletonCount }).map((_, i) => (
+              <ReviewSkeleton key={`skeleton-${i}`} isLast={i === skeletonCount - 1} />
+            ))}
+          </View>
+        )}
+        renderContent={() => null}
+      />
     );
   }, [isLoading, reviews.length]);
 

--- a/features/nostrSigner/components/SummaryPreviewCards.tsx
+++ b/features/nostrSigner/components/SummaryPreviewCards.tsx
@@ -32,6 +32,7 @@ import { popup } from '@/shared/lib/popup';
 import { Avatar } from '@/shared/ui/primitives/Avatar';
 import { Pressable } from '@/shared/ui/primitives/Pressable';
 import { Skeleton } from '@/shared/ui/primitives/Skeleton';
+import { SkeletonContentCrossfade } from '@/shared/ui/composed/SkeletonContentCrossfade';
 import { Text } from '@/shared/ui/primitives/Text';
 import { HStack } from '@/shared/ui/primitives/View/HStack';
 import { View } from '@/shared/ui/primitives/View/View';
@@ -139,20 +140,9 @@ export function ReferencedNoteCard({
 
   if (eventId === undefined) return null;
 
-  if (fetched.status === 'loading' || fetched.status === 'idle') {
-    return (
-      <View className="bg-surface rounded-2xl p-3" style={PREVIEW_CARD_STYLE}>
-        <HStack spacing={8} style={CENTER_ROW_STYLE}>
-          <Skeleton style={SKELETON_AVATAR_STYLE} />
-          <Skeleton style={SKELETON_NAME_STYLE} />
-        </HStack>
-        <Skeleton style={SKELETON_LINE_FULL_STYLE} />
-        <Skeleton style={SKELETON_LINE_SHORT_STYLE} />
-      </View>
-    );
-  }
+  const isPreviewLoading = fetched.status === 'loading' || fetched.status === 'idle';
 
-  if (fetched.status === 'unavailable' || fetched.event === undefined) {
+  if (!isPreviewLoading && (fetched.status === 'unavailable' || fetched.event === undefined)) {
     return (
       <View className="bg-surface rounded-2xl p-3">
         <Text size={13} color={muted}>
@@ -163,16 +153,36 @@ export function ReferencedNoteCard({
   }
 
   return (
-    <View className="bg-surface rounded-2xl p-3" style={PREVIEW_CARD_STYLE}>
-      <PeerIdentityRow
-        pubkey={fetched.event.pubkey}
-        nameOverride={fetched.author?.name}
-        pictureOverride={fetched.author?.picture}
-      />
-      <Text size={14} numberOfLines={3} color={foreground}>
-        {boundDisplay(fetched.event.content.trim(), CONTENT_PREVIEW_MAX_CHARS)}
-      </Text>
-    </View>
+    <SkeletonContentCrossfade
+      loading={isPreviewLoading}
+      visualKey="referenced-post-preview"
+      visualSurface="nostr-signer"
+      renderSkeleton={() => (
+        <View className="bg-surface rounded-2xl p-3" style={PREVIEW_CARD_STYLE}>
+          <HStack spacing={8} style={CENTER_ROW_STYLE}>
+            <Skeleton style={SKELETON_AVATAR_STYLE} />
+            <Skeleton style={SKELETON_NAME_STYLE} />
+          </HStack>
+          <Skeleton style={SKELETON_LINE_FULL_STYLE} />
+          <Skeleton style={SKELETON_LINE_SHORT_STYLE} />
+        </View>
+      )}
+      renderContent={() => {
+        if (fetched.event === undefined) return null;
+        return (
+          <View className="bg-surface rounded-2xl p-3" style={PREVIEW_CARD_STYLE}>
+            <PeerIdentityRow
+              pubkey={fetched.event.pubkey}
+              nameOverride={fetched.author?.name}
+              pictureOverride={fetched.author?.picture}
+            />
+            <Text size={14} numberOfLines={3} color={foreground}>
+              {boundDisplay(fetched.event.content.trim(), CONTENT_PREVIEW_MAX_CHARS)}
+            </Text>
+          </View>
+        );
+      }}
+    />
   );
 }
 

--- a/features/nostrSigner/components/SummaryPreviewCards.tsx
+++ b/features/nostrSigner/components/SummaryPreviewCards.tsx
@@ -124,7 +124,7 @@ export function ReferencedNoteCard({
   eventId?: string;
   embedded?: { id?: string; pubkey: string; text: string };
 }) {
-  const [foreground, muted] = useThemeColor(['foreground', 'muted'] as const);
+  const [foreground, muted, surface] = useThemeColor(['foreground', 'muted', 'surface'] as const);
   const fetched = useReferencedEventPreview(embedded === undefined ? eventId : undefined);
 
   if (embedded !== undefined) {
@@ -155,6 +155,7 @@ export function ReferencedNoteCard({
   return (
     <SkeletonContentCrossfade
       loading={isPreviewLoading}
+      surfaceColor={surface}
       visualKey="referenced-post-preview"
       visualSurface="nostr-signer"
       renderSkeleton={() => (

--- a/features/receive/screens/ReceiveScreen.tsx
+++ b/features/receive/screens/ReceiveScreen.tsx
@@ -30,6 +30,7 @@ import { Screen as ScreenWrapper } from '@/shared/ui/composed/Screen';
 import { ScreenErrorState } from '@/shared/ui/composed/ScreenStates';
 import { UnderlineTabs } from '@/shared/ui/composed/UnderlineTabs';
 import { Skeleton } from '@/shared/ui/primitives/Skeleton';
+import { SkeletonContentCrossfade } from '@/shared/ui/composed/SkeletonContentCrossfade';
 import { EnhancedHaptics } from '@/shared/ui/primitives/Haptics';
 import { Text } from '@/shared/ui/primitives/Text';
 import { View } from '@/shared/ui/primitives/View/View';
@@ -337,21 +338,28 @@ export function ReceiveScreen({ receiveEntry, unit }: ReceiveScreenProps) {
         </View>
       )}
 
-      {!receiveEntryData ? (
-        <ReceiveHubPlaceholder />
-      ) : quickAccessP2PK && selectedTab === 'P2PK' ? (
-        <ReceiveP2pkTab data={receiveEntryData} actions={actions} muted={muted} />
-      ) : (
-        <ReceiveLightningTab
-          data={receiveEntryData}
-          unit={unit}
-          mintInfo={mintInfo}
-          selectedMintUrl={mintUrl}
-          isNpcMintUpdating={isNpcMintUpdating}
-          actions={actions}
-          muted={muted}
-        />
-      )}
+      <SkeletonContentCrossfade
+        loading={!receiveEntryData}
+        visualKey="receive-hub"
+        visualSurface="receive"
+        renderSkeleton={() => <ReceiveHubPlaceholder />}
+        renderContent={() => {
+          if (!receiveEntryData) return null;
+          return quickAccessP2PK && selectedTab === 'P2PK' ? (
+            <ReceiveP2pkTab data={receiveEntryData} actions={actions} muted={muted} />
+          ) : (
+            <ReceiveLightningTab
+              data={receiveEntryData}
+              unit={unit}
+              mintInfo={mintInfo}
+              selectedMintUrl={mintUrl}
+              isNpcMintUpdating={isNpcMintUpdating}
+              actions={actions}
+              muted={muted}
+            />
+          );
+        }}
+      />
     </ScreenWrapper>
   );
 }

--- a/features/settings/index.ts
+++ b/features/settings/index.ts
@@ -12,6 +12,7 @@ export { SettingsDesignSystemLoadingScreen } from './screens/SettingsDesignSyste
 export { SettingsDesignSystemSegmentedScreen } from './screens/SettingsDesignSystemSegmentedScreen';
 export { SettingsDesignSystemTimelineScreen } from './screens/SettingsDesignSystemTimelineScreen';
 export { SettingsDesignSystemEmptyStatesScreen } from './screens/SettingsDesignSystemEmptyStatesScreen';
+export { SettingsDesignSystemSkeletonCrossfadeScreen } from './screens/SettingsDesignSystemSkeletonCrossfadeScreen';
 export { SettingsAvatarScreen } from './screens/SettingsAvatarScreen';
 export { SettingsNotificationPolicyScreen } from './screens/SettingsNotificationPolicyScreen';
 export { DeleteScreen } from './screens/DeleteScreen';

--- a/features/settings/screens/SettingsDesignSystemScreen.tsx
+++ b/features/settings/screens/SettingsDesignSystemScreen.tsx
@@ -36,6 +36,11 @@ const COMPONENTS: ComponentEntry[] = [
     title: 'Empty states',
     description: 'Every "nothing to show" surface, unified via EmptyState',
   },
+  {
+    href: '/(settings-flow)/design-system-skeleton-crossfade',
+    title: 'Skeleton crossfade',
+    description: 'Region wave, 220ms skeleton→content fade, independent image fades',
+  },
 ];
 
 const DesignSystemLinkItem: React.FC<ComponentEntry> = ({ href, title, description }) => (

--- a/features/settings/screens/SettingsDesignSystemSkeletonCrossfadeScreen.tsx
+++ b/features/settings/screens/SettingsDesignSystemSkeletonCrossfadeScreen.tsx
@@ -5,10 +5,10 @@ import { Button, Card } from 'heroui-native';
 
 import { Screen as ScreenWrapper } from '@/shared/ui/composed/Screen';
 import { Text } from '@/shared/ui/primitives/Text';
-import { View } from '@/shared/ui/primitives/View/View';
 import { VStack } from '@/shared/ui/primitives/View/VStack';
 import { HStack } from '@/shared/ui/primitives/View/HStack';
 import { Avatar } from '@/shared/ui/primitives/Avatar';
+import { useThemeColor } from '@/shared/hooks/useThemeColor';
 import { SkeletonContentCrossfade } from '@/shared/ui/composed/SkeletonContentCrossfade';
 
 const STEP_DURATION_MS = 2200;
@@ -38,6 +38,9 @@ function DemoProfileRow({ loading, pictureUrl }: { loading: boolean; pictureUrl?
 }
 
 export function SettingsDesignSystemSkeletonCrossfadeScreen() {
+  // The demo cards are `Card variant="secondary"` — the wave must match THAT
+  // surface (what the skeleton sits on), not the screen background.
+  const surfaceSecondary = useThemeColor('surface-secondary');
   const [loading, setLoading] = useState(true);
   const [auto, setAuto] = useState(true);
   // Bust expo-image's cache each cycle so the avatar performs a real load and
@@ -97,6 +100,7 @@ export function SettingsDesignSystemSkeletonCrossfadeScreen() {
             <SkeletonContentCrossfade
               loading={loading}
               wave="region"
+              surfaceColor={surfaceSecondary}
               renderSkeleton={() => <DemoProfileRow loading />}
               renderContent={() => <DemoProfileRow loading={false} pictureUrl={pictureUrl} />}
             />
@@ -115,9 +119,7 @@ export function SettingsDesignSystemSkeletonCrossfadeScreen() {
             <SkeletonContentCrossfade
               loading={loading}
               wave="none"
-              renderSkeleton={() => (
-                <Text loading placeholder="1,000 sats" bold size={20} />
-              )}
+              renderSkeleton={() => <Text loading placeholder="1,000 sats" bold size={20} />}
               renderContent={() => (
                 <Text bold size={20} className="text-foreground">
                   21,000 sats
@@ -150,7 +152,10 @@ export function SettingsDesignSystemSkeletonCrossfadeScreen() {
             <Button variant="secondary" size="sm" onPress={toggle}>
               <Button.Label>{loading ? 'Show content' : 'Show skeleton'}</Button.Label>
             </Button>
-            <Button variant={auto ? 'primary' : 'secondary'} size="sm" onPress={() => setAuto((v) => !v)}>
+            <Button
+              variant={auto ? 'primary' : 'secondary'}
+              size="sm"
+              onPress={() => setAuto((v) => !v)}>
               <Button.Label>{auto ? 'Stop auto-cycle' : 'Start auto-cycle'}</Button.Label>
             </Button>
           </Card.Body>

--- a/features/settings/screens/SettingsDesignSystemSkeletonCrossfadeScreen.tsx
+++ b/features/settings/screens/SettingsDesignSystemSkeletonCrossfadeScreen.tsx
@@ -1,0 +1,161 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { ScrollView } from 'react-native';
+
+import { Button, Card } from 'heroui-native';
+
+import { Screen as ScreenWrapper } from '@/shared/ui/composed/Screen';
+import { Text } from '@/shared/ui/primitives/Text';
+import { View } from '@/shared/ui/primitives/View/View';
+import { VStack } from '@/shared/ui/primitives/View/VStack';
+import { HStack } from '@/shared/ui/primitives/View/HStack';
+import { Avatar } from '@/shared/ui/primitives/Avatar';
+import { SkeletonContentCrossfade } from '@/shared/ui/composed/SkeletonContentCrossfade';
+
+const STEP_DURATION_MS = 2200;
+
+/** Profile-style row: SAME chrome in both branches (only the `loading` bars
+ *  differ), so the crossfade reveals content under a fading skeleton with zero
+ *  layout shift. */
+function DemoProfileRow({ loading, pictureUrl }: { loading: boolean; pictureUrl?: string }) {
+  return (
+    <HStack align="center" gap={12}>
+      <Avatar
+        state={loading ? 'loading' : pictureUrl ? 'image' : 'fallback'}
+        size={44}
+        picture={pictureUrl}
+        name="Sovran"
+      />
+      <VStack spacing={4} className="flex-1">
+        <Text loading={loading} placeholder="Display Name" bold size={15}>
+          Satoshi Nakamoto
+        </Text>
+        <Text loading={loading} placeholder="@handle@relay.example" size={13}>
+          @satoshi@sovran.money
+        </Text>
+      </VStack>
+    </HStack>
+  );
+}
+
+export function SettingsDesignSystemSkeletonCrossfadeScreen() {
+  const [loading, setLoading] = useState(true);
+  const [auto, setAuto] = useState(true);
+  // Bust expo-image's cache each cycle so the avatar performs a real load and
+  // fades in independently of the data crossfade.
+  const [imageSeed, setImageSeed] = useState(1);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (!auto) {
+      if (timerRef.current) clearInterval(timerRef.current);
+      timerRef.current = null;
+      return;
+    }
+    timerRef.current = setInterval(() => {
+      setLoading((prev) => {
+        const next = !prev;
+        if (!next) setImageSeed((s) => s + 1);
+        return next;
+      });
+    }, STEP_DURATION_MS);
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+      timerRef.current = null;
+    };
+  }, [auto]);
+
+  const toggle = useCallback(() => {
+    setAuto(false);
+    setLoading((prev) => {
+      const next = !prev;
+      if (!next) setImageSeed((s) => s + 1);
+      return next;
+    });
+  }, []);
+
+  const pictureUrl = loading ? undefined : `https://picsum.photos/seed/sovran-${imageSeed}/88`;
+
+  return (
+    <ScreenWrapper name="SettingsDesignSystemSkeletonCrossfadeScreen" scroll="custom" safeArea>
+      <ScrollView className="px-4">
+        <Text size={12} className="text-foreground/60 mb-4 mt-2">
+          The canonical{' '}
+          <Text size={12} bold className="text-foreground">
+            SkeletonContentCrossfade
+          </Text>
+          . While loading, a sizeable region shows the wave; on data arrival the skeleton fades out
+          and content fades in. Images fade in independently (their own expo-image transition), and
+          system Reduce Motion turns the wave + fade into an instant swap.
+        </Text>
+
+        {/* 1 — Region wave + crossfade */}
+        <Card variant="secondary" className="mb-4">
+          <Card.Body className="gap-3 py-5">
+            <Text size={11} bold className="text-foreground/50 tracking-widest">
+              REGION WAVE + CROSSFADE
+            </Text>
+            <SkeletonContentCrossfade
+              loading={loading}
+              wave="region"
+              renderSkeleton={() => <DemoProfileRow loading />}
+              renderContent={() => <DemoProfileRow loading={false} pictureUrl={pictureUrl} />}
+            />
+          </Card.Body>
+        </Card>
+
+        {/* 2 — Inline (no wave) */}
+        <Card variant="secondary" className="mb-4">
+          <Card.Body className="gap-3 py-5">
+            <Text size={11} bold className="text-foreground/50 tracking-widest">
+              INLINE — PULSE, NO WAVE
+            </Text>
+            <Text size={12} className="text-foreground/60">
+              Compact swaps keep the cheap pulse and skip the sweep.
+            </Text>
+            <SkeletonContentCrossfade
+              loading={loading}
+              wave="none"
+              renderSkeleton={() => (
+                <Text loading placeholder="1,000 sats" bold size={20} />
+              )}
+              renderContent={() => (
+                <Text bold size={20} className="text-foreground">
+                  21,000 sats
+                </Text>
+              )}
+            />
+          </Card.Body>
+        </Card>
+
+        {/* 3 — Independent image fade */}
+        <Card variant="secondary" className="mb-4">
+          <Card.Body className="gap-3 py-5">
+            <Text size={11} bold className="text-foreground/50 tracking-widest">
+              INDEPENDENT IMAGE FADE
+            </Text>
+            <Text size={12} className="text-foreground/60">
+              Text settles immediately; the avatar image fades in on its own when it finishes
+              loading — the crossfade never waits on it.
+            </Text>
+            <DemoProfileRow loading={false} pictureUrl={pictureUrl} />
+          </Card.Body>
+        </Card>
+
+        {/* Controls */}
+        <Card variant="secondary" className="mb-4">
+          <Card.Body className="gap-3">
+            <Text size={11} bold className="text-foreground/50 tracking-widest">
+              STATE: {loading ? 'LOADING' : 'LOADED'}
+            </Text>
+            <Button variant="secondary" size="sm" onPress={toggle}>
+              <Button.Label>{loading ? 'Show content' : 'Show skeleton'}</Button.Label>
+            </Button>
+            <Button variant={auto ? 'primary' : 'secondary'} size="sm" onPress={() => setAuto((v) => !v)}>
+              <Button.Label>{auto ? 'Stop auto-cycle' : 'Start auto-cycle'}</Button.Label>
+            </Button>
+          </Card.Body>
+        </Card>
+      </ScrollView>
+    </ScreenWrapper>
+  );
+}

--- a/features/transactions/components/detail/HistoryEntryRefresh.tsx
+++ b/features/transactions/components/detail/HistoryEntryRefresh.tsx
@@ -11,6 +11,7 @@ import type { HistoryEntry } from '@cashu/coco-core';
 import Icon from 'assets/icons';
 import { MintIcon } from '@/shared/ui/composed/MintIcon';
 import { Skeleton } from '@/shared/ui/primitives/Skeleton';
+import { SkeletonContentCrossfade } from '@/shared/ui/composed/SkeletonContentCrossfade';
 import { GradientCard } from '@/shared/ui/composed/GradientCard';
 import { useThemeColor } from '@/shared/hooks/useThemeColor';
 import { usePaymentCopyResolver } from '@/shared/hooks/usePaymentCopyResolver';
@@ -55,13 +56,18 @@ export function HistoryEntryRefresh({ mintInfo, historyEntry, onPress }: History
       </ListGroup.ItemPrefix>
       <ListGroup.ItemContent>
         <ListGroup.ItemTitle className="font-normal">{statusLabel}</ListGroup.ItemTitle>
-        {loading ? (
-          <Skeleton className="mt-1 h-4 w-28 rounded-md" />
-        ) : (
-          <ListGroup.ItemDescription className="text-foreground text-base font-bold">
-            {mintInfo?.name}
-          </ListGroup.ItemDescription>
-        )}
+        <SkeletonContentCrossfade
+          loading={loading}
+          wave="none"
+          visualKey="history-refresh-name"
+          visualSurface="transactions"
+          renderSkeleton={() => <Skeleton className="mt-1 h-4 w-28 rounded-md" />}
+          renderContent={() => (
+            <ListGroup.ItemDescription className="text-foreground text-base font-bold">
+              {mintInfo?.name}
+            </ListGroup.ItemDescription>
+          )}
+        />
       </ListGroup.ItemContent>
       {onPress && (
         <ListGroup.ItemSuffix>

--- a/shared/blocks/PaymentInfo.tsx
+++ b/shared/blocks/PaymentInfo.tsx
@@ -14,6 +14,7 @@ import {
 import { HStack } from '@/shared/ui/primitives/View/HStack';
 import { View } from '@/shared/ui/primitives/View/View';
 import { Skeleton } from '@/shared/ui/primitives/Skeleton';
+import { SkeletonContentCrossfade } from '@/shared/ui/composed/SkeletonContentCrossfade';
 import { copyPopup, type CopyTarget } from '@/shared/lib/popup';
 import { EnhancedHaptics } from '@/shared/ui/primitives/Haptics';
 import { Log, paymentLog } from '@/shared/lib/logger';
@@ -100,76 +101,84 @@ export function PaymentInfo({
     copyPopup(copyTarget);
   }, [link, selectedValue, copyTarget]);
 
-  if (!selectedValue) {
+  const loading = !selectedValue;
+  if (loading) {
     paymentLog.debug('ui.payment_info.empty', {
       dataType: typeof data,
       isArray: Array.isArray(data),
     });
-    return (
-      <HStack align="center" justify="center">
-        <Skeleton className="bg-surface-secondary h-64 w-64" />
-      </HStack>
-    );
+  } else {
+    paymentLog.debug('ui.payment_info.render', {
+      unit,
+      copyTarget,
+      animated: willAnimate,
+      variant,
+      dataLength: selectedValue.length,
+    });
   }
 
-  paymentLog.debug('ui.payment_info.render', {
-    unit,
-    copyTarget,
-    animated: willAnimate,
-    variant,
-    dataLength: selectedValue.length,
-  });
-
   return (
-    <Log name="PaymentInfo">
-      <View>
-        {/* Hidden Text node carrying the full payment value, so log-doctor's
+    <SkeletonContentCrossfade
+      loading={loading}
+      visualKey="payment-info"
+      visualSurface="payment"
+      renderSkeleton={() => (
+        <HStack align="center" justify="center">
+          <Skeleton className="bg-surface-secondary h-64 w-64" />
+        </HStack>
+      )}
+      renderContent={() => (
+        <Log name="PaymentInfo">
+          <View>
+            {/* Hidden Text node carrying the full payment value, so log-doctor's
             `capture-id-label` step can read the token/address straight from
             the AX tree without bouncing through the iOS pasteboard. Text
             elements are always included in the iOS AX tree (unlike Views
             with opacity:0, which iOS strips), and the visible content is
             what populates the WDA `name`/`label` fields — that's why the
             value is the Text child rather than `accessibilityLabel`. */}
-        <Text
-          testID={`payment-info-${kebabCase(copyTarget)}-data`}
-          numberOfLines={1}
-          style={{
-            position: 'absolute',
-            width: 1,
-            height: 1,
-            fontSize: 1,
-            color: 'transparent',
-            overflow: 'hidden',
-          }}>
-          {selectedValue}
-        </Text>
-        {/* QR code — tap to copy */}
-        <Pressable onPress={handleCopyPress}>
-          <ViewShot captureMode="mount" onCapture={setUri}>
-            <AnimatedQRCode
-              padding={32}
-              unit={unit}
-              address={selectedValue}
-              animate={animated}
-              variant={variant}
-              intervalMs={SPEED_PRESETS[speedIndex].intervalMs}
-              fragmentSize={DENSITY_PRESETS[densityIndex].fragmentSize}
-            />
-          </ViewShot>
-        </Pressable>
+            <Text
+              testID={`payment-info-${kebabCase(copyTarget)}-data`}
+              numberOfLines={1}
+              style={{
+                position: 'absolute',
+                width: 1,
+                height: 1,
+                fontSize: 1,
+                color: 'transparent',
+                overflow: 'hidden',
+              }}>
+              {selectedValue}
+            </Text>
+            {/* QR code — tap to copy */}
+            <Pressable onPress={handleCopyPress}>
+              <ViewShot captureMode="mount" onCapture={setUri}>
+                <AnimatedQRCode
+                  padding={32}
+                  unit={unit}
+                  address={selectedValue}
+                  animate={animated}
+                  variant={variant}
+                  intervalMs={SPEED_PRESETS[speedIndex].intervalMs}
+                  fragmentSize={DENSITY_PRESETS[densityIndex].fragmentSize}
+                />
+              </ViewShot>
+            </Pressable>
 
-        {/* Speed + Density controls — outside the copy pressable */}
-        {willAnimate && (
-          <View style={{ marginTop: 12 }}>
-            <QRSpeedControls
-              speedIndex={speedIndex}
-              densityIndex={densityIndex}
-              onCycleSpeed={cycleSpeed}
-              onCycleDensity={cycleDensity}
-            />
+            {/* Speed + Density controls — outside the copy pressable */}
+            {willAnimate && (
+              <View style={{ marginTop: 12 }}>
+                <QRSpeedControls
+                  speedIndex={speedIndex}
+                  densityIndex={densityIndex}
+                  onCycleSpeed={cycleSpeed}
+                  onCycleDensity={cycleDensity}
+                />
+              </View>
+            )}
           </View>
-        )}
-      </View>
-    </Log>
+        </Log>
+      )}
+    />
   );
 }

--- a/shared/lib/loggerCore.ts
+++ b/shared/lib/loggerCore.ts
@@ -285,12 +285,33 @@ const SECRET_STRING_PATTERNS: { name: string; test: (s: string) => boolean }[] =
   // their preview) when you need a readable identity in logs. Runs before the
   // base64/hex long-string patterns, which would otherwise preview it.
   { name: 'hex32', test: (s) => /^(0x)?[0-9a-fA-F]{64}$/.test(s) },
+  // BIP32 extended PRIVATE keys (xprv/yprv/zprv + testnet tprv/uprv/vprv).
+  // base58, ~111 chars — without this they fall through to the base64 long
+  // pattern and (being ≤120) get logged in full.
+  {
+    name: 'xprv',
+    test: (s) => /^(xprv|yprv|zprv|tprv|uprv|vprv)[1-9A-HJ-NP-Za-km-z]{100,}$/.test(s),
+  },
+  // WIF private keys: base58, mainnet 5/K/L, testnet 9/c, 51-52 chars.
+  // Otherwise classified as a generic long_string and logged in full.
+  { name: 'wif', test: (s) => /^[59cKL][1-9A-HJ-NP-Za-km-z]{50,51}$/.test(s) },
+  // base64 that decodes to a 32- or 64-byte payload — the size of a private key
+  // or seed. Ambiguous (could be a 32-byte hash) but we hide rather than risk
+  // leaking key material; the length is still reported via `len`.
+  {
+    name: 'base64_key',
+    test: (s) => /^[A-Za-z0-9+/]{43}={0,1}$|^[A-Za-z0-9+/]{86,88}={0,2}$/.test(s),
+  },
 ];
 
 const EMBEDDED_SECRET_PATTERNS: { replacement: string; pattern: RegExp }[] = [
   {
     replacement: '<REDACTED:nsec>',
     pattern: /\bnsec1[023456789acdefghjklmnpqrstuvwxyz]{58}\b/g,
+  },
+  {
+    replacement: '<REDACTED:xprv>',
+    pattern: /\b(xprv|yprv|zprv|tprv|uprv|vprv)[1-9A-HJ-NP-Za-km-z]{100,}/g,
   },
   {
     replacement: '<REDACTED:cashu-token>',
@@ -306,28 +327,38 @@ const EMBEDDED_SECRET_PATTERNS: { replacement: string; pattern: RegExp }[] = [
   },
 ];
 
-const LONG_STRING_PATTERNS: { name: string; test: (s: string) => boolean }[] = [
-  { name: 'npub', test: (s) => /^npub1[023456789acdefghjklmnpqrstuvwxyz]{58}$/.test(s) },
-  { name: 'base64', test: (s) => /^[A-Za-z0-9+/]{60,}={0,2}$/.test(s) },
-  { name: 'hex', test: (s) => /^(0x)?[0-9a-fA-F]{40,}$/.test(s) },
-  {
-    name: 'uuid',
-    test: (s) => /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(s),
-  },
-  { name: 'url', test: (s) => /^https?:\/\/.{80,}/.test(s) },
-  { name: 'json_blob', test: (s) => s.length > 200 && (s[0] === '{' || s[0] === '[') },
-  { name: 'xml_blob', test: (s) => s.length > 200 && s.trimStart().startsWith('<') },
-  { name: 'solana_pubkey', test: (s) => /^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(s) && s.length >= 32 },
-];
+// `noPreview` marks opaque encodings whose first 32 chars could themselves be
+// key material — emit `{ _kind, len }` only, never the bytes (even when short
+// enough to otherwise print in full).
+const LONG_STRING_PATTERNS: { name: string; noPreview?: boolean; test: (s: string) => boolean }[] =
+  [
+    { name: 'npub', test: (s) => /^npub1[023456789acdefghjklmnpqrstuvwxyz]{58}$/.test(s) },
+    { name: 'base64', noPreview: true, test: (s) => /^[A-Za-z0-9+/]{60,}={0,2}$/.test(s) },
+    { name: 'hex', noPreview: true, test: (s) => /^(0x)?[0-9a-fA-F]{40,}$/.test(s) },
+    {
+      name: 'uuid',
+      test: (s) => /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(s),
+    },
+    { name: 'url', test: (s) => /^https?:\/\/.{80,}/.test(s) },
+    { name: 'json_blob', test: (s) => s.length > 200 && (s[0] === '{' || s[0] === '[') },
+    { name: 'xml_blob', test: (s) => s.length > 200 && s.trimStart().startsWith('<') },
+    // Opaque base58 (>=32 chars): could be a Solana pubkey, a base58-encoded key,
+    // or other key material. Indistinguishable by value, so never show the bytes.
+    {
+      name: 'base58',
+      noPreview: true,
+      test: (s) => /^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(s) && s.length >= 32,
+    },
+  ];
 
 type StringClass =
   | { kind: 'secret'; name: string }
-  | { kind: 'long'; name: string }
-  | { kind: 'long'; name: 'long_string' };
+  | { kind: 'long'; name: string; noPreview?: boolean };
 
 function classifyString(s: string): StringClass {
   for (const p of SECRET_STRING_PATTERNS) if (p.test(s)) return { kind: 'secret', name: p.name };
-  for (const p of LONG_STRING_PATTERNS) if (p.test(s)) return { kind: 'long', name: p.name };
+  for (const p of LONG_STRING_PATTERNS)
+    if (p.test(s)) return { kind: 'long', name: p.name, noPreview: p.noPreview };
   return { kind: 'long', name: 'long_string' };
 }
 
@@ -349,6 +380,9 @@ function summarizeString(s: string, maxLen: number): Compact {
     if (redacted.length <= maxLen) return redacted;
     return { _kind: 'redacted_string', len: s.length, preview: redacted.slice(0, 32) + '…' };
   }
+  // Opaque encodings (hex/base64/base58) could be key material — never show
+  // their bytes, even when short enough to otherwise print in full.
+  if (c.kind === 'long' && c.noPreview) return { _kind: c.name, len: s.length };
   if (s.length <= maxLen) return s;
   return { _kind: c.name, len: s.length, preview: s.slice(0, 32) + '…' };
 }

--- a/shared/lib/nostr/buildNostrDataLayer.ts
+++ b/shared/lib/nostr/buildNostrDataLayer.ts
@@ -3,17 +3,26 @@ import { createNaggClient, setNostrLogger, facade, type NostrLogger } from '@sov
 import { backendConfig } from '@/shared/config/backend';
 import { log } from '@/shared/lib/logger';
 import { getNostrTierConfig } from '@/shared/lib/nostr/nostrTierConfig';
+import { useProfileStore } from '@/shared/stores/global/profileStore';
 
 // ---------------------------------------------------------------------------
-// Builds the tier-selecting Nostr data-layer facade from the live config +
-// dev tier toggles (Settings → Network). A disabled tier is omitted from the
-// nagg → Primal → relay fallback chain, so the toggles actually change which
-// source serves a read.
+// The tier-selecting Nostr data-layer facade — a PROFILE-SCOPED SINGLETON.
 //
-// NOTE (local-dev proof): this imports the facade from @sovranbitcoin/nagg-ts.
-// The facade only exists in the LOCAL (symlinked) nagg-ts; the published
-// registry 0.5.0 predates it, so an EAS/release build will fail to resolve
-// these symbols until nagg-ts is published. Local dev is fine.
+// One shared facade (and therefore one shared entity cache) is memoised per
+// active profile + tier configuration. Every caller — feed, thread, DM, profile
+// search — gets the SAME instance, so a profile fetched for search instantly
+// renders in the feed, and a note seen in the feed opens as a thread with no
+// refetch. (Previously each call built a fresh facade with a fresh cache, so the
+// cache never accumulated across reads.)
+//
+// On identity switch the active pubkey changes, so the memo misses and the old
+// profile-scoped cache is cleared and replaced — one account never serves
+// another's cached data (ADR-0002). Tier toggles (Settings → Network) likewise
+// rebuild, so a disabled tier drops out of the nagg → Primal → relay chain.
+//
+// NOTE (local-dev proof): the facade only exists in the LOCAL (symlinked)
+// nagg-ts; the published registry 0.5.0 predates it, so an EAS/release build
+// fails to resolve these symbols until nagg-ts is published. Local dev is fine.
 // ---------------------------------------------------------------------------
 
 let loggerBridged = false;
@@ -30,14 +39,10 @@ function bridgeNostrLoggerOnce(): void {
   setNostrLogger(bridge);
 }
 
-/**
- * Build a facade whose tiers reflect the current enable/disable toggles.
- * Returns null when every tier is disabled (nothing can serve a read).
- */
-export function buildNostrDataLayer(): facade.NostrDataLayer | null {
-  bridgeNostrLoggerOnce();
-  const config = getNostrTierConfig();
+type TierConfig = ReturnType<typeof getNostrTierConfig>;
 
+/** Assemble a fresh facade whose tiers reflect the enable/disable toggles. */
+function assembleLayer(config: TierConfig): facade.NostrDataLayer | null {
   const tiers: facade.NostrTierStrategy[] = [];
 
   if (config.nagg.enabled) {
@@ -64,4 +69,40 @@ export function buildNostrDataLayer(): facade.NostrDataLayer | null {
     return null;
   }
   return facade.createNostrDataLayer({ tiers });
+}
+
+type LayerMemo = {
+  layer: facade.NostrDataLayer;
+  configKey: string;
+  pubkey: string | undefined;
+};
+
+let memo: LayerMemo | null = null;
+
+function activeViewerPubkey(): string | undefined {
+  return useProfileStore.getState().getActiveProfile()?.pubkey;
+}
+
+/**
+ * The profile-scoped Nostr data-layer singleton (see file header). Returns the
+ * memoised facade for the active profile + tier config, rebuilding only when the
+ * identity or the toggles change. Returns null when every tier is disabled.
+ */
+export function buildNostrDataLayer(): facade.NostrDataLayer | null {
+  bridgeNostrLoggerOnce();
+  const config = getNostrTierConfig();
+  const configKey = JSON.stringify(config);
+  const pubkey = activeViewerPubkey();
+
+  if (memo && memo.configKey === configKey && memo.pubkey === pubkey) return memo.layer;
+
+  // Identity switch: drop the prior profile's cache before serving the new one.
+  if (memo && memo.pubkey !== pubkey) {
+    memo.layer.cache.clear();
+    log.info('nostr.facade.profile_switch_cleared');
+  }
+
+  const layer = assembleLayer(config);
+  memo = layer ? { layer, configKey, pubkey } : null;
+  return layer;
 }

--- a/shared/lib/nostr/buildNostrDataLayer.ts
+++ b/shared/lib/nostr/buildNostrDataLayer.ts
@@ -84,6 +84,29 @@ function activeViewerPubkey(): string | undefined {
 }
 
 /**
+ * Seed the active profile's cached name/picture (from profileStore) into the
+ * entity cache at low confidence ('cache' rank, seenAt 0) so the viewer's own
+ * pfp/name render instantly — notably on the notifications screen, whose targets
+ * are the viewer's own posts — with zero fetch. A real kind-0 from any tier
+ * overrides it. Re-run on every (re)build so it survives an identity switch.
+ */
+function seedOwnProfile(layer: facade.NostrDataLayer): void {
+  const profile = useProfileStore.getState().getActiveProfile();
+  if (!profile?.pubkey) return;
+  const { cachedDisplayName, cachedPicture } = profile;
+  if (!cachedDisplayName && !cachedPicture) return;
+  layer.cache.ingestProfileInfos(
+    {
+      [profile.pubkey]: {
+        name: cachedDisplayName ?? '',
+        ...(cachedPicture ? { picture: cachedPicture } : {}),
+      },
+    },
+    'cache'
+  );
+}
+
+/**
  * The profile-scoped Nostr data-layer singleton (see file header). Returns the
  * memoised facade for the active profile + tier config, rebuilding only when the
  * identity or the toggles change. Returns null when every tier is disabled.
@@ -103,6 +126,7 @@ export function buildNostrDataLayer(): facade.NostrDataLayer | null {
   }
 
   const layer = assembleLayer(config);
+  if (layer) seedOwnProfile(layer);
   memo = layer ? { layer, configKey, pubkey } : null;
   return layer;
 }

--- a/shared/lib/nostr/useEntityCache.ts
+++ b/shared/lib/nostr/useEntityCache.ts
@@ -1,0 +1,97 @@
+import { useCallback, useMemo, useSyncExternalStore } from 'react';
+
+import { facade } from '@sovranbitcoin/nagg-ts';
+
+import type {
+  FeedEvent,
+  NoteMetrics,
+  ProfileInfo,
+} from '@/features/feed/components/nostr/feedTypes';
+import { buildNostrDataLayer } from '@/shared/lib/nostr/buildNostrDataLayer';
+
+// ---------------------------------------------------------------------------
+// Reactive bindings over the authoritative nagg-ts entity cache.
+//
+// A row reads its author/profile/metrics straight from the singleton cache and
+// re-renders ONLY when that specific key changes (subscribeKey) — so a feed-wide
+// ingest doesn't churn unaffected rows, and a profile that arrives later fills
+// in place with no manual re-keying. `get(key)` returns a stable reference for an
+// unchanged record (writes are idempotent in the store), which is exactly what
+// useSyncExternalStore needs to avoid render loops.
+// ---------------------------------------------------------------------------
+
+export type ProfileStatus = 'cached' | 'loading' | 'absent';
+
+const NOOP_UNSUB = () => {};
+
+function useCachedRecord<T>(
+  store: facade.NormalizingStore<T> | undefined,
+  key: string | undefined
+): T | undefined {
+  const subscribe = useCallback(
+    (onChange: () => void) => (store && key ? store.subscribeKey(key, onChange) : NOOP_UNSUB),
+    [store, key]
+  );
+  const getSnapshot = useCallback(() => (store && key ? store.get(key) : undefined), [store, key]);
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+function usePendingProfile(
+  pending: facade.PendingSet | undefined,
+  key: string | undefined
+): boolean {
+  const subscribe = useCallback(
+    (onChange: () => void) => (pending && key ? pending.subscribeKey(key, onChange) : NOOP_UNSUB),
+    [pending, key]
+  );
+  const getSnapshot = useCallback(
+    () => (pending && key ? pending.has(key) : false),
+    [pending, key]
+  );
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+/**
+ * The author profile for a pubkey, plus a status that distinguishes a real
+ * cached record from a fetch-in-flight (skeleton) and a genuinely-absent profile
+ * (fallback). Reads the per-active-profile singleton cache.
+ */
+export function useProfile(pubkey: string | undefined): {
+  profile: ProfileInfo | undefined;
+  status: ProfileStatus;
+} {
+  const cache = buildNostrDataLayer()?.cache;
+  const record = useCachedRecord(cache?.profiles, pubkey);
+  const pending = usePendingProfile(cache?.pendingProfiles, pubkey);
+  return useMemo(() => {
+    const profile: ProfileInfo | undefined = record
+      ? { name: record.name ?? '', ...(record.picture ? { picture: record.picture } : {}) }
+      : undefined;
+    const status: ProfileStatus = record ? 'cached' : pending ? 'loading' : 'absent';
+    return { profile, status };
+  }, [record, pending]);
+}
+
+/** A cached note body by id (structurally a FeedEvent). */
+export function useNote(id: string | undefined): FeedEvent | undefined {
+  const cache = buildNostrDataLayer()?.cache;
+  return useCachedRecord(cache?.notes, id);
+}
+
+/** Cached engagement metrics for a note id, mapped to the app's NoteMetrics shape. */
+export function useNoteStats(id: string | undefined): NoteMetrics | undefined {
+  const cache = buildNostrDataLayer()?.cache;
+  const record = useCachedRecord(cache?.noteStats, id);
+  return useMemo(
+    () =>
+      record
+        ? {
+            likeCount: record.likes,
+            repostCount: record.reposts,
+            replyCount: record.replies,
+            satsZapped: record.satsZapped,
+          }
+        : undefined,
+    [record]
+  );
+}

--- a/shared/lib/popup/popups/sendMemoSheet.tsx
+++ b/shared/lib/popup/popups/sendMemoSheet.tsx
@@ -25,6 +25,7 @@ import { Button } from '@/shared/ui/primitives/Button';
 import { Pressable } from '@/shared/ui/primitives/Pressable';
 import { ContactRow, nostrIdentity } from '@/shared/ui/composed/ContactRow';
 import { List } from '@/shared/ui/composed/List';
+import { SkeletonContentCrossfade } from '@/shared/ui/composed/SkeletonContentCrossfade';
 import { Text } from '@/shared/ui/primitives/Text';
 import { View } from '@/shared/ui/primitives/View/View';
 import { useThemeColor } from '@/shared/hooks/useThemeColor';
@@ -388,7 +389,16 @@ function MentionSearchResults({
       />
     );
   } else if (showSkeletons) {
-    content = <MentionSkeletonRows />;
+    content = (
+      <SkeletonContentCrossfade
+        loading
+        exit="none"
+        visualKey="mention-results"
+        visualSurface="send-memo"
+        renderSkeleton={() => <MentionSkeletonRows />}
+        renderContent={() => null}
+      />
+    );
   } else if (results.length === 0) {
     content = (
       <MentionEmptyState

--- a/shared/ui/composed/MintIcon.tsx
+++ b/shared/ui/composed/MintIcon.tsx
@@ -9,6 +9,12 @@ import { prefetchImage } from '@/shared/lib/imageCache';
 
 const MINT_DEFAULT_ICON = 'mingcute:bank-fill';
 
+// Mirrors `AVATAR_IMAGE_FADE_MS`: a real network/disk load fades the icon in
+// over its placeholder rather than popping. expo-image skips the transition for
+// memory-cached images, so a recycled icon stays put. This is independent of any
+// parent skeleton→content crossfade — the icon never blocks the data swap.
+const MINT_ICON_IMAGE_FADE_MS = 200;
+
 interface MintIconProps {
   iconUrl?: string | null;
   name?: string | null;
@@ -87,6 +93,7 @@ export function MintIcon({
           source={imageSource}
           cachePolicy="memory-disk"
           contentFit="cover"
+          transition={MINT_ICON_IMAGE_FADE_MS}
           style={StyleSheet.absoluteFill}
           accessibilityLabel={imageAlt}
           onError={handleImageError}

--- a/shared/ui/composed/SkeletonContentCrossfade.tsx
+++ b/shared/ui/composed/SkeletonContentCrossfade.tsx
@@ -73,8 +73,6 @@ interface SkeletonContentCrossfadeProps {
    *  swaps instantly — use inside FlashList-recycled cells and for footer-only
    *  skeletons with no in-place content. */
   exit?: ExitMode;
-  /** Overrides the shimmer highlight tint (defaults to the theme `surface`). */
-  highlightColor?: string;
   style?: StyleProp<ViewStyle>;
   testID?: string;
   /** Telemetry passthrough for the region shimmer (see `contentShiftLog`). */
@@ -91,7 +89,6 @@ export function SkeletonContentCrossfade({
   durationMs = SKELETON_CONTENT_FADE_MS,
   wave = 'region',
   exit = 'fade',
-  highlightColor,
   style,
   testID,
   visualKey,
@@ -100,10 +97,11 @@ export function SkeletonContentCrossfade({
   visualDisabled,
 }: SkeletonContentCrossfadeProps) {
   const reducedMotion = useReducedMotion();
-  const surface = useThemeColor('surface');
-  // Surface-tinted highlight (matching the thread shimmer) — the background-tint
-  // fallback is nearly invisible, which reads as "no wave".
-  const resolvedHighlight = highlightColor ?? surface;
+  // The wave highlight is ALWAYS the background color. A background-colored band
+  // sweeping over the skeleton momentarily "erases" it, giving the illusion of
+  // the skeleton disappearing and reappearing — not a brighter stripe painted on
+  // top. This is a deliberate, non-overridable design rule.
+  const background = useThemeColor('background');
   const animatedExit = exit === 'fade' && !reducedMotion;
   const showWave = wave === 'region' && !reducedMotion;
 
@@ -174,7 +172,7 @@ export function SkeletonContentCrossfade({
         {showWave ? (
           <SkeletonLoadingShimmer
             active
-            highlightColor={resolvedHighlight}
+            highlightColor={background}
             visualKey={visualKey}
             visualSurface={visualSurface}
             visualComponent={visualComponent}

--- a/shared/ui/composed/SkeletonContentCrossfade.tsx
+++ b/shared/ui/composed/SkeletonContentCrossfade.tsx
@@ -3,11 +3,12 @@
  * transition for the app.
  *
  * While `loading`, it renders the skeleton tree and (for sizeable regions) a
- * single `SkeletonLoadingShimmer` "wave" sweep over it. When data arrives the
- * skeleton **fades out** to reveal the real content sitting underneath it at
- * full opacity — so the content never fades from empty space, and any images
- * inside it fade in **independently** on their own `expo-image` transition
- * rather than blocking (or double-fading with) the swap.
+ * single `SkeletonLoadingShimmer` "wave" sweep over it. When data arrives it
+ * runs ONE consistent transition everywhere: the skeleton **fades out**, then
+ * the real content **fades in** — a clear two-step crossfade, fast enough not to
+ * feel like waiting (`SKELETON_CONTENT_FADE_MS` total). Images inside the
+ * content fade in **independently** on their own `expo-image` transition, so the
+ * swap never blocks on a slow image load.
  *
  * Why a region helper and not per-leaf animation: the loading primitives
  * (`Text loading`, `Skeleton`, `Avatar state="loading"`, `MintIcon isLoading`)
@@ -19,9 +20,10 @@
  * and the skeleton overlay lines up pixel-for-pixel with the content, so the
  * swap shifts nothing.
  *
- * `exit="none"` skips the skeleton fade-out entirely (skeleton unmounts, content
- * appears) for FlashList-recycled lists where an exiting overlay would render in
- * a recycled cell's slot — there the real content owns its own entrance fade.
+ * `exit="none"` skips the fade entirely (skeleton unmounts, content appears) for
+ * FlashList-recycled lists where an exiting overlay would render in a recycled
+ * cell's slot, and for footer-only skeletons that have no in-place content to
+ * fade into.
  *
  * Reduced-motion (system setting) drops both the wave and the fade for an
  * instant swap.
@@ -32,6 +34,8 @@ import { StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
 import Animated, {
   cancelAnimation,
   Easing,
+  Extrapolation,
+  interpolate,
   ReduceMotion,
   runOnJS,
   useAnimatedStyle,
@@ -40,11 +44,13 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 
+import { useThemeColor } from '@/shared/hooks/useThemeColor';
 import { SkeletonLoadingShimmer } from '@/shared/ui/composed/SkeletonExitShimmer';
 
-/** Canonical skeleton→content fade duration. Matches the thread reply reveal so
- *  the whole app crossfades at one cadence. */
-const SKELETON_CONTENT_FADE_MS = 220;
+/** Total skeleton→content transition: the skeleton fades out over the first
+ *  half, the content fades in over the second. Kept short so the swap reads as a
+ *  crisp crossfade, not a wait. */
+const SKELETON_CONTENT_FADE_MS = 300;
 
 type WaveMode = 'region' | 'none';
 type ExitMode = 'fade' | 'none';
@@ -58,16 +64,16 @@ interface SkeletonContentCrossfadeProps {
   renderSkeleton: () => ReactNode;
   /** The real content tree. Lazy so it isn't built while still loading. */
   renderContent: () => ReactNode;
-  /** Fade duration in ms. Defaults to {@link SKELETON_CONTENT_FADE_MS}. */
+  /** Total fade duration in ms. Defaults to {@link SKELETON_CONTENT_FADE_MS}. */
   durationMs?: number;
   /** `'region'` (default) sweeps one shimmer wave over the skeleton; `'none'`
    *  keeps the cheaper static pulse for compact/inline placeholders. */
   wave?: WaveMode;
-  /** `'fade'` (default) fades the skeleton out over the content; `'none'`
-   *  unmounts the skeleton with no exit animation — use inside
-   *  FlashList-recycled cells, where the content owns its own entrance. */
+  /** `'fade'` (default) runs the skeleton-out/content-in crossfade; `'none'`
+   *  swaps instantly — use inside FlashList-recycled cells and for footer-only
+   *  skeletons with no in-place content. */
   exit?: ExitMode;
-  /** Overrides the shimmer highlight tint. */
+  /** Overrides the shimmer highlight tint (defaults to the theme `surface`). */
   highlightColor?: string;
   style?: StyleProp<ViewStyle>;
   testID?: string;
@@ -94,6 +100,10 @@ export function SkeletonContentCrossfade({
   visualDisabled,
 }: SkeletonContentCrossfadeProps) {
   const reducedMotion = useReducedMotion();
+  const surface = useThemeColor('surface');
+  // Surface-tinted highlight (matching the thread shimmer) — the background-tint
+  // fallback is nearly invisible, which reads as "no wave".
+  const resolvedHighlight = highlightColor ?? surface;
   const animatedExit = exit === 'fade' && !reducedMotion;
   const showWave = wave === 'region' && !reducedMotion;
 
@@ -101,16 +111,18 @@ export function SkeletonContentCrossfade({
   // recycled FlashList cell rebinding to loaded data) starts in 'content' and
   // never plays a spurious fade.
   const [phase, setPhase] = useState<Phase>(loading ? 'loading' : 'content');
-  const skeletonOpacity = useSharedValue(1);
+  // 0 → 1 across the whole transition: [0, 0.5] fades the skeleton out, then
+  // [0.5, 1] fades the content in.
+  const progress = useSharedValue(0);
 
   const finishExit = useCallback(() => setPhase('content'), []);
 
   // React to the loading edge. Entering loading always wins and cancels an
-  // in-flight exit fade (so rapid true→false→true never stacks overlays).
+  // in-flight exit (so rapid true→false→true never stacks overlays).
   useEffect(() => {
     if (loading) {
-      cancelAnimation(skeletonOpacity);
-      skeletonOpacity.set(1);
+      cancelAnimation(progress);
+      progress.set(0);
       setPhase('loading');
       return;
     }
@@ -118,18 +130,18 @@ export function SkeletonContentCrossfade({
       if (prev !== 'loading') return prev;
       return animatedExit ? 'exiting' : 'content';
     });
-  }, [loading, animatedExit, skeletonOpacity]);
+  }, [loading, animatedExit, progress]);
 
-  // Drive the one-shot skeleton fade-out while exiting.
+  // Drive the one-shot crossfade while exiting.
   useEffect(() => {
     if (phase !== 'exiting') return;
-    skeletonOpacity.set(1);
-    skeletonOpacity.set(
+    progress.set(0);
+    progress.set(
       withTiming(
-        0,
+        1,
         {
           duration: durationMs,
-          easing: Easing.out(Easing.cubic),
+          easing: Easing.inOut(Easing.quad),
           reduceMotion: ReduceMotion.System,
         },
         (finished) => {
@@ -137,10 +149,15 @@ export function SkeletonContentCrossfade({
         }
       )
     );
-    return () => cancelAnimation(skeletonOpacity);
-  }, [phase, durationMs, skeletonOpacity, finishExit]);
+    return () => cancelAnimation(progress);
+  }, [phase, durationMs, progress, finishExit]);
 
-  const exitStyle = useAnimatedStyle(() => ({ opacity: skeletonOpacity.get() }));
+  const skeletonExitStyle = useAnimatedStyle(() => ({
+    opacity: interpolate(progress.get(), [0, 0.5], [1, 0], Extrapolation.CLAMP),
+  }));
+  const contentEnterStyle = useAnimatedStyle(() => ({
+    opacity: interpolate(progress.get(), [0.5, 1], [0, 1], Extrapolation.CLAMP),
+  }));
 
   if (phase === 'content') {
     return (
@@ -157,7 +174,7 @@ export function SkeletonContentCrossfade({
         {showWave ? (
           <SkeletonLoadingShimmer
             active
-            highlightColor={highlightColor}
+            highlightColor={resolvedHighlight}
             visualKey={visualKey}
             visualSurface={visualSurface}
             visualComponent={visualComponent}
@@ -168,12 +185,12 @@ export function SkeletonContentCrossfade({
     );
   }
 
-  // 'exiting' — real content sits at full opacity in normal flow; the skeleton
-  // fades out on top of it (so images underneath fade in on their own).
+  // 'exiting' — content fades in (second half) in normal flow (it owns the
+  // height, so no shift); the skeleton fades out (first half) on top of it.
   return (
     <View style={style} testID={testID}>
-      {renderContent()}
-      <Animated.View pointerEvents="none" style={[StyleSheet.absoluteFill, exitStyle]}>
+      <Animated.View style={contentEnterStyle}>{renderContent()}</Animated.View>
+      <Animated.View pointerEvents="none" style={[StyleSheet.absoluteFill, skeletonExitStyle]}>
         {renderSkeleton()}
       </Animated.View>
     </View>

--- a/shared/ui/composed/SkeletonContentCrossfade.tsx
+++ b/shared/ui/composed/SkeletonContentCrossfade.tsx
@@ -73,6 +73,13 @@ interface SkeletonContentCrossfadeProps {
    *  swaps instantly — use inside FlashList-recycled cells and for footer-only
    *  skeletons with no in-place content. */
   exit?: ExitMode;
+  /** The color of the surface the skeleton sits ON — the wave is painted in this
+   *  color so it "erases" the skeleton as it sweeps (disappear/reappear), rather
+   *  than reading as a stripe on top. Defaults to the screen `background`; pass
+   *  the container's color when the skeleton is on a card/surface (e.g. a
+   *  `surface-secondary` Card). This is the only thing that should set the wave
+   *  color — never a brand/accent tint. */
+  surfaceColor?: string;
   style?: StyleProp<ViewStyle>;
   testID?: string;
   /** Telemetry passthrough for the region shimmer (see `contentShiftLog`). */
@@ -89,6 +96,7 @@ export function SkeletonContentCrossfade({
   durationMs = SKELETON_CONTENT_FADE_MS,
   wave = 'region',
   exit = 'fade',
+  surfaceColor,
   style,
   testID,
   visualKey,
@@ -97,11 +105,12 @@ export function SkeletonContentCrossfade({
   visualDisabled,
 }: SkeletonContentCrossfadeProps) {
   const reducedMotion = useReducedMotion();
-  // The wave highlight is ALWAYS the background color. A background-colored band
-  // sweeping over the skeleton momentarily "erases" it, giving the illusion of
-  // the skeleton disappearing and reappearing — not a brighter stripe painted on
-  // top. This is a deliberate, non-overridable design rule.
-  const background = useThemeColor('background');
+  // The wave is painted in the color of the surface the skeleton sits on, so the
+  // band "erases" the skeleton as it sweeps (disappear/reappear) rather than
+  // reading as a brighter stripe on top. Defaults to the screen background;
+  // callers on a card/surface pass that surface's color.
+  const screenBackground = useThemeColor('background');
+  const waveColor = surfaceColor ?? screenBackground;
   const animatedExit = exit === 'fade' && !reducedMotion;
   const showWave = wave === 'region' && !reducedMotion;
 
@@ -172,7 +181,7 @@ export function SkeletonContentCrossfade({
         {showWave ? (
           <SkeletonLoadingShimmer
             active
-            highlightColor={background}
+            highlightColor={waveColor}
             visualKey={visualKey}
             visualSurface={visualSurface}
             visualComponent={visualComponent}

--- a/shared/ui/composed/SkeletonContentCrossfade.tsx
+++ b/shared/ui/composed/SkeletonContentCrossfade.tsx
@@ -1,0 +1,181 @@
+/**
+ * @fileoverview `SkeletonContentCrossfade` — the canonical skeleton → content
+ * transition for the app.
+ *
+ * While `loading`, it renders the skeleton tree and (for sizeable regions) a
+ * single `SkeletonLoadingShimmer` "wave" sweep over it. When data arrives the
+ * skeleton **fades out** to reveal the real content sitting underneath it at
+ * full opacity — so the content never fades from empty space, and any images
+ * inside it fade in **independently** on their own `expo-image` transition
+ * rather than blocking (or double-fading with) the swap.
+ *
+ * Why a region helper and not per-leaf animation: the loading primitives
+ * (`Text loading`, `Skeleton`, `Avatar state="loading"`, `MintIcon isLoading`)
+ * stay dumb geometry-preserving placeholders. Putting the fade here, at the
+ * region seam, keeps those primitives cheap, avoids replaying opacity tweens on
+ * FlashList row recycling, and preserves the "share the chrome" convention:
+ * pass the SAME component in both branches —
+ * `renderSkeleton={() => <Row loading />}` / `renderContent={() => <Row />}` —
+ * and the skeleton overlay lines up pixel-for-pixel with the content, so the
+ * swap shifts nothing.
+ *
+ * `exit="none"` skips the skeleton fade-out entirely (skeleton unmounts, content
+ * appears) for FlashList-recycled lists where an exiting overlay would render in
+ * a recycled cell's slot — there the real content owns its own entrance fade.
+ *
+ * Reduced-motion (system setting) drops both the wave and the fade for an
+ * instant swap.
+ */
+
+import React, { useCallback, useEffect, useState, type ReactNode } from 'react';
+import { StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
+import Animated, {
+  cancelAnimation,
+  Easing,
+  ReduceMotion,
+  runOnJS,
+  useAnimatedStyle,
+  useReducedMotion,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+
+import { SkeletonLoadingShimmer } from '@/shared/ui/composed/SkeletonExitShimmer';
+
+/** Canonical skeleton→content fade duration. Matches the thread reply reveal so
+ *  the whole app crossfades at one cadence. */
+const SKELETON_CONTENT_FADE_MS = 220;
+
+type WaveMode = 'region' | 'none';
+type ExitMode = 'fade' | 'none';
+type Phase = 'loading' | 'exiting' | 'content';
+
+interface SkeletonContentCrossfadeProps {
+  /** True while the real data is loading. The skeleton shows; on the
+   *  true→false edge the crossfade runs. */
+  loading: boolean;
+  /** The loading placeholder tree. Lazy so it isn't built once content shows. */
+  renderSkeleton: () => ReactNode;
+  /** The real content tree. Lazy so it isn't built while still loading. */
+  renderContent: () => ReactNode;
+  /** Fade duration in ms. Defaults to {@link SKELETON_CONTENT_FADE_MS}. */
+  durationMs?: number;
+  /** `'region'` (default) sweeps one shimmer wave over the skeleton; `'none'`
+   *  keeps the cheaper static pulse for compact/inline placeholders. */
+  wave?: WaveMode;
+  /** `'fade'` (default) fades the skeleton out over the content; `'none'`
+   *  unmounts the skeleton with no exit animation — use inside
+   *  FlashList-recycled cells, where the content owns its own entrance. */
+  exit?: ExitMode;
+  /** Overrides the shimmer highlight tint. */
+  highlightColor?: string;
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+  /** Telemetry passthrough for the region shimmer (see `contentShiftLog`). */
+  visualKey?: string;
+  visualSurface?: string;
+  visualComponent?: string;
+  visualDisabled?: boolean;
+}
+
+export function SkeletonContentCrossfade({
+  loading,
+  renderSkeleton,
+  renderContent,
+  durationMs = SKELETON_CONTENT_FADE_MS,
+  wave = 'region',
+  exit = 'fade',
+  highlightColor,
+  style,
+  testID,
+  visualKey,
+  visualSurface,
+  visualComponent = 'SkeletonContentCrossfade',
+  visualDisabled,
+}: SkeletonContentCrossfadeProps) {
+  const reducedMotion = useReducedMotion();
+  const animatedExit = exit === 'fade' && !reducedMotion;
+  const showWave = wave === 'region' && !reducedMotion;
+
+  // Phase is seeded from `loading`, so a row that mounts already-loaded (e.g. a
+  // recycled FlashList cell rebinding to loaded data) starts in 'content' and
+  // never plays a spurious fade.
+  const [phase, setPhase] = useState<Phase>(loading ? 'loading' : 'content');
+  const skeletonOpacity = useSharedValue(1);
+
+  const finishExit = useCallback(() => setPhase('content'), []);
+
+  // React to the loading edge. Entering loading always wins and cancels an
+  // in-flight exit fade (so rapid true→false→true never stacks overlays).
+  useEffect(() => {
+    if (loading) {
+      cancelAnimation(skeletonOpacity);
+      skeletonOpacity.set(1);
+      setPhase('loading');
+      return;
+    }
+    setPhase((prev) => {
+      if (prev !== 'loading') return prev;
+      return animatedExit ? 'exiting' : 'content';
+    });
+  }, [loading, animatedExit, skeletonOpacity]);
+
+  // Drive the one-shot skeleton fade-out while exiting.
+  useEffect(() => {
+    if (phase !== 'exiting') return;
+    skeletonOpacity.set(1);
+    skeletonOpacity.set(
+      withTiming(
+        0,
+        {
+          duration: durationMs,
+          easing: Easing.out(Easing.cubic),
+          reduceMotion: ReduceMotion.System,
+        },
+        (finished) => {
+          if (finished) runOnJS(finishExit)();
+        }
+      )
+    );
+    return () => cancelAnimation(skeletonOpacity);
+  }, [phase, durationMs, skeletonOpacity, finishExit]);
+
+  const exitStyle = useAnimatedStyle(() => ({ opacity: skeletonOpacity.get() }));
+
+  if (phase === 'content') {
+    return (
+      <View style={style} testID={testID}>
+        {renderContent()}
+      </View>
+    );
+  }
+
+  if (phase === 'loading') {
+    return (
+      <View style={style} testID={testID}>
+        {renderSkeleton()}
+        {showWave ? (
+          <SkeletonLoadingShimmer
+            active
+            highlightColor={highlightColor}
+            visualKey={visualKey}
+            visualSurface={visualSurface}
+            visualComponent={visualComponent}
+            visualDisabled={visualDisabled}
+          />
+        ) : null}
+      </View>
+    );
+  }
+
+  // 'exiting' — real content sits at full opacity in normal flow; the skeleton
+  // fades out on top of it (so images underneath fade in on their own).
+  return (
+    <View style={style} testID={testID}>
+      {renderContent()}
+      <Animated.View pointerEvents="none" style={[StyleSheet.absoluteFill, exitStyle]}>
+        {renderSkeleton()}
+      </Animated.View>
+    </View>
+  );
+}


### PR DESCRIPTION
## What

Adds **`SkeletonContentCrossfade`** (`shared/ui/composed/SkeletonContentCrossfade.tsx`) — the canonical region-level skeleton→content transition — and adopts it across the app's existing skeleton sites.

Behavior:
- While loading, a sizeable region shows the shared `SkeletonLoadingShimmer` **wave** (one sweep per region; compact/inline swaps use `wave="none"` and keep the cheap pulse).
- On the loading→loaded edge, the skeleton **fades out over** the real content (220ms), so images inside fade in **independently** via `expo-image`'s `transition` and never block (or double-fade with) the swap.
- **Leaf primitives stay dumb** (`Text loading`, `Skeleton`, `Avatar`, `MintIcon`) — the fade lives at the region seam, which keeps recycling safe and primitives cheap.
- **Share the chrome**: pass the same component in both branches → zero content shift.
- System **Reduce Motion** → instant swap (no wave, no fade).
- `exit="none"` for FlashList-recycled cells (skeleton unmounts; real item owns its entrance).

## Adoption
Add Mints (results region), Mint info (stats + rating), Mint reviews (footer skeletons), Receive (QR hub), payment QR, referenced-post preview, history-refresh row, mention search. **`MintIcon`** gained its missing `expo-image` `transition`. New **Design System** demo at `/(settings-flow)/design-system-skeleton-crossfade`.

## Deliberately left on the shared wave
**Thread** (`PostCardSkeleton`/`ThreadView`) and **profile** (`UserProfileScreen`) keep using `SkeletonLoadingShimmer` directly. Thread items are FlashList-recycled — wrapping them reintroduces the wrong-recycled-slot exit glitch that `ThreadView.tsx:400-403` already guards against; the profile stats grid has a tuned 3-branch layout + content-shift telemetry not worth a regression-prone rewrite. Both already run the shared wave + a FlashList-safe `FadeIn`, so they're adopted at the wave level.

## Tests / gates
- New `__tests__/skeletonContentCrossfade.test.tsx` (8 tests): phase machine, wave gating, reduced-motion, `exit="none"`, rapid-toggle (no stacked overlay), mount-already-loaded (no spurious fade).
- `tsc` clean, `eslint` clean (pre-existing react-perf warnings only), `knip` no new unused exports.
- Pre-existing `naggFeedClient*` suite failures are unrelated to this change (fail identically on the base branch).

Stacked on #228. Skill docs (`sovran-ui/references/thread-skeletons.md`, `ui-patterns.md`) updated in the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)