### PR TITLE
fix(release): initialize submodules for release source checkouts

### DIFF
--- a/.github/workflows/release-stage.yml
+++ b/.github/workflows/release-stage.yml
@@ -30,6 +30,9 @@ jobs:
           path: source
           persist-credentials: false
           fetch-depth: 1
+          # Vendored bitchat native sources are git submodules; EAS archives
+          # the checked-out tree, so an uninitialized submodule ships empty.
+          submodules: true
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '22'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,7 @@ jobs:
           ref: ${{ needs.prepare.outputs.sha }}
           path: source
           persist-credentials: false
+          submodules: true
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           ref: ${{ github.sha }}

--- a/release/tests/workflow.test.mjs
+++ b/release/tests/workflow.test.mjs
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+const workflows = path.join(import.meta.dirname, '..', '..', '.github', 'workflows');
+
+// The bitchat iOS/Android native sources are git submodules under
+// app/modules/bitchat-module. EAS archives the checked-out tree, so every
+// checkout of the release source must initialize submodules or the native
+// builds compile against empty vendor directories.
+test('release source checkouts initialize submodules', () => {
+  for (const file of ['release.yml', 'release-stage.yml']) {
+    const text = readFileSync(path.join(workflows, file), 'utf8');
+    const blocks = text.split(/\n\s+- (?:if: [^\n]+\n\s+)?uses: actions\/checkout@/).slice(1);
+    const sources = blocks.filter((block) => /^\s+path: source$/m.test(block));
+    assert.ok(sources.length >= 1, `${file} checks out the release source`);
+    for (const block of sources) assert.match(block, /^\s+submodules: true$/m, `${file} source checkout sets submodules: true`);
+  }
+});


### PR DESCRIPTION
## Summary
- Both 0.1.2 production builds errored on EAS (iOS `40ef9514`, Android `2c248212`): iOS could not find any bitchat types in scope; Android failed in Gradle.
- Cause: the bitchat iOS/Android native sources are git submodules under `app/modules/bitchat-module`, and the release workflow checkouts never initialized them. EAS archived empty vendor directories and `sync-bitchat-android.js` skipped with "submodule not checked out".
- Fix: `submodules: true` on the validate and build source checkouts. Add `release/tests/workflow.test.mjs` so the release test gate fails if either source checkout drops it.

## Verification
- `bun run test:release`: 33 node tests + 5 python tests pass; the new test fails when `submodules` is removed.
- Local `git status` after postinstall stays clean with submodules present, so the build stage's "source changed during installation" guard is unaffected (iOS submodule is `ignore = dirty`; Android sync writes to a gitignored dir).

## Follow-up after merge
Controller fix only; the active 0.1.2 release stays pinned to `148ebd08`. The ledger's errored build entries need a reviewed state correction and the two errored EAS builds removed before the next reconcile can requeue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnhaZJ8CJem2coLy8wr4qR