### PR TITLE
fix(release): report error class and code for suppressed stage failures

### DIFF
--- a/release/core.mjs
+++ b/release/core.mjs
@@ -42,8 +42,17 @@ export async function request(url, { hosts, token, method = 'GET', body, bytes, 
     return type === 'application/json' ? (data.length ? JSON.parse(data.toString()) : null) : data;
   } catch (error) {
     if (error instanceof HttpError) throw error;
-    throw new Error('Provider response failed validation or timed out');
+    throw new Error('Provider response failed validation or timed out', { cause: error });
   }
+}
+// Failure class plus a network error code only. Messages, bodies and URLs from
+// providers or subprocesses can carry tokens, so they never reach the log.
+export function diagnostic(error) {
+  const tag = (value) => (/^[A-Za-z0-9_]{1,40}$/.test(String(value ?? '')) ? String(value) : 'unknown');
+  const cause = error?.cause;
+  const parts = [tag(error?.constructor?.name)];
+  if (cause) parts.push(tag(cause?.code ?? cause?.constructor?.name));
+  return parts.join('/');
 }
 export function command(binary, args, options = {}) {
   try { return execFileSync(binary, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 600_000, maxBuffer: 16 * 1024 * 1024, ...options }); }
@@ -61,7 +70,7 @@ export async function download(url, hosts, limit = 1_000_000_000) {
     safeUrl(url, hosts);
     let response;
     try { response = await fetch(url, { redirect: 'manual', signal: AbortSignal.timeout(300_000) }); }
-    catch { throw new Error('Artifact download failed'); }
+    catch (error) { throw new Error('Artifact download failed', { cause: error }); }
     if ([301, 302, 303, 307, 308].includes(response.status)) {
       const location = response.headers.get('location'); await response.body?.cancel();
       check(location, 'Artifact redirect missing destination'); url = new URL(location, url).href; continue;

--- a/release/run.mjs
+++ b/release/run.mjs
@@ -1,5 +1,5 @@
 import { appendFileSync } from 'node:fs';
-import { config, check, GitHub, Ledger, required, ReleaseError, HttpError } from './core.mjs';
+import { config, check, diagnostic, GitHub, Ledger, required, ReleaseError, HttpError } from './core.mjs';
 import { prepare } from './prepare.mjs';
 import { build } from './build.mjs';
 import { appleRelease } from './apple.mjs';
@@ -31,5 +31,7 @@ try {
   const message = String(error?.message ?? '');
   const safe = (error instanceof ReleaseError || error instanceof HttpError) && /^[A-Za-z0-9 .:;()/_-]{1,180}$/.test(message);
   console.error(safe ? message : 'Release stage failed; inspect provider status without exposing credentials.');
+  // Class names and error codes only: never messages, bodies or URLs.
+  if (!safe) console.error(`Diagnostic: ${diagnostic(error)}`);
   process.exitCode = 1;
 }

--- a/release/tests/core.test.mjs
+++ b/release/tests/core.test.mjs
@@ -1,6 +1,6 @@
 import { test, mock } from 'node:test';
 import assert from 'node:assert/strict';
-import { request, download, safeUrl, GitHub, Ledger, sha256, compareVersion, published } from '../core.mjs';
+import { request, download, safeUrl, GitHub, Ledger, sha256, compareVersion, published, diagnostic } from '../core.mjs';
 
 test('API credentials cannot follow redirects or escape the allowed origin', async () => {
   const calls = [];
@@ -86,4 +86,20 @@ test('large checkpoint files resume through the immutable Git blob', async () =>
     assert.equal(result.sha, sha);
     assert.equal(calls.length, 2);
   } finally { handle.mock.restore(); }
+});
+
+test('diagnostics expose only error classes and codes, never provider text', async () => {
+  const canary = 'fake-canary-secret';
+  const network = Object.assign(new TypeError(`fetch failed ${canary}`), { code: 'ECONNRESET' });
+  assert.equal(diagnostic(new Error(canary, { cause: network })), 'Error/ECONNRESET');
+  assert.equal(diagnostic(new Error(canary, { cause: new TypeError(canary) })), 'Error/TypeError');
+  assert.equal(diagnostic(new TypeError(canary)), 'TypeError');
+  assert.equal(diagnostic(Object.assign(new Error(canary), { cause: { code: `bad ${canary}` } })), 'Error/unknown');
+  assert.equal(diagnostic(undefined), 'unknown');
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => { throw Object.assign(new TypeError(canary), { code: 'UND_ERR_SOCKET' }); };
+  try {
+    await assert.rejects(request('https://api.github.com/', { hosts: ['api.github.com'] }), (error) => diagnostic(error) === 'Error/UND_ERR_SOCKET' && !error.message.includes(canary));
+    await assert.rejects(download('https://github.com/', ['github.com']), (error) => diagnostic(error) === 'Error/UND_ERR_SOCKET' && !error.message.includes(canary));
+  } finally { globalThis.fetch = originalFetch; }
 });


### PR DESCRIPTION
## Summary
- The 0.1.2 android stage (run 34667476087) failed ~600ms into reconcile with only `Release stage failed; inspect provider status without exposing credentials.` That hides whether the first Play call's fetch threw, JSON parsing failed, or something else.
- Preserve the underlying `cause` on wrapped `request()`/`download()` failures and print one extra `Diagnostic: <ErrorClass>/<code-or-cause-class>` line for non-safe errors. Values are whitelisted to `[A-Za-z0-9_]{1,40}`; messages, bodies and URLs remain suppressed.

## Verification
- `bun run test:release`: 34 node + 5 python tests pass. New test asserts a canary in the wrapped error/cause never reaches the diagnostic or message.

## Context
Controller-only change; the active 0.1.2 release stays pinned to `148ebd08`. iOS build 175 is uploaded (EAS submission `f9cfc06f` FINISHED). Android build 23 is ready; its Play upload is the blocked step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnhaZJ8CJem2coLy8wr4qR