### PR TITLE
feat(feed): dev-only per-post source-tier badge (n/c/r)

### DIFF
--- a/features/feed/components/nostr/PostCard.tsx
+++ b/features/feed/components/nostr/PostCard.tsx
@@ -24,6 +24,7 @@ import Reanimated, {
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 
 import type { FeedEvent, NoteMetrics, ProfileInfo } from './feedTypes';
+import { TierBadge } from './TierBadge';
 import { formatDate, formatRelative } from '@/shared/lib/date';
 import { tryNpubEncode } from './feedParse';
 import { useQuotePost } from '@/features/feed/lib/useQuotePost';
@@ -68,6 +69,7 @@ function PostCardGutterHeader({
   shortTime,
   placeholderAuthor,
   placeholderTimestamp,
+  tierBadge,
   onProfilePress,
   onMorePress,
   onNestedPressIn,
@@ -82,6 +84,8 @@ function PostCardGutterHeader({
   shortTime?: string;
   placeholderAuthor?: string;
   placeholderTimestamp?: string;
+  // Dev-only source-tier chip rendered after the timestamp; never set in production.
+  tierBadge?: React.ReactNode;
   onProfilePress?: () => void;
   onMorePress?: () => void;
   onNestedPressIn?: () => void;
@@ -128,6 +132,7 @@ function PostCardGutterHeader({
             </Text>
           </>
         ) : null}
+        {tierBadge}
       </HStack>
       {hasMore ? (
         loading ? (
@@ -474,6 +479,7 @@ export const PostCard = React.memo(function PostCard({
           displayName={displayName}
           nameFallback={nameFallback}
           shortTime={shortTime}
+          tierBadge={<TierBadge eventId={event.id} />}
           onProfilePress={navigateToProfile}
           onMorePress={handleMorePress}
           onNestedPressIn={handleNestedPressIn}

--- a/features/feed/components/nostr/TierBadge.tsx
+++ b/features/feed/components/nostr/TierBadge.tsx
@@ -1,0 +1,33 @@
+import type { NostrTier } from '@sovranbitcoin/schemas';
+import * as React from 'react';
+
+import { Badge } from '@/shared/ui/primitives/Badge';
+import { useDebugTier } from '@/features/feed/stores/debugTierStore';
+
+// Single-letter debug chip showing which facade tier served this note's data.
+// Legend: n = nagg (app-view), c = primal (public cache server), r = relay (raw NIP-01).
+// Colour tracks source quality: nagg=success, primal=warning, relay=error.
+const TIER_DISPLAY: Record<
+  NostrTier,
+  { letter: string; variant: 'success' | 'warning' | 'error' | 'secondary' }
+> = {
+  nagg: { letter: 'n', variant: 'success' },
+  primal: { letter: 'c', variant: 'warning' },
+  relay: { letter: 'r', variant: 'error' },
+  cache: { letter: 'c', variant: 'secondary' },
+};
+
+/**
+ * Dev-only per-post tier badge. Renders nothing in production builds or before the
+ * serving tier for `eventId` has been recorded (see {@link useDebugTier}).
+ */
+export function TierBadge({ eventId }: { eventId: string }): React.ReactElement | null {
+  const tier = useDebugTier(eventId);
+  if (!__DEV__ || !tier) return null;
+  const display = TIER_DISPLAY[tier] ?? { letter: tier.charAt(0), variant: 'secondary' as const };
+  return (
+    <Badge variant={display.variant} size={10}>
+      {display.letter}
+    </Badge>
+  );
+}

--- a/features/feed/data/facadeFeedAdapter.ts
+++ b/features/feed/data/facadeFeedAdapter.ts
@@ -2,6 +2,7 @@ import { facade } from '@sovranbitcoin/nagg-ts';
 
 import { parseJson } from '../components/nostr/feedParse';
 import type { FeedEvent, FeedItem, NoteMetrics, ProfileInfo } from '../components/nostr/feedTypes';
+import { recordDebugTiers } from '../stores/debugTierStore';
 import type { FeedParseResult } from './feedClient';
 
 // Pure shape bridge between the tier-selecting facade and the app's feed UI.
@@ -28,6 +29,21 @@ export function mapAppSpecToFeedSpec(
 /** Adapt the facade's ResolvedFeedPage to the app's FeedParseResult. */
 export function resolvedFeedPageToParseResult(page: facade.ResolvedFeedPage): FeedParseResult {
   const orderedFeedItems = page.items.map(toAppFeedItem);
+
+  // Dev-only: stamp each note with the tier that served this page so PostCard can
+  // badge its source (n/c/r). No-op in production. Cover both the visible event and
+  // the original of a repost so whichever id PostCard renders resolves a tier.
+  if (__DEV__) {
+    const ids: string[] = [];
+    for (const item of orderedFeedItems) {
+      if (item.type === 'note') ids.push(item.event.id);
+      else {
+        ids.push(item.repostEvent.id);
+        if (item.originalEvent) ids.push(item.originalEvent.id);
+      }
+    }
+    recordDebugTiers(ids, page.tier);
+  }
 
   const metricsMap = new Map<string, NoteMetrics>();
   for (const [id, s] of Object.entries(page.stats)) {

--- a/features/feed/data/facadeFeedClient.ts
+++ b/features/feed/data/facadeFeedClient.ts
@@ -5,6 +5,7 @@ import { feedLog } from '@/shared/lib/logger';
 import { buildNostrDataLayer } from '@/shared/lib/nostr/buildNostrDataLayer';
 import { getNostrTierConfig } from '@/shared/lib/nostr/nostrTierConfig';
 import { mapAppSpecToFeedSpec, resolvedFeedPageToParseResult } from './facadeFeedAdapter';
+import { recordDebugTiers } from '../stores/debugTierStore';
 import {
   resolvedNotificationsToResult,
   toFacadeNotificationsRequest,
@@ -49,6 +50,9 @@ function eventsFromAppFeedItem(item: FeedItem): FeedEvent[] {
 
 /** Write a thread result's notes/profiles/metrics into the shared cache. */
 function ingestThreadIntoCache(result: ThreadSeedBuckets): void {
+  // Dev-only: this is the nagg GraphQL thread path, so every note here was served
+  // by nagg — badge it as such on PostCard. No-op in production.
+  if (__DEV__) recordDebugTiers([...result.allEvents.keys()], 'nagg');
   const cache = buildNostrDataLayer()?.cache;
   if (!cache) return;
   cache.ingestNotes([...result.allEvents.values(), ...result.quotedEvents.values()]);
@@ -58,6 +62,15 @@ function ingestThreadIntoCache(result: ThreadSeedBuckets): void {
 
 /** Write a parsed feed/user-feed page's notes/profiles/metrics into the shared cache. */
 function ingestFeedPageIntoCache(result: FeedParseResult): void {
+  // Dev-only: the nagg GraphQL feed paths (home fallback, profile feed, search)
+  // funnel through here, so badge every rendered note as 'nagg'. No-op in prod.
+  if (__DEV__) {
+    const ids: string[] = [];
+    for (const item of result.orderedFeedItems) {
+      for (const event of eventsFromAppFeedItem(item)) ids.push(event.id);
+    }
+    recordDebugTiers(ids, 'nagg');
+  }
   const cache = buildNostrDataLayer()?.cache;
   if (!cache) return;
   const events: FeedEvent[] = [];

--- a/features/feed/data/facadeThreadAdapter.ts
+++ b/features/feed/data/facadeThreadAdapter.ts
@@ -2,6 +2,7 @@ import { facade } from '@sovranbitcoin/nagg-ts';
 
 import { buildThreadStructure } from '@/features/feed/lib/buildThreadStructure';
 import type { FeedEvent, NoteMetrics, ProfileInfo } from '../components/nostr/feedTypes';
+import { recordDebugTiers } from '../stores/debugTierStore';
 import type { ThreadRequest, ThreadResult } from './feedClient';
 
 // Pure shape bridge: facade ResolvedThread → the app's ThreadResult. Used only
@@ -105,6 +106,10 @@ export function resolvedThreadToResult(
     allEvents.set(event.id, event);
     replyEvents.push(event);
   }
+
+  // Dev-only: stamp every note in the thread (root + parents + replies) with the
+  // tier that served it so PostCard can badge its source. No-op in production.
+  if (__DEV__) recordDebugTiers([...allEvents.keys()], thread.tier);
 
   const quotedEvents = new Map<string, FeedEvent>(
     Object.entries(thread.quoted) as [string, FeedEvent][]

--- a/features/feed/stores/debugTierStore.ts
+++ b/features/feed/stores/debugTierStore.ts
@@ -1,0 +1,39 @@
+import type { NostrTier } from '@sovranbitcoin/schemas';
+import { create } from 'zustand';
+
+/**
+ * Dev-only map of note id → the facade tier that served it (nagg / primal / relay).
+ *
+ * The nagg-ts waterfall resolves a tier per *page* fetch, not per item, but the
+ * feed/thread stores accumulate notes from many fetches — so the only accurate
+ * per-post answer is to stamp each item with its page's tier at ingest. This keeps
+ * the source attached to the note id (surviving merge/dedup/reorder) without
+ * polluting the wire `FeedEvent` type or threading a prop through every call site.
+ *
+ * Entirely a debug aid: recording is a no-op outside `__DEV__`, the badge that
+ * reads it renders null in production, and the state is ephemeral (never persisted).
+ */
+type DebugTierStore = {
+  tiers: Map<string, NostrTier>;
+  recordTiers: (eventIds: readonly string[], tier: NostrTier) => void;
+};
+
+const useDebugTierStore = create<DebugTierStore>((set, get) => ({
+  tiers: new Map(),
+  recordTiers: (eventIds, tier) => {
+    if (!__DEV__ || eventIds.length === 0) return;
+    const next = new Map(get().tiers);
+    for (const id of eventIds) next.set(id, tier);
+    set({ tiers: next });
+  },
+}));
+
+/** Record the serving tier for every note id in a freshly-ingested page/thread. */
+export function recordDebugTiers(eventIds: readonly string[], tier: NostrTier): void {
+  useDebugTierStore.getState().recordTiers(eventIds, tier);
+}
+
+/** Subscribe to the serving tier for a single note (undefined until recorded). */
+export function useDebugTier(eventId: string): NostrTier | undefined {
+  return useDebugTierStore((state) => state.tiers.get(eventId));
+}


### PR DESCRIPTION
## What

A **dev-only** single-letter badge on every post showing which `@sovranbitcoin/nagg-ts` facade tier served its data — so the `nagg → primal → relay` waterfall is visible while debugging.

Legend: **`n`** nagg (app-view, green) · **`c`** primal (public *cache* server, amber) · **`r`** relay (raw NIP-01, red).

## How

The facade resolves a tier **per page**, not per item, but the feed/thread stores accumulate notes across many fetches — so the only accurate per-post answer is to stamp each note with its page's tier at ingest. A dev-only Zustand store (`debugTierStore`) maps `noteId → tier`; `PostCard` reads it via `TierBadge`, rendered after the timestamp on the shared `PostCardGutterHeader`.

Stamping covers every surface that renders `PostCard`:

| Surface | Path | Badged |
|---|---|---|
| Home feed (For You / Following) | facade | real tier `n`/`c`/`r` |
| Home fallback / profile feed / search | nagg GraphQL | `n` |
| Thread (nagg on) | nagg GraphQL | `n` |
| Thread (nagg off) | facade | real tier `c`/`r` |

Facade paths record their real tier in `facadeFeedAdapter` / `facadeThreadAdapter`; the legacy nagg GraphQL paths piggyback on the existing `ingest*IntoCache` chokepoint in `facadeFeedClient` (already tagging the source `'nagg'`). Notifications are skipped — they don't render `PostCard`.

## Safety

Entirely `__DEV__`-gated: `recordDebugTiers` no-ops and `TierBadge` returns `null` in production. The wire `FeedEvent` type stays pure (no `source` field), no prop threading through call sites, and **no nagg-ts change**. State is ephemeral (never persisted).

`tsc --noEmit` clean · eslint clean on touched files.