### PR TITLE
feat: actionable "update available" sheet with Download CTA

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -40,7 +40,7 @@
         "@sovranbitcoin/coco-cashu-plugin-p2pk-import": "^0.1.0",
         "@sovranbitcoin/colada": "^0.7.0",
         "@sovranbitcoin/nagg-ts": "^0.6.0",
-        "@sovranbitcoin/schemas": "^2.1.0",
+        "@sovranbitcoin/schemas": "^2.2.0",
         "bitchat-module": "file:./modules/bitchat-module",
         "buffer": "^6.0.3",
         "cashu-kym": "^0.4.1",
@@ -1081,7 +1081,7 @@
 
     "@sovranbitcoin/nagg-ts": ["@sovranbitcoin/nagg-ts@0.6.0", "https://npm.pkg.github.com/download/@sovranbitcoin/nagg-ts/0.6.0/c9e5db6bd6993a8c32afab73531e520df68c1d64", { "dependencies": { "neverthrow": "^8.2.0" }, "peerDependencies": { "@sovranbitcoin/schemas": "*", "zod": "^4.0.0" } }, "sha512-JAcuL1pFanAyZg6TJeeMcTJynujimsVH2oxW49I277ZggNsTu+dm5Bb+/V2tK+We2+SwhXQuRRDIoQLeAHyjkQ=="],
 
-    "@sovranbitcoin/schemas": ["@sovranbitcoin/schemas@2.1.0", "https://npm.pkg.github.com/download/@sovranbitcoin/schemas/2.1.0/a28546a4d07aec52f8d8e9d70510538f418d6a39", { "peerDependencies": { "neverthrow": "^8.0.0", "zod": "^4.0.0" } }, "sha512-tEUXlDToT/+87A+YKb1v10EbDdPw/wIYvqehywXfYxct/Gfx6HoQUpfQnlTw77rxsAQIBqGNaPUbi927VrBD9w=="],
+    "@sovranbitcoin/schemas": ["@sovranbitcoin/schemas@2.2.0", "https://npm.pkg.github.com/download/@sovranbitcoin/schemas/2.2.0/0da1da74127741be9521efe8769c5428820a79fe", { "peerDependencies": { "neverthrow": "^8.0.0", "zod": "^4.0.0" } }, "sha512-Zr8U85aL+NRW6xw9ZbAgnBfc6WEBF05rcVjERNPZS2dFbtNLDwkBScpoKs/ULX3EKOlptTu70/nJPseT+E9arw=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.2.1", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.31.1", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.1" } }, "sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg=="],
 

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@sovranbitcoin/coco-cashu-plugin-p2pk-import": "^0.1.0",
     "@sovranbitcoin/colada": "^0.7.0",
     "@sovranbitcoin/nagg-ts": "^0.6.0",
-    "@sovranbitcoin/schemas": "^2.1.0",
+    "@sovranbitcoin/schemas": "^2.2.0",
     "bitchat-module": "file:./modules/bitchat-module",
     "buffer": "^6.0.3",
     "cashu-kym": "^0.4.1",

--- a/shared/blocks/popup/PopupHost.tsx
+++ b/shared/blocks/popup/PopupHost.tsx
@@ -479,13 +479,17 @@ function SheetContent({
       <SubmessageRenderer submessage={standardPayload?.submessage} animation={confirmedAnimation} />
 
       {(standardPayload?.buttons?.length ?? 0) > 0 ? (
-        <View className="mt-4 gap-2">
+        <View
+          className={
+            standardPayload?.buttonLayout === 'row' ? 'mt-4 w-full flex-row gap-2' : 'mt-4 gap-2'
+          }>
           {standardPayload?.buttons?.map((button, index) => (
             <SheetActionButton
               key={`${button.text}-${index}`}
               button={button}
               variant={index === 0 ? 'primary' : 'tertiary'}
               feedbackVariant={hasLiveStatus ? 'scale' : undefined}
+              row={standardPayload?.buttonLayout === 'row'}
               close={close}
             />
           ))}
@@ -506,11 +510,20 @@ type SheetActionButtonProps = {
   button: { text: string; page?: string; onPress?: () => void | Promise<void> };
   variant: 'primary' | 'tertiary';
   feedbackVariant: 'scale' | undefined;
+  /** In a row layout each button takes an equal share of the width. */
+  row?: boolean;
   close: () => void;
 };
 
-function SheetActionButton({ button, variant, feedbackVariant, close }: SheetActionButtonProps) {
-  const className = getSheetButtonClassName(variant);
+function SheetActionButton({
+  button,
+  variant,
+  feedbackVariant,
+  row,
+  close,
+}: SheetActionButtonProps) {
+  const baseClassName = getSheetButtonClassName(variant);
+  const className = row ? `${baseClassName ?? ''} flex-1`.trim() : baseClassName;
   const labelClassName = getSheetButtonLabelClassName(variant);
   const handlePress = useSingleFlight(async () => {
     if (button.onPress) {

--- a/shared/hooks/useVersionCheck.ts
+++ b/shared/hooks/useVersionCheck.ts
@@ -51,8 +51,9 @@ export const useVersionCheck = () => {
         log.info('hook.version_check.update_available', {
           currentVersion,
           latestVersion: payload.version,
+          hasMessage: !!payload.message,
         });
-        paramPopup('new-version', { version: payload.version });
+        paramPopup('new-version', { version: payload.version, message: payload.message });
       } else {
         log.debug('hook.version_check.up_to_date', { currentVersion });
       }

--- a/shared/lib/popup/popups/bridge.ts
+++ b/shared/lib/popup/popups/bridge.ts
@@ -83,6 +83,7 @@ export type SheetConfig = {
   dismissable?: boolean;
   duration?: number;
   buttons?: { text: string; page?: string; onPress?: () => void }[];
+  buttonLayout?: 'row' | 'stack';
   onClose?: (event: SheetCloseEvent) => void;
   live?: LiveSheetConfig;
 };

--- a/shared/lib/popup/popups/engine.tsx
+++ b/shared/lib/popup/popups/engine.tsx
@@ -33,6 +33,7 @@ interface PopupConfig {
   dismissable?: boolean;
   duration?: number;
   buttons?: PopupButton[];
+  buttonLayout?: 'row' | 'stack';
   onOpen?: () => void;
   onClose?: (event: SheetCloseEvent) => void;
   type?: PopupSeverity;
@@ -64,6 +65,7 @@ export const popup = (config: PopupConfig) => {
       dismissable: options.dismissable ?? true,
       duration: options.duration,
       buttons: resolvedButtons,
+      buttonLayout: options.buttonLayout,
       onClose: options.onClose,
       live: options.live,
     };

--- a/shared/lib/popup/popups/index.ts
+++ b/shared/lib/popup/popups/index.ts
@@ -3,6 +3,7 @@ import { popup } from './engine';
 import type { PopupOverrides } from './types';
 import type { PopupIcon } from '../icons';
 import type { PopupTextSegment } from '../format';
+import { openExternalUrl } from '@/shared/lib/url';
 
 export type { CopyTarget } from './copy';
 export { copyPopup } from './copy';
@@ -31,6 +32,11 @@ const ALERT_ICON = 'icon:mdi:alert-circle-outline';
 const CAMERA_ICON = 'icon:mdi:camera';
 const QR_ICON = 'icon:mdi:qrcode';
 
+// Single download landing page (kept current server-side) so we don't need to
+// detect the user's install source — App Store, Freedom Store (AltStore), or
+// GitHub releases are all linked from there.
+const DOWNLOAD_URL = 'https://sovran.money/en/download';
+
 type PopupSpec = {
   message: string;
   text?: string | ReactNode | PopupTextSegment[];
@@ -38,6 +44,7 @@ type PopupSpec = {
   type?: 'success' | 'error' | 'warning' | 'info';
   variant?: 'toast' | 'sheet';
   buttons?: { text: string; page?: string; onPress?: () => void }[];
+  buttonLayout?: 'row' | 'stack';
 };
 
 const STATIC_POPUPS = {
@@ -306,11 +313,18 @@ const PARAM_POPUPS = {
     type: 'warning',
   }),
 
-  'new-version': (p: { version: string }): PopupSpec => ({
-    message: 'New version available',
-    text: `A new version (${p.version}) is available. Please update to the latest version.`,
-    icon: 'icon:mdi:download',
+  'new-version': (p: { version: string; message?: string }): PopupSpec => ({
+    message: 'Update available',
+    text:
+      p.message ??
+      `Version ${p.version} is now available. Update for the latest features and fixes.`,
+    icon: 'icon:mdi:cloud-download-outline',
     variant: 'sheet',
+    buttonLayout: 'row',
+    buttons: [
+      { text: 'Download', onPress: () => void openExternalUrl(DOWNLOAD_URL) },
+      { text: 'Later' },
+    ],
   }),
 
   'engagement-update-failed': (action: 'follow' | 'like' | 'repost'): PopupSpec => ({

--- a/shared/stores/runtime/popupStore.ts
+++ b/shared/stores/runtime/popupStore.ts
@@ -28,6 +28,8 @@ export type StandardSheetPayload = {
   dismissable?: boolean;
   duration?: number;
   buttons?: SheetButton[];
+  /** Lay buttons side by side ('row') instead of the default vertical stack. */
+  buttonLayout?: 'row' | 'stack';
   onClose?: (event: SheetCloseEvent) => void;
   live?: LiveSheetConfig;
   /** Set by live.get() for styling (e.g. animate to green when confirmed). */


### PR DESCRIPTION
## Summary
Turns the existing version-check popup into a polished, actionable update prompt.

- **Download / Later buttons, side by side** — added an opt-in `buttonLayout: 'row'` threaded through the popup chain (`PopupSpec` → engine → bridge → `StandardSheetPayload` → `PopupHost`); each button is `flex-1`. Default remains a vertical stack, so all other sheets are unchanged.
- **Download** opens `https://sovran.money/en/download` (single page that routes to App Store / Freedom Store / GitHub releases — no install-source detection needed).
- **Server message** (`payload.message`) is shown as the sheet body when present, else default update copy.
- Icon `mdi:download` → `mdi:cloud-download-outline` (verified bundled in `.monicon/icons.js`).
- Title "Update available"; the existing `useVersionCheck` semver gate is unchanged — sheet only shows when the server advertises a newer version.

## Files
`shared/hooks/useVersionCheck.ts`, `shared/lib/popup/popups/index.ts`, `shared/blocks/popup/PopupHost.tsx`, `shared/lib/popup/popups/{engine,bridge}.tsx`, `shared/stores/runtime/popupStore.ts`.

## Sequencing / CI note
Depends on **sovran-schemas#2** (`2.2.0`) for the `message` field. The lockfile here still resolves `@sovranbitcoin/schemas@2.1.0`, so **after schemas 2.2.0 is published**, run `bun update @sovranbitcoin/schemas` and commit the lockfile — until then CI type-check will fail on `payload.message` (it resolves locally via the dev symlink to the sibling repo).

## Testing
`bun run type-check` ✅ · lint ✅ (0 errors) · knip ✅. Behavior verified on-device with the gate temporarily forced on.

## Verification (device)
| # | Verify | Expected |
|---|---|---|
| 1 | API advertises a newer version | sheet shows on home load |
| 2 | Buttons | Download + Later in a row |
| 3 | Download | opens sovran.money/en/download; sheet closes |
| 4 | Later | closes; re-shows next launch |
| 5 | Server message set | shown as sheet body |