### PR TITLE
chore(deps): bump @sovranbitcoin/colada to 0.9.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -33,7 +33,7 @@
         "@shopify/flash-list": "2.0.2",
         "@shopify/react-native-skia": "2.6.2",
         "@sovranbitcoin/coco-cashu-plugin-p2pk-import": "^0.1.0",
-        "@sovranbitcoin/colada": "^0.9.0",
+        "@sovranbitcoin/colada": "^0.9.1",
         "@sovranbitcoin/nagg-ts": "^0.6.0",
         "@sovranbitcoin/schemas": "^2.2.0",
         "bitchat-module": "file:./modules/bitchat-module",
@@ -1054,7 +1054,7 @@
 
     "@sovranbitcoin/coco-cashu-plugin-p2pk-import": ["@sovranbitcoin/coco-cashu-plugin-p2pk-import@0.1.0", "https://npm.pkg.github.com/download/@sovranbitcoin/coco-cashu-plugin-p2pk-import/0.1.0/3f7be1c41a6ed5a327559cba0b915aa0e84fd697", { "dependencies": { "@noble/hashes": "^2.0.1", "nostr-tools": "^2.0.0" }, "peerDependencies": { "@cashu/coco-core": "^1.0.1" } }, "sha512-nC5/13xmdsHTLCFMjtu18CqUmbQtXp1kUAGFr9Jmx6fugrCgpL+Bfxo4GEKMrtfJ27oIjbCDXMdTgFCfAVO2rw=="],
 
-    "@sovranbitcoin/colada": ["@sovranbitcoin/colada@0.9.0", "https://npm.pkg.github.com/download/@sovranbitcoin/colada/0.9.0/1e430b6245ab10d33b34d6da72a6cddefbcc4d95", { "dependencies": { "@cashu/cashu-ts": "3.5.0", "@gandlaf21/bolt11-decode": "^3.1.1", "@noble/hashes": "^2.0.0", "@scure/bip39": "2.0.1", "@sovranbitcoin/nagg-ts": "^0.6.0", "@sovranbitcoin/schemas": "^2.2.0", "neverthrow": "^8.2.0", "nostr-tools": "^2.0.0", "zod": "^4.3.6" }, "peerDependencies": { "@cashu/coco-core": "^1.0.1", "react": ">=18.0.0" } }, "sha512-SfiGW3J5Rop0fUI5Lswm2pO6yJ98vdMpSDcsSbcFRKP2eX7O1Cyxl1AD8yHl+QKBed3L834h2FXeXBfCB3qFvg=="],
+    "@sovranbitcoin/colada": ["@sovranbitcoin/colada@0.9.1", "https://npm.pkg.github.com/download/@sovranbitcoin/colada/0.9.1/0e98bc71bc52a943a71ae1a37a895a5a260b00ca", { "dependencies": { "@cashu/cashu-ts": "3.5.0", "@gandlaf21/bolt11-decode": "^3.1.1", "@noble/hashes": "^2.0.0", "@scure/bip39": "2.0.1", "@sovranbitcoin/nagg-ts": "^0.6.0", "@sovranbitcoin/schemas": "^2.2.0", "neverthrow": "^8.2.0", "nostr-tools": "^2.0.0", "zod": "^4.3.6" }, "peerDependencies": { "@cashu/coco-core": "^1.0.1", "react": ">=18.0.0" } }, "sha512-JyRwHvo5r1NGmo/Uxtp5XFanBMxjtZvzeS2FihHplFBiXADIDyymY4PpEwepJz792j3m7Fo2Huo/+mqo5NT6vw=="],
 
     "@sovranbitcoin/nagg-ts": ["@sovranbitcoin/nagg-ts@0.6.0", "https://npm.pkg.github.com/download/@sovranbitcoin/nagg-ts/0.6.0/c9e5db6bd6993a8c32afab73531e520df68c1d64", { "dependencies": { "neverthrow": "^8.2.0" }, "peerDependencies": { "@sovranbitcoin/schemas": "*", "zod": "^4.0.0" } }, "sha512-JAcuL1pFanAyZg6TJeeMcTJynujimsVH2oxW49I277ZggNsTu+dm5Bb+/V2tK+We2+SwhXQuRRDIoQLeAHyjkQ=="],
 

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@shopify/flash-list": "2.0.2",
     "@shopify/react-native-skia": "2.6.2",
     "@sovranbitcoin/coco-cashu-plugin-p2pk-import": "^0.1.0",
-    "@sovranbitcoin/colada": "^0.9.0",
+    "@sovranbitcoin/colada": "^0.9.1",
     "@sovranbitcoin/nagg-ts": "^0.6.0",
     "@sovranbitcoin/schemas": "^2.2.0",
     "bitchat-module": "file:./modules/bitchat-module",


### PR DESCRIPTION
## Summary

Bumps `@sovranbitcoin/colada` from `^0.9.0` → `^0.9.1` to pick up the Lightning melt fix in [SovranBitcoin/colada#11](https://github.com/SovranBitcoin/colada/pull/11).

**Behavior fixed:** scanning a BOLT11 invoice no longer forces the mint selector when 2+ mints can each cover the amount — it auto-picks the preferred mint (else the highest-balance eligible mint) and lands on the Lightning confirm screen, where the mint pill still lets the user change mints.

## Changes

- `package.json`: `@sovranbitcoin/colada` `^0.9.0` → `^0.9.1`
- `bun.lock`: re-resolved to the published `0.9.1` (GitHub Packages)

colada `0.9.1` is already published to GitHub Packages, so CI/EAS resolve the fix from the registry. Locally, `link-local-siblings` continues to overlay the local `../colada` checkout as before.

## Testing

- `bun install` resolves `0.9.1` cleanly; lockfile integrity matches the published tarball.
- colada side: type-check clean, 767 tests pass (incl. new melt cases + ecash-send regression guard).