### PR TITLE
feat(map): unify map stats glass button with the wallet fiat pill

### DIFF
--- a/features/map/components/StatsCard.tsx
+++ b/features/map/components/StatsCard.tsx
@@ -1,22 +1,14 @@
 import { memo, useCallback, useRef } from 'react';
-import {
-  Host,
-  Button as SwiftUIButton,
-  Menu,
-  HStack as SwiftUIHStack,
-  VStack as SwiftUIVStack,
-  Image as SwiftUIImage,
-  Text as SwiftUIText,
-} from '@expo/ui/swift-ui';
-import { font, foregroundStyle, frame, glassEffect, padding } from '@expo/ui/swift-ui/modifiers';
+import { LiquidGlassMenu } from 'liquid-glass-menu';
 import { Menu as HeroMenu, type MenuTriggerRef } from 'heroui-native';
 import { ActionSheetIOS, Platform, StyleSheet, Text } from 'react-native';
 import { MenuScrim } from '@/shared/blocks/popup/MenuScrim';
 import { HStack } from '@/shared/ui/primitives/View/HStack';
 import opacity from 'hex-color-opacity';
 import Icon from 'assets/icons';
+import { useColorScheme } from '@/shared/hooks/useColorScheme';
 import { useThemeColor } from '@/shared/hooks/useThemeColor';
-import { alpha, radius, shadow, spacing, zIndex, fontSize } from '@/shared/styles/tokens';
+import { alpha, radius, shadow, spacing, fontSize } from '@/shared/styles/tokens';
 import { useCapabilities } from '@/shared/ui/capability';
 import { BITCOIN_ACCENT } from '@/shared/lib/brandColors';
 import { MERCHANT_CATEGORIES, type MerchantCategoryId } from '@/shared/lib/map/categories';
@@ -61,6 +53,7 @@ export const StatsCard = memo(function StatsCard({
     'success',
   ] as const);
   const { liquidGlass } = useCapabilities();
+  const colorScheme = useColorScheme();
   const menuTriggerRef = useRef<MenuTriggerRef>(null);
   const openCategoryMenu = useCallback(() => {
     setTimeout(() => menuTriggerRef.current?.open(), 0);
@@ -71,7 +64,9 @@ export const StatsCard = memo(function StatsCard({
     ? 'Loading...'
     : `${totalCount.toLocaleString()} total • ${categoryLabel(category)}`;
 
-  if (!liquidGlass) {
+  // The glass path needs the native UIKit glass-button morph; without it we fall
+  // through to the flat card (which also covers Android and pre-iOS-26).
+  if (!liquidGlass || !LiquidGlassMenu.isSupported) {
     const handlePress = () => {
       if (Platform.OS !== 'ios') {
         // Android: heroui Menu bottom sheet (the canonical pick-one-of-N
@@ -158,59 +153,30 @@ export const StatsCard = memo(function StatsCard({
     );
   }
 
-  // `Menu` (not `ContextMenu`) so the glass capsule opens the category filter on
-  // a single TAP. `ContextMenu` is hardcoded to long-press, which is why the
-  // dropdown "did nothing" when tapped. Omitting `onPrimaryAction` means the tap
-  // opens the menu (matching the proven FiatCurrencyPill.liquid pattern). The
-  // glass effect + frame live on the Menu; the label is the trigger content.
-  const glassCardModifiers = [
-    frame({ width: cardWidth, height: 64, alignment: 'center' }),
-    glassEffect({
-      shape: 'capsule' as const,
-      glass: { variant: 'regular' as const, interactive: true },
-    }),
-  ];
-
+  // Same native UIKit glass-button morph the wallet's FiatCurrencyPill uses, so
+  // the map card animates as smoothly (a SwiftUI `glassEffect` Host felt buggy
+  // by comparison). A single TAP opens the category menu and morphs the capsule;
+  // the leading bitcoin icon + two-line label live inside the button itself.
   return (
     <View style={styles.statsContainer}>
-      <Host style={{ zIndex: zIndex.sticky, height: 64, width: cardWidth }} matchContents>
-        <Menu
-          modifiers={glassCardModifiers}
-          label={
-            <SwiftUIHStack
-              alignment="center"
-              spacing={12}
-              modifiers={[
-                frame({ maxWidth: Infinity, height: 64, alignment: 'leading' }),
-                padding({ horizontal: 18 }),
-              ]}>
-              <SwiftUIImage systemName="bitcoinsign.circle.fill" size={24} color={BITCOIN_ACCENT} />
-              {/* VStack takes the remaining width so the chevron sits at the
-                  far right edge instead of crammed against the subtitle. */}
-              <SwiftUIVStack
-                alignment="leading"
-                spacing={2}
-                modifiers={[frame({ maxWidth: Infinity, alignment: 'leading' })]}>
-                <SwiftUIText
-                  modifiers={[font({ size: 18, weight: 'bold' }), foregroundStyle(foreground)]}>
-                  {visibleText}
-                </SwiftUIText>
-                <SwiftUIText modifiers={[font({ size: 12 }), foregroundStyle(foreground)]}>
-                  {totalText}
-                </SwiftUIText>
-              </SwiftUIVStack>
-              <SwiftUIImage systemName="chevron.down" size={14} color={foreground} />
-            </SwiftUIHStack>
-          }>
-          {CATEGORY_FILTERS.map((cat) => (
-            <SwiftUIButton
-              key={cat}
-              label={`${categoryLabel(cat)}${cat === category ? ' ✓' : ''}`}
-              onPress={() => onCategoryChange(cat)}
-            />
-          ))}
-        </Menu>
-      </Host>
+      <LiquidGlassMenu
+        style={{ width: cardWidth, height: 64 }}
+        image="bitcoinsign.circle.fill"
+        imageColor={BITCOIN_ACCENT}
+        label={visibleText}
+        subtitle={totalText}
+        labelColor={foreground}
+        labelSize={18}
+        contentAlignment="leading"
+        colorScheme={colorScheme}
+        menuTitle="Merchant category"
+        actions={CATEGORY_FILTERS.map((cat) => ({
+          id: cat,
+          title: categoryLabel(cat),
+          selected: cat === category,
+        }))}
+        onSelectAction={({ nativeEvent }) => onCategoryChange(nativeEvent.id as CategoryFilter)}
+      />
     </View>
   );
 });

--- a/modules/liquid-glass-menu/ios/LiquidGlassMenuModule.swift
+++ b/modules/liquid-glass-menu/ios/LiquidGlassMenuModule.swift
@@ -24,6 +24,22 @@ public class LiquidGlassMenuModule: Module {
                 view.labelSize = CGFloat(value)
                 view.apply()
             }
+            Prop("subtitle") { (view: LiquidGlassMenuView, value: String?) in
+                view.subtitle = value ?? ""
+                view.apply()
+            }
+            Prop("image") { (view: LiquidGlassMenuView, value: String?) in
+                view.imageName = value ?? ""
+                view.apply()
+            }
+            Prop("imageColor") { (view: LiquidGlassMenuView, value: String?) in
+                view.imageColorHex = value
+                view.apply()
+            }
+            Prop("contentAlignment") { (view: LiquidGlassMenuView, value: String?) in
+                view.alignLeading = value == "leading"
+                view.apply()
+            }
             Prop("tint") { (view: LiquidGlassMenuView, value: String?) in
                 view.tintHex = value
                 view.apply()

--- a/modules/liquid-glass-menu/ios/LiquidGlassMenuView.swift
+++ b/modules/liquid-glass-menu/ios/LiquidGlassMenuView.swift
@@ -28,6 +28,10 @@ public final class LiquidGlassMenuView: ExpoView {
     var label: String = ""
     var labelColorHex: String?
     var labelSize: CGFloat = 14
+    var subtitle: String = ""
+    var imageName: String = ""
+    var imageColorHex: String?
+    var alignLeading: Bool = false
     var tintHex: String?
     var schemeStr: String = ""
     var hasPrimaryAction: Bool = false
@@ -73,11 +77,39 @@ public final class LiquidGlassMenuView: ExpoView {
         container.font = UIFont.systemFont(ofSize: labelSize, weight: .bold)
         container.foregroundColor = color
         config.attributedTitle = AttributedString(label, attributes: container)
+
+        // Optional second line, rendered regular weight a couple points down.
+        if subtitle.isEmpty {
+            config.attributedSubtitle = nil
+        } else {
+            var sub = AttributeContainer()
+            sub.font = UIFont.systemFont(ofSize: max(11, labelSize - 6), weight: .regular)
+            sub.foregroundColor = color
+            config.attributedSubtitle = AttributedString(subtitle, attributes: sub)
+            config.titleAlignment = .leading
+        }
+
+        // Optional leading SF Symbol, tinted via a color transformer so it keeps
+        // its own colour through the glass rather than inheriting the label tint.
+        if imageName.isEmpty {
+            config.image = nil
+        } else {
+            config.image = UIImage(systemName: imageName)
+            config.imagePlacement = .leading
+            config.imagePadding = 10
+            let imageColor = imageColorHex.flatMap { Self.color(hex: $0) } ?? color
+            config.imageColorTransformer = UIConfigurationColorTransformer { _ in imageColor }
+        }
+
         config.contentInsets = NSDirectionalEdgeInsets(top: 4, leading: 12, bottom: 4, trailing: 12)
         if let tint = tintHex.flatMap({ Self.color(hex: $0) }) {
             config.baseBackgroundColor = tint
         }
         button.configuration = config
+
+        // Left-align the whole content (icon + text) for the wider map card; the
+        // currency pill keeps the default centred layout.
+        button.contentHorizontalAlignment = alignLeading ? .leading : .center
 
         overrideUserInterfaceStyle =
             schemeStr == "dark" ? .dark : (schemeStr == "light" ? .light : .unspecified)

--- a/modules/liquid-glass-menu/src/LiquidGlassMenu.types.ts
+++ b/modules/liquid-glass-menu/src/LiquidGlassMenu.types.ts
@@ -11,11 +11,19 @@ export type GlassMenuAction = {
 };
 
 export type LiquidGlassMenuProps = {
-  /** Pill label, e.g. "≈ $12.34". */
+  /** Pill label, e.g. "≈ $12.34". The bold primary line. */
   label: string;
   /** "#RRGGBB" / "#RRGGBBAA". Defaults to the system label color. */
   labelColor?: string;
   labelSize?: number;
+  /** Optional second line under `label` (regular weight, smaller). */
+  subtitle?: string;
+  /** Optional leading SF Symbol (e.g. "bitcoinsign.circle.fill"). */
+  image?: string;
+  /** Tint for `image`, "#RRGGBB" / "#RRGGBBAA". Defaults to the label color. */
+  imageColor?: string;
+  /** Horizontal layout of the button content. Defaults to `'center'`. */
+  contentAlignment?: 'center' | 'leading';
   /** Glass tint, "#RRGGBB" / "#RRGGBBAA". */
   tint?: string | null;
   /** Force the menu/glass to render in a specific scheme. */


### PR DESCRIPTION
## What & why

The Bitcoin map's "visible" stats button rolled its **own** liquid glass via `@expo/ui/swift-ui` (`Host` + `Menu` + `glassEffect`). That SwiftUI-hosted glass morphs less smoothly / feels buggier than the wallet's fiat "≈" pill (`FiatCurrencyPill.liquid`), which uses the **native UIKit glass-button morph** in the local `liquid-glass-menu` module. This makes both surfaces share that one smooth primitive.

## Changes

- **`LiquidGlassMenu` (shared native primitive)** — extended backward-compatibly with optional props: `subtitle` (second line), `image` (leading SF Symbol) + `imageColor`, and `contentAlignment` (`center` default / `leading`). Native `apply()` renders an attributed subtitle, a tinted leading symbol, and left-vs-centered content.
- **`StatsCard.tsx`** — the iOS-26 branch now renders the map card (bitcoin icon + "N visible" / "M total • Category" + category menu) through `LiquidGlassMenu` instead of the `@expo/ui` SwiftUI block. Glass is gated on `liquidGlass && LiquidGlassMenu.isSupported`, mirroring the pill; the flat fallback (iOS ActionSheet / Android heroui) is unchanged.
- **`FiatCurrencyPill` untouched** — all new props are optional, so the wallet pill keeps its centered single-line look.

## Deliberate trade-offs

- **Chevron drops on the glass path.** `UIButton.Configuration` cleanly holds a leading icon + title + subtitle but not a second trailing symbol; the glass morph itself is the tap affordance (same as the fiat pill). The flat fallback card keeps its chevron.
- **Gating shift:** the rare `liquidGlass===true` but `LiquidGlassMenu.isSupported===false` case (iOS 26 beta without the `UIGlassEffect` symbol) now shows the flat card instead of SwiftUI glass — safer.

## Verification

- ✅ `tsc --noEmit` — 0 errors
- ✅ `eslint` — 0 errors (only pre-existing `react-perf` inline-prop warnings already present in the file)
- ⚠️ **Native Swift not yet verified on-device** — requires a fresh dev-client rebuild; a JS reload won't show the glass change.
- No StatsCard unit tests exist.