### PR TITLE
Network settings: live tier health + trimmed copy

### DIFF
--- a/__tests__/tierHealth.test.ts
+++ b/__tests__/tierHealth.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Pure liveness probes for the Nostr data tiers: the nagg HTTP `/healthz` check
+ * (routed through a mocked `fetchJson`), the Primal WebSocket round-trip (driven
+ * by a fake socket), and the relay-map fold. No network or harness required.
+ */
+/* eslint-disable import/first */
+
+jest.mock('@/shared/lib/apiClient', () => ({
+  __esModule: true,
+  fetchJson: jest.fn(),
+}));
+
+// `fetchJson` is mocked, so the parser built by `parseWith` is never invoked;
+// stub it to dodge jest's ESM directory-import resolution of the schemas source.
+jest.mock('@sovranbitcoin/schemas', () => ({
+  __esModule: true,
+  parseWith: () => () => undefined,
+}));
+
+import { ok, err } from 'neverthrow';
+
+import { fetchJson } from '@/shared/lib/apiClient';
+import { foldRelayStatus, probeNaggHealth, probePrimalHealth } from '@/shared/lib/nostr/tierHealth';
+
+const mockFetchJson = fetchJson as jest.Mock;
+
+describe('probeNaggHealth', () => {
+  afterEach(() => {
+    mockFetchJson.mockReset();
+  });
+
+  it('is online for a body of { ok: "true" }', async () => {
+    mockFetchJson.mockResolvedValue(ok({ ok: 'true' }));
+    const result = await probeNaggHealth('https://nagg.example');
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap()).toBe(true);
+  });
+
+  it('is online for a body of { ok: true } (boolean)', async () => {
+    mockFetchJson.mockResolvedValue(ok({ ok: true }));
+    const result = await probeNaggHealth('https://nagg.example');
+    expect(result._unsafeUnwrap()).toBe(true);
+  });
+
+  it('is offline (ok false) for a body of { ok: "false" }', async () => {
+    mockFetchJson.mockResolvedValue(ok({ ok: 'false' }));
+    const result = await probeNaggHealth('https://nagg.example');
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap()).toBe(false);
+  });
+
+  it('errors (offline) when the fetch fails — non-2xx, malformed, or unreachable', async () => {
+    mockFetchJson.mockResolvedValue(err(new Error('Fetch error: 503')));
+    const result = await probeNaggHealth('https://nagg.example');
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('strips a trailing slash before appending /healthz', async () => {
+    mockFetchJson.mockResolvedValue(ok({ ok: 'true' }));
+    await probeNaggHealth('https://nagg.example/');
+    expect(mockFetchJson).toHaveBeenCalledWith(
+      'https://nagg.example/healthz',
+      expect.anything(),
+      'nostr/nagg-healthz',
+      undefined,
+      expect.objectContaining({ timeoutMs: 4000 })
+    );
+  });
+});
+
+/** Minimal scriptable WebSocket stand-in driving the probe's event callbacks. */
+class FakeWebSocket {
+  onopen: (() => void) | null = null;
+  onmessage: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  sent: string[] = [];
+  closed = false;
+  constructor(public url: string) {}
+  send(data: string) {
+    this.sent.push(data);
+  }
+  close() {
+    this.closed = true;
+  }
+}
+
+describe('probePrimalHealth', () => {
+  it('is online when a frame arrives after the REQ, and closes the socket', async () => {
+    let socket: FakeWebSocket | null = null;
+    const Ctor = function (this: unknown, url: string) {
+      socket = new FakeWebSocket(url);
+      return socket;
+    } as unknown as typeof WebSocket;
+
+    const promise = probePrimalHealth('wss://cache.example', { WebSocketImpl: Ctor });
+    socket!.onopen?.();
+    socket!.onmessage?.();
+
+    const result = await promise;
+    expect(result._unsafeUnwrap()).toBe(true);
+    expect(socket!.sent.some((m) => m.includes('REQ'))).toBe(true);
+    expect(socket!.sent.some((m) => m.includes('CLOSE'))).toBe(true);
+    expect(socket!.closed).toBe(true);
+  });
+
+  it('is offline when the timeout fires with no response', async () => {
+    jest.useFakeTimers();
+    let socket: FakeWebSocket | null = null;
+    const Ctor = function (this: unknown, url: string) {
+      socket = new FakeWebSocket(url);
+      return socket;
+    } as unknown as typeof WebSocket;
+
+    const promise = probePrimalHealth('wss://cache.example', {
+      WebSocketImpl: Ctor,
+      timeoutMs: 1000,
+    });
+    socket!.onopen?.();
+    jest.advanceTimersByTime(1000);
+    const result = await promise;
+    expect(result._unsafeUnwrap()).toBe(false);
+    jest.useRealTimers();
+  });
+
+  it('is offline on a socket error', async () => {
+    let socket: FakeWebSocket | null = null;
+    const Ctor = function (this: unknown, url: string) {
+      socket = new FakeWebSocket(url);
+      return socket;
+    } as unknown as typeof WebSocket;
+
+    const promise = probePrimalHealth('wss://cache.example', { WebSocketImpl: Ctor });
+    socket!.onerror?.();
+    const result = await promise;
+    expect(result._unsafeUnwrap()).toBe(false);
+  });
+
+  it('is offline when the WebSocket constructor throws', async () => {
+    const Ctor = function () {
+      throw new Error('bad url');
+    } as unknown as typeof WebSocket;
+    const result = await probePrimalHealth('wss://cache.example', { WebSocketImpl: Ctor });
+    expect(result._unsafeUnwrap()).toBe(false);
+  });
+});
+
+describe('foldRelayStatus', () => {
+  it('is online when any relay is connected', () => {
+    expect(foldRelayStatus({ a: 'connected', b: 'disconnected' })).toBe('online');
+  });
+  it('is checking when any is connecting and none connected', () => {
+    expect(foldRelayStatus({ a: 'connecting', b: 'failed' })).toBe('checking');
+  });
+  it('is offline when all are down', () => {
+    expect(foldRelayStatus({ a: 'disconnected', b: 'failed' })).toBe('offline');
+  });
+  it('is offline for an empty pool', () => {
+    expect(foldRelayStatus({})).toBe('offline');
+  });
+});

--- a/__tests__/tierHealth.test.ts
+++ b/__tests__/tierHealth.test.ts
@@ -49,6 +49,12 @@ describe('probeNaggHealth', () => {
     expect(result._unsafeUnwrap()).toBe(false);
   });
 
+  it('is offline (ok false) for a body of { ok: false } (boolean)', async () => {
+    mockFetchJson.mockResolvedValue(ok({ ok: false }));
+    const result = await probeNaggHealth('https://nagg.example');
+    expect(result._unsafeUnwrap()).toBe(false);
+  });
+
   it('errors (offline) when the fetch fails — non-2xx, malformed, or unreachable', async () => {
     mockFetchJson.mockResolvedValue(err(new Error('Fetch error: 503')));
     const result = await probeNaggHealth('https://nagg.example');
@@ -76,6 +82,7 @@ class FakeWebSocket {
   onclose: (() => void) | null = null;
   sent: string[] = [];
   closed = false;
+  readyState = 1; // OPEN
   constructor(public url: string) {}
   send(data: string) {
     this.sent.push(data);
@@ -142,6 +149,40 @@ describe('probePrimalHealth', () => {
     } as unknown as typeof WebSocket;
     const result = await probePrimalHealth('wss://cache.example', { WebSocketImpl: Ctor });
     expect(result._unsafeUnwrap()).toBe(false);
+  });
+
+  it('is offline and closes the socket when aborted via signal', async () => {
+    let socket: FakeWebSocket | null = null;
+    const Ctor = function (this: unknown, url: string) {
+      socket = new FakeWebSocket(url);
+      return socket;
+    } as unknown as typeof WebSocket;
+    const controller = new AbortController();
+
+    const promise = probePrimalHealth('wss://cache.example', {
+      WebSocketImpl: Ctor,
+      signal: controller.signal,
+    });
+    socket!.onopen?.();
+    controller.abort();
+    const result = await promise;
+    expect(result._unsafeUnwrap()).toBe(false);
+    expect(socket!.closed).toBe(true);
+  });
+
+  it('resolves once: a late onclose after onmessage does not change the verdict', async () => {
+    let socket: FakeWebSocket | null = null;
+    const Ctor = function (this: unknown, url: string) {
+      socket = new FakeWebSocket(url);
+      return socket;
+    } as unknown as typeof WebSocket;
+
+    const promise = probePrimalHealth('wss://cache.example', { WebSocketImpl: Ctor });
+    socket!.onopen?.();
+    socket!.onmessage?.();
+    socket!.onclose?.(); // late event — must be ignored by the settled guard
+    const result = await promise;
+    expect(result._unsafeUnwrap()).toBe(true);
   });
 });
 

--- a/docs/adr/0006-network-tier-health.md
+++ b/docs/adr/0006-network-tier-health.md
@@ -1,0 +1,75 @@
+# 6. Live tier-health on the Network settings screen
+
+Date: 2026-06-24
+Status: Accepted (observability for the tiered data layer of ADR 0003)
+
+## Context
+
+The Network settings screen (`SettingsNetworkScreen`) configures the three tiers
+of the resilient Nostr data layer (ADR 0003): nagg → Primal cache → raw relays.
+It carried an enable/disable switch per tier but gave no signal of whether each
+source is actually reachable, so a user (or a developer testing fallback) could
+not tell a *disabled* tier from a *down* one. The screen had also drifted from
+the sibling settings pages — a long intro paragraph and a bespoke `TierToggleCard`
+instead of the shared `Section` + `ListGroup` + `Badge` scaffold.
+
+The three tiers expose health very differently:
+
+- **nagg** (we operate it) serves an HTTP `GET /healthz` returning `{ ok: "true",
+  … }`.
+- **Primal cache** (Primal operates it) has **no** health endpoint — `/healthz`
+  returns 404. Its transport is a Nostr WebSocket.
+- **raw relays** already have live per-relay connection state from the NDK pool,
+  surfaced by `useRelayHealth` (2s poll).
+
+## Decision
+
+Add a composed health layer and render one live `Online / Offline / Checking`
+badge per tier, plus a per-tier dim when its toggle is off.
+
+- **Pure probes** in `shared/lib/nostr/tierHealth.ts`:
+  - `probeNaggHealth` routes through the canonical `fetchJson` client (timeout,
+    URL redaction, zod validation) and reports online iff the body is `{ ok:
+    "true" | true }`.
+  - `probePrimalHealth` opens the Primal WebSocket, sends a minimal Nostr `REQ`,
+    and treats the **first response frame within a timeout** as online — because
+    Primal has no `/healthz`, a round-trip is the honest liveness signal. The
+    socket is always `CLOSE`d and closed before resolving.
+  - `foldRelayStatus` collapses the NDK per-relay map into one tier status.
+- **Composed hook** `useNostrTierHealth` exposes a uniform `{ nagg, primal, relay,
+  isRefreshing, refresh }`. It reads tier config through the canonical owner
+  (`useNostrTierConfig`), probes only while the screen is focused (on focus +
+  every 30s), skips disabled tiers, and guards against stale async writes with a
+  monotonic run id.
+- The screen is rebuilt on the shared settings scaffold and its copy trimmed from
+  ~103 words to ~22 (intro paragraph removed; per-tier descriptions one line).
+- **Persistence fix**: the three tier toggles were declared in `settingsStore` but
+  omitted from `partialize`, so they silently reset to `true` on every launch.
+  They are added to `partialize`.
+
+This is observability + presentation only: it reads the existing toggles and the
+existing endpoints and never gates the nagg → Primal → relay fallback routing.
+
+## Consequences
+
+- A disabled tier is now visually distinct from an unreachable one, and fallback
+  testing (toggle a tier off) is legible.
+- Two lightweight network probes run only while the screen is focused, at 30s
+  cadence; the relay tier adds no network (in-memory NDK read). Probes stop on
+  blur.
+- Tier preferences now survive an app restart.
+- Probe transports are deliberately separate from the live data-layer connections
+  (ADR 0003's facade): the health screen must not interfere with real reads, and a
+  per-transport probe keeps each tier's liveness honest.
+
+## Alternatives considered
+
+- **HTTP reachability ping for Primal** (`GET` the host, 200 = up) — rejected; the
+  host is fronted by nginx that 200s regardless, so it proves nothing about the
+  cache serving Nostr queries. The WebSocket round-trip is the honest signal.
+- **Reuse the live data-layer's Primal connection state** — rejected; it couples
+  UI health to the facade's internal connections and risks interfering with real
+  reads. A self-contained probe keeps the seam clean.
+- **Probe disabled tiers too** (so a user previews health before enabling) —
+  rejected for battery; a disabled tier is out of the fallback chain, so its
+  liveness is moot until re-enabled.

--- a/features/settings/screens/SettingsNetworkScreen.tsx
+++ b/features/settings/screens/SettingsNetworkScreen.tsx
@@ -1,24 +1,25 @@
 /**
  * @fileoverview Network configuration — the three tiers of the resilient Nostr
- * data layer: aggregators (nagg), caching (Primal), and relays.
+ * data layer (nagg → Primal cache → raw relays) with live health, plus the
+ * active profile's NIP-65 relay list (add/remove, read/write markers, publish).
  *
  * Each tier has an enable/disable switch (a disabled tier drops out of the
- * facade's nagg → Primal → relays fallback chain — handy for simulating a tier
- * being down). The relays section additionally manages the active profile's
- * NIP-65 list (kind:10002): connection health, read/write markers, add/remove,
- * restore defaults, and publish.
+ * facade's fallback chain) and a live Online/Offline badge from
+ * `useNostrTierHealth`. Toggling a tier does not change the fallback logic — it
+ * only sets the persisted preference the data layer reads.
  */
 import React, { useCallback, useMemo, useState } from 'react';
-import { ScrollView, View } from 'react-native';
+import { RefreshControl, ScrollView, View } from 'react-native';
 import { NDKEvent, useNDK } from '@nostr-dev-kit/ndk-mobile';
 import { Button, Card, Input, ListGroup, Separator, Switch, TextField } from 'heroui-native';
 
 import Icon from 'assets/icons';
-import { backendConfig } from '@/shared/config/backend';
 import { useSettingsStore } from '@/shared/stores/global/settingsStore';
 import { useThemeColor } from '@/shared/hooks/useThemeColor';
 import { useRelayHealth, type RelayHealth } from '@/shared/hooks/useRelayHealth';
-import { log } from '@/shared/lib/logger';
+import { useNostrTierHealth } from '@/shared/hooks/useNostrTierHealth';
+import { type TierStatus } from '@/shared/lib/nostr/tierHealth';
+import { log, useLifecycleLogger } from '@/shared/lib/logger';
 import { publishEvent } from '@/shared/lib/nostr/publish';
 import { DEFAULT_RELAYS, safeNormalizeRelay } from '@/shared/lib/nostr/outbox/defaults';
 import { RELAY_LIST_KIND, serializeRelayList } from '@/shared/lib/nostr/outbox/nip65';
@@ -26,9 +27,11 @@ import { getOwnWriteRelays, useRelayListStore } from '@/shared/lib/nostr/outbox/
 import { Section } from '@/shared/ui/composed/Section';
 import { Screen as ScreenWrapper } from '@/shared/ui/composed/Screen';
 import { EmptyState } from '@/shared/ui/composed/EmptyState';
+import { Badge } from '@/shared/ui/primitives/Badge';
 import { Text } from '@/shared/ui/primitives/Text';
 
 export function SettingsNetworkScreen() {
+  useLifecycleLogger('SettingsNetworkScreen');
   const { ndk } = useNDK();
   const naggTierEnabled = useSettingsStore((s) => s.naggTierEnabled);
   const setNaggTierEnabled = useSettingsStore((s) => s.setNaggTierEnabled);
@@ -44,6 +47,7 @@ export function SettingsNetworkScreen() {
   const restoreDefaults = useRelayListStore((s) => s.restoreDefaults);
   const markPublished = useRelayListStore((s) => s.markPublished);
   const health = useRelayHealth();
+  const tierHealth = useNostrTierHealth();
 
   const [draftUrl, setDraftUrl] = useState('');
   const [addError, setAddError] = useState<string | null>(null);
@@ -64,6 +68,43 @@ export function SettingsNetworkScreen() {
       failed: dangerColor,
     }),
     [successColor, accentColor, mutedColor, dangerColor]
+  );
+
+  const tiers = useMemo(
+    () => [
+      {
+        name: 'nagg',
+        description: 'App-view. Ranked, fully bundled feeds.',
+        status: tierHealth.nagg,
+        enabled: naggTierEnabled,
+        onToggle: setNaggTierEnabled,
+      },
+      {
+        name: 'Primal cache',
+        description: 'Public fallback cache.',
+        status: tierHealth.primal,
+        enabled: primalTierEnabled,
+        onToggle: setPrimalTierEnabled,
+      },
+      {
+        name: 'Raw relays',
+        description: 'Decentralized floor. Direct relay reads.',
+        status: tierHealth.relay,
+        enabled: relayTierEnabled,
+        onToggle: setRelayTierEnabled,
+      },
+    ],
+    [
+      tierHealth.nagg,
+      tierHealth.primal,
+      tierHealth.relay,
+      naggTierEnabled,
+      primalTierEnabled,
+      relayTierEnabled,
+      setNaggTierEnabled,
+      setPrimalTierEnabled,
+      setRelayTierEnabled,
+    ]
   );
 
   const hasUnpublished = source === 'local';
@@ -96,7 +137,7 @@ export function SettingsNetworkScreen() {
         log.info('settings.relays.published', { accepted: result.value.accepted.length });
         setPublishMsg(`Published to ${result.value.accepted.length} relays.`);
       } else {
-        setPublishMsg('Could not publish to any relay. Check your connection and try again.');
+        setPublishMsg('Could not publish. Check your connection and try again.');
       }
     } finally {
       setPublishing(false);
@@ -113,46 +154,37 @@ export function SettingsNetworkScreen() {
       <ScrollView
         className="px-4"
         contentInsetAdjustmentBehavior="automatic"
-        contentContainerStyle={{ paddingBottom: 32 }}>
-        <Text size={13} className="mb-3 px-1" style={{ color: mutedColor }}>
-          Sovran reads Nostr nagg-first, then falls back to Primal&apos;s cache, then raw relays.
-          Turn a source off to skip it (e.g. to test the fallback).
-        </Text>
-
-        <Section title="Aggregator">
-          <TierToggleCard
-            name="nagg"
-            description="Our app-view — fully bundled, ranked"
-            url={backendConfig.nostrAppViewBaseUrl}
-            enabled={naggTierEnabled}
-            onToggle={setNaggTierEnabled}
-          />
-        </Section>
-
-        <Section title="Caching">
-          <TierToggleCard
-            name="Primal cache"
-            description="Primal's public cache server"
-            url={backendConfig.primalCacheUrl}
-            enabled={primalTierEnabled}
-            onToggle={setPrimalTierEnabled}
-          />
-        </Section>
-
-        <Section title="Relays">
-          <TierToggleCard
-            name="Raw relays"
-            description="The decentralised floor — a bit rough but functional"
-            enabled={relayTierEnabled}
-            onToggle={setRelayTierEnabled}
-          />
+        contentContainerStyle={{ paddingBottom: 32 }}
+        refreshControl={
+          <RefreshControl refreshing={tierHealth.isRefreshing} onRefresh={tierHealth.refresh} />
+        }>
+        <Section title="Data layer">
+          <ListGroup variant="secondary">
+            {tiers.map((tier, index) => (
+              <React.Fragment key={tier.name}>
+                {index > 0 ? <Separator className="mx-4" /> : null}
+                <ListGroup.Item className={tier.enabled ? undefined : 'opacity-40'}>
+                  <ListGroup.ItemContent>
+                    <View className="flex-row items-center gap-2">
+                      <ListGroup.ItemTitle>{tier.name}</ListGroup.ItemTitle>
+                      <TierHealthBadge status={tier.status} checkingColor={mutedColor} />
+                    </View>
+                    <ListGroup.ItemDescription>{tier.description}</ListGroup.ItemDescription>
+                  </ListGroup.ItemContent>
+                  <ListGroup.ItemSuffix>
+                    <Switch isSelected={tier.enabled} onSelectedChange={tier.onToggle} />
+                  </ListGroup.ItemSuffix>
+                </ListGroup.Item>
+              </React.Fragment>
+            ))}
+          </ListGroup>
         </Section>
 
         {sortedEntries.length === 0 ? (
           <EmptyState
             icon="mdi:server-network-off"
             title="No relays"
-            subtitle="Add a relay or restore the defaults to start publishing."
+            subtitle="Add one or restore defaults."
           />
         ) : (
           <Section title="Your relays">
@@ -230,8 +262,7 @@ export function SettingsNetworkScreen() {
         <Section title="Publish">
           {hasUnpublished ? (
             <Text size={13} className="mb-2 px-1" style={{ color: mutedColor }}>
-              You have unpublished relay changes. Publish so other apps and your followers can find
-              your posts.
+              Unpublished changes. Publish so others can find your posts.
             </Text>
           ) : null}
           <View className="gap-2">
@@ -253,37 +284,29 @@ export function SettingsNetworkScreen() {
   );
 }
 
-function TierToggleCard({
-  name,
-  description,
-  url,
-  enabled,
-  onToggle,
-}: {
-  name: string;
-  description: string;
-  url?: string;
-  enabled: boolean;
-  onToggle: (next: boolean) => void;
-}) {
-  return (
-    <ListGroup variant="secondary">
-      <View className="flex-row items-center gap-3 px-4 py-3">
-        <View className="flex-1">
-          <Text size={15}>{name}</Text>
-          <Text size={12} className="text-muted mt-0.5">
-            {description}
-          </Text>
-          {url ? (
-            <Text size={12} className="text-muted mt-1" numberOfLines={1}>
-              {url}
-            </Text>
-          ) : null}
-        </View>
-        <Switch isSelected={enabled} onSelectedChange={onToggle} />
-      </View>
-    </ListGroup>
-  );
+function TierHealthBadge({ status, checkingColor }: { status: TierStatus; checkingColor: string }) {
+  switch (status) {
+    case 'online':
+      return (
+        <Badge variant="success" icon="mdi:check-circle" size={11}>
+          Online
+        </Badge>
+      );
+    case 'offline':
+      return (
+        <Badge variant="error" icon="mdi:close-circle" size={11}>
+          Offline
+        </Badge>
+      );
+    case 'checking':
+      return (
+        <Badge variant="secondary" color={checkingColor} icon="mdi:loading" size={11}>
+          Checking
+        </Badge>
+      );
+    case 'disabled':
+      return null;
+  }
 }
 
 function RelayMarkerToggle({

--- a/features/settings/screens/SettingsNetworkScreen.tsx
+++ b/features/settings/screens/SettingsNetworkScreen.tsx
@@ -47,7 +47,7 @@ export function SettingsNetworkScreen() {
   const restoreDefaults = useRelayListStore((s) => s.restoreDefaults);
   const markPublished = useRelayListStore((s) => s.markPublished);
   const health = useRelayHealth();
-  const tierHealth = useNostrTierHealth();
+  const tierHealth = useNostrTierHealth(health);
 
   const [draftUrl, setDraftUrl] = useState('');
   const [addError, setAddError] = useState<string | null>(null);

--- a/shared/hooks/useNostrTierHealth.ts
+++ b/shared/hooks/useNostrTierHealth.ts
@@ -1,0 +1,102 @@
+/**
+ * @fileoverview Live Online/Offline status for the three Nostr data tiers, for
+ * the Network settings screen.
+ *
+ * Composes an HTTP probe (nagg), a WebSocket round-trip probe (Primal), and the
+ * existing NDK-pool relay health (`useRelayHealth`) into one uniform per-tier
+ * status. Active probes run only while the screen is focused — on focus and then
+ * every `POLL_INTERVAL_MS` — to bound battery/network cost; a disabled tier is
+ * not probed (its status is `disabled`). A monotonic run id guards against a
+ * slow probe from an earlier run overwriting a newer result.
+ */
+import { useCallback, useRef, useState } from 'react';
+import { useFocusEffect } from 'expo-router';
+
+import { useRelayHealth } from '@/shared/hooks/useRelayHealth';
+import { log } from '@/shared/lib/logger';
+import { useNostrTierConfig } from '@/shared/lib/nostr/nostrTierConfig';
+import {
+  foldRelayStatus,
+  probeNaggHealth,
+  probePrimalHealth,
+  type TierStatus,
+} from '@/shared/lib/nostr/tierHealth';
+
+const POLL_INTERVAL_MS = 30_000;
+
+interface NostrTierHealth {
+  nagg: TierStatus;
+  primal: TierStatus;
+  relay: TierStatus;
+  isRefreshing: boolean;
+  refresh: () => void;
+}
+
+/** Keep the last known online/offline during a refresh; only show `checking`
+ * when transitioning from a `disabled` (or initial) state, to avoid flicker. */
+function toChecking(prev: TierStatus): TierStatus {
+  return prev === 'disabled' ? 'checking' : prev;
+}
+
+export function useNostrTierHealth(): NostrTierHealth {
+  const config = useNostrTierConfig();
+  const relayMap = useRelayHealth();
+
+  const [nagg, setNagg] = useState<TierStatus>('checking');
+  const [primal, setPrimal] = useState<TierStatus>('checking');
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const runIdRef = useRef(0);
+
+  const relay: TierStatus = config.relay.enabled ? foldRelayStatus(relayMap) : 'disabled';
+
+  const naggEnabled = config.nagg.enabled;
+  const naggUrl = config.nagg.appViewBaseUrl;
+  const primalEnabled = config.primal.enabled;
+  const primalUrl = config.primal.url;
+
+  const runProbes = useCallback(
+    (trigger: 'focus' | 'interval' | 'pull') => {
+      const runId = ++runIdRef.current;
+      log.debug('settings.network.health.refresh', { trigger });
+      setIsRefreshing(true);
+
+      setNagg((prev) => (naggEnabled ? toChecking(prev) : 'disabled'));
+      setPrimal((prev) => (primalEnabled ? toChecking(prev) : 'disabled'));
+
+      const naggTask: Promise<TierStatus> = naggEnabled
+        ? probeNaggHealth(naggUrl).match(
+            (online) => (online ? 'online' : 'offline'),
+            () => 'offline'
+          )
+        : Promise.resolve('disabled');
+      const primalTask: Promise<TierStatus> = primalEnabled
+        ? probePrimalHealth(primalUrl).match(
+            (online) => (online ? 'online' : 'offline'),
+            () => 'offline'
+          )
+        : Promise.resolve('disabled');
+
+      void Promise.all([naggTask, primalTask]).then(([naggStatus, primalStatus]) => {
+        if (runId !== runIdRef.current) return; // a newer run superseded this one
+        setNagg(naggStatus);
+        setPrimal(primalStatus);
+        setIsRefreshing(false);
+        log.info('settings.network.health.probe', { tier: 'nagg', status: naggStatus });
+        log.info('settings.network.health.probe', { tier: 'primal', status: primalStatus });
+      });
+    },
+    [naggEnabled, naggUrl, primalEnabled, primalUrl]
+  );
+
+  useFocusEffect(
+    useCallback(() => {
+      runProbes('focus');
+      const interval = setInterval(() => runProbes('interval'), POLL_INTERVAL_MS);
+      return () => clearInterval(interval);
+    }, [runProbes])
+  );
+
+  const refresh = useCallback(() => runProbes('pull'), [runProbes]);
+
+  return { nagg, primal, relay, isRefreshing, refresh };
+}

--- a/shared/hooks/useNostrTierHealth.ts
+++ b/shared/hooks/useNostrTierHealth.ts
@@ -3,16 +3,20 @@
  * the Network settings screen.
  *
  * Composes an HTTP probe (nagg), a WebSocket round-trip probe (Primal), and the
- * existing NDK-pool relay health (`useRelayHealth`) into one uniform per-tier
- * status. Active probes run only while the screen is focused — on focus and then
- * every `POLL_INTERVAL_MS` — to bound battery/network cost; a disabled tier is
- * not probed (its status is `disabled`). A monotonic run id guards against a
- * slow probe from an earlier run overwriting a newer result.
+ * caller-supplied NDK-pool relay health map into one uniform per-tier status.
+ * The relay map is passed in (rather than calling `useRelayHealth` here) so the
+ * screen runs a single relay poll for both the per-relay dots and this tier fold.
+ *
+ * Active probes run only while the screen is focused — on focus and then every
+ * `POLL_INTERVAL_MS` — to bound battery/network cost; a disabled tier is not
+ * probed (status `disabled`). Each run gets a fresh `AbortController`; starting a
+ * new run (or blurring/unmounting) aborts the previous one, and a monotonic run
+ * id drops any late result so it can't update state after the screen is gone.
  */
 import { useCallback, useRef, useState } from 'react';
 import { useFocusEffect } from 'expo-router';
 
-import { useRelayHealth } from '@/shared/hooks/useRelayHealth';
+import type { RelayHealth } from '@/shared/hooks/useRelayHealth';
 import { log } from '@/shared/lib/logger';
 import { useNostrTierConfig } from '@/shared/lib/nostr/nostrTierConfig';
 import {
@@ -38,14 +42,14 @@ function toChecking(prev: TierStatus): TierStatus {
   return prev === 'disabled' ? 'checking' : prev;
 }
 
-export function useNostrTierHealth(): NostrTierHealth {
+export function useNostrTierHealth(relayMap: Record<string, RelayHealth>): NostrTierHealth {
   const config = useNostrTierConfig();
-  const relayMap = useRelayHealth();
 
   const [nagg, setNagg] = useState<TierStatus>('checking');
   const [primal, setPrimal] = useState<TierStatus>('checking');
   const [isRefreshing, setIsRefreshing] = useState(false);
   const runIdRef = useRef(0);
+  const abortRef = useRef<AbortController | null>(null);
 
   const relay: TierStatus = config.relay.enabled ? foldRelayStatus(relayMap) : 'disabled';
 
@@ -56,6 +60,9 @@ export function useNostrTierHealth(): NostrTierHealth {
 
   const runProbes = useCallback(
     (trigger: 'focus' | 'interval' | 'pull') => {
+      abortRef.current?.abort(); // cancel any still-running probe from a prior run
+      const controller = new AbortController();
+      abortRef.current = controller;
       const runId = ++runIdRef.current;
       log.debug('settings.network.health.refresh', { trigger });
       setIsRefreshing(true);
@@ -64,20 +71,20 @@ export function useNostrTierHealth(): NostrTierHealth {
       setPrimal((prev) => (primalEnabled ? toChecking(prev) : 'disabled'));
 
       const naggTask: Promise<TierStatus> = naggEnabled
-        ? probeNaggHealth(naggUrl).match(
+        ? probeNaggHealth(naggUrl, { signal: controller.signal }).match(
             (online) => (online ? 'online' : 'offline'),
             () => 'offline'
           )
         : Promise.resolve('disabled');
       const primalTask: Promise<TierStatus> = primalEnabled
-        ? probePrimalHealth(primalUrl).match(
+        ? probePrimalHealth(primalUrl, { signal: controller.signal }).match(
             (online) => (online ? 'online' : 'offline'),
             () => 'offline'
           )
         : Promise.resolve('disabled');
 
       void Promise.all([naggTask, primalTask]).then(([naggStatus, primalStatus]) => {
-        if (runId !== runIdRef.current) return; // a newer run superseded this one
+        if (runId !== runIdRef.current) return; // a newer run (or cleanup) superseded this one
         setNagg(naggStatus);
         setPrimal(primalStatus);
         setIsRefreshing(false);
@@ -92,7 +99,11 @@ export function useNostrTierHealth(): NostrTierHealth {
     useCallback(() => {
       runProbes('focus');
       const interval = setInterval(() => runProbes('interval'), POLL_INTERVAL_MS);
-      return () => clearInterval(interval);
+      return () => {
+        clearInterval(interval);
+        runIdRef.current++; // drop any in-flight result so it can't update state after blur
+        abortRef.current?.abort();
+      };
     }, [runProbes])
   );
 

--- a/shared/lib/nostr/tierHealth.ts
+++ b/shared/lib/nostr/tierHealth.ts
@@ -1,0 +1,117 @@
+/**
+ * @fileoverview Liveness probes for the Nostr data layer's three tiers.
+ *
+ * nagg exposes an HTTP `/healthz` (JSON `{ ok: "true", … }`). Primal's cache has
+ * no health endpoint, so we treat a WebSocket round-trip — a minimal Nostr REQ
+ * answered by any frame before a timeout — as "online". Raw relay liveness comes
+ * from the NDK pool via `useRelayHealth`; `foldRelayStatus` collapses that
+ * per-URL map into one tier status.
+ *
+ * These are pure functions (no React, no module globals) so the screen hook
+ * stays thin and they unit-test without a harness. The success channel is a
+ * `boolean` (the probe ran and produced a verdict); `err` means the probe itself
+ * could not run (network/abort/socket failure) and is treated as offline.
+ */
+import { ok, err, ResultAsync } from 'neverthrow';
+import { z } from 'zod';
+import { parseWith } from '@sovranbitcoin/schemas';
+
+import { fetchJson } from '@/shared/lib/apiClient';
+import { redactError, type RedactedError } from '@/shared/lib/logger';
+import type { RelayHealth } from '@/shared/hooks/useRelayHealth';
+
+/** Uniform per-tier status the Network screen renders. `disabled` = toggle off. */
+export type TierStatus = 'online' | 'offline' | 'checking' | 'disabled';
+
+const NAGG_HEALTH_TIMEOUT_MS = 4_000;
+const PRIMAL_HEALTH_TIMEOUT_MS = 5_000;
+
+const healthzSchema = z.object({ ok: z.union([z.string(), z.boolean()]) });
+const parseHealthz = parseWith(healthzSchema, 'nostr/nagg-healthz');
+
+/**
+ * Probe nagg's HTTP `/healthz` through the shared `fetchJson` client (timeout,
+ * URL redaction, zod validation). The `err` channel means the probe could not
+ * run (unreachable / non-2xx / malformed body) — offline; `ok(true)` means the
+ * body reported `{ ok: "true" | true }`.
+ */
+export function probeNaggHealth(
+  baseUrl: string,
+  options: { signal?: AbortSignal } = {}
+): ResultAsync<boolean, RedactedError> {
+  const url = `${baseUrl.replace(/\/+$/, '')}/healthz`;
+  return ResultAsync.fromSafePromise(
+    fetchJson(url, parseHealthz, 'nostr/nagg-healthz', undefined, {
+      signal: options.signal,
+      timeoutMs: NAGG_HEALTH_TIMEOUT_MS,
+    })
+  ).andThen((result) =>
+    result.match(
+      (body) => ok(body.ok === true || body.ok === 'true'),
+      (e) => err(redactError(e))
+    )
+  );
+}
+
+/**
+ * Probe Primal's cache. It has no `/healthz`, so we open the WebSocket, send a
+ * minimal Nostr REQ, and treat the first response frame as "online". The socket
+ * is always closed (CLOSE + `close()`) before resolving, and a timer caps the
+ * wait so a dead host resolves offline rather than hanging.
+ */
+export function probePrimalHealth(
+  url: string,
+  options: { timeoutMs?: number; WebSocketImpl?: typeof WebSocket } = {}
+): ResultAsync<boolean, RedactedError> {
+  const timeoutMs = options.timeoutMs ?? PRIMAL_HEALTH_TIMEOUT_MS;
+  const WebSocketCtor = options.WebSocketImpl ?? WebSocket;
+  return ResultAsync.fromPromise(
+    new Promise<boolean>((resolve) => {
+      const subId = `health-${Math.random().toString(36).slice(2, 10)}`;
+      let settled = false;
+      let ws: WebSocket | null = null;
+      const finish = (online: boolean) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        try {
+          ws?.send(JSON.stringify(['CLOSE', subId]));
+          ws?.close();
+        } catch {
+          // Socket already closing/closed — nothing left to clean up.
+        }
+        resolve(online);
+      };
+      const timer = setTimeout(() => finish(false), timeoutMs);
+      try {
+        ws = new WebSocketCtor(url);
+      } catch {
+        finish(false);
+        return;
+      }
+      ws.onopen = () => {
+        try {
+          ws?.send(JSON.stringify(['REQ', subId, { kinds: [1], limit: 1 }]));
+        } catch {
+          finish(false);
+        }
+      };
+      ws.onmessage = () => finish(true);
+      ws.onerror = () => finish(false);
+      ws.onclose = () => finish(false);
+    }),
+    redactError
+  );
+}
+
+/**
+ * Collapse the per-relay NDK-pool health map into one tier status: online if any
+ * relay is connected, checking if any is connecting (and none connected), else
+ * offline (including an empty pool).
+ */
+export function foldRelayStatus(map: Record<string, RelayHealth>): TierStatus {
+  const values = Object.values(map);
+  if (values.some((s) => s === 'connected')) return 'online';
+  if (values.some((s) => s === 'connecting')) return 'checking';
+  return 'offline';
+}

--- a/shared/lib/nostr/tierHealth.ts
+++ b/shared/lib/nostr/tierHealth.ts
@@ -61,11 +61,11 @@ export function probeNaggHealth(
  */
 export function probePrimalHealth(
   url: string,
-  options: { timeoutMs?: number; WebSocketImpl?: typeof WebSocket } = {}
+  options: { timeoutMs?: number; signal?: AbortSignal; WebSocketImpl?: typeof WebSocket } = {}
 ): ResultAsync<boolean, RedactedError> {
   const timeoutMs = options.timeoutMs ?? PRIMAL_HEALTH_TIMEOUT_MS;
   const WebSocketCtor = options.WebSocketImpl ?? WebSocket;
-  return ResultAsync.fromPromise(
+  return ResultAsync.fromSafePromise(
     new Promise<boolean>((resolve) => {
       const subId = `health-${Math.random().toString(36).slice(2, 10)}`;
       let settled = false;
@@ -74,11 +74,16 @@ export function probePrimalHealth(
         if (settled) return;
         settled = true;
         clearTimeout(timer);
+        // Close in its own try so a throwing `send` (socket not OPEN) can't skip it.
         try {
-          ws?.send(JSON.stringify(['CLOSE', subId]));
+          if (ws && ws.readyState === 1 /* OPEN */) ws.send(JSON.stringify(['CLOSE', subId]));
+        } catch {
+          // Socket changed state mid-call; close() below still runs.
+        }
+        try {
           ws?.close();
         } catch {
-          // Socket already closing/closed — nothing left to clean up.
+          // Already closing/closed — nothing left to clean up.
         }
         resolve(online);
       };
@@ -99,8 +104,9 @@ export function probePrimalHealth(
       ws.onmessage = () => finish(true);
       ws.onerror = () => finish(false);
       ws.onclose = () => finish(false);
-    }),
-    redactError
+      if (options.signal?.aborted) finish(false);
+      else options.signal?.addEventListener('abort', () => finish(false), { once: true });
+    })
   );
 }
 

--- a/shared/stores/global/settingsStore.ts
+++ b/shared/stores/global/settingsStore.ts
@@ -455,6 +455,9 @@ export const useSettingsStore = create<SettingsStore>()(
           avatarFallbackVariant: state.avatarFallbackVariant,
           minTransferThreshold: state.minTransferThreshold,
           middlemanRouting: state.middlemanRouting,
+          naggTierEnabled: state.naggTierEnabled,
+          primalTierEnabled: state.primalTierEnabled,
+          relayTierEnabled: state.relayTierEnabled,
         }),
         afterHydrate: (state, error) => {
           if (error) return;


### PR DESCRIPTION
## What

Redesigns the **Network settings page** so it matches the other settings pages and clearly shows whether each Nostr data tier is online.

### Live tier health
Each tier now renders an **Online / Offline / Checking** badge, and dims when its toggle is off:
- **nagg** — HTTP `GET /healthz` (via the canonical `fetchJson` client: timeout, URL redaction, zod validation).
- **Primal cache** — Primal has **no** `/healthz` (returns 404), so health is a **WebSocket round-trip**: open the socket, send a minimal Nostr `REQ`, online if it answers within a timeout. The socket is always closed.
- **Raw relays** — folds the existing `useRelayHealth` NDK-pool state into one tier status.

Probes run only while the screen is focused (on focus + every 30s), skip disabled tiers, and guard against stale async writes with a monotonic run id. **Observability/UI only — the nagg → Primal → relay fallback routing is untouched.**

### Less copy, sibling-consistent layout
Rebuilt on the shared `Section` + `ListGroup` + `Badge` scaffold (like Storage/Routing/Keyring). Copy trimmed from **~103 → ~22 words** (intro paragraph removed; per-tier descriptions cut to one line; publish/empty-state hints shortened).

### Persistence fix
`naggTierEnabled` / `primalTierEnabled` / `relayTierEnabled` were declared in `settingsStore` but **omitted from `partialize`**, so they silently reset to `true` on every launch. Added to `partialize`.

## Files
- `shared/lib/nostr/tierHealth.ts` (new) — pure probes + relay fold.
- `shared/hooks/useNostrTierHealth.ts` (new) — composed focus-gated hook.
- `features/settings/screens/SettingsNetworkScreen.tsx` — redesigned screen.
- `shared/stores/global/settingsStore.ts` — persist tier toggles.
- `__tests__/tierHealth.test.ts` (new) — probe truth tables + fold.
- `docs/adr/0006-network-tier-health.md` (new) — decision record.

## Verification
- `tierHealth` unit tests: 13 passing.
- Type-check: 0 errors. Lint: no new errors. Knip: clean.

This plan was drafted dual-model (Claude + Codex) and merged; the persistence-omission bug was surfaced by the cross-model pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)