### PR TITLE
fix(release): locate suppressed failures and tolerate empty Play release lists

### DIFF
--- a/release/android.mjs
+++ b/release/android.mjs
@@ -38,7 +38,8 @@ export async function androidRelease(ledger) {
   if (!state.builds.android?.ready) return;
   if (state.apk && state.channels.googlePlay?.version === state.version) return;
   const number = state.builds.android.number;
-  let summaries = (await play('tracks/production/releases')).releases ?? [];
+  // An empty 2xx body decodes to null; treat it as a track with no releases.
+  let summaries = (await play('tracks/production/releases'))?.releases ?? [];
   let summary = summaries.find((r) => r.activeArtifacts?.some((a) => String(a.versionCode) === number));
   let aab;
   if (!state.aabSha256) {

--- a/release/core.mjs
+++ b/release/core.mjs
@@ -52,7 +52,9 @@ export function diagnostic(error) {
   const cause = error?.cause;
   const parts = [tag(error?.constructor?.name)];
   if (cause) parts.push(tag(cause?.code ?? cause?.constructor?.name));
-  return parts.join('/');
+  // First controller frame: our own file name and position, nothing else.
+  const frame = String(error?.stack ?? '').match(/\/release\/([a-z]+\.mjs):(\d+):(\d+)/);
+  return parts.join('/') + (frame ? `@${frame[1]}:${frame[2]}:${frame[3]}` : '');
 }
 export function command(binary, args, options = {}) {
   try { return execFileSync(binary, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 600_000, maxBuffer: 16 * 1024 * 1024, ...options }); }

--- a/release/tests/core.test.mjs
+++ b/release/tests/core.test.mjs
@@ -96,10 +96,13 @@ test('diagnostics expose only error classes and codes, never provider text', asy
   assert.equal(diagnostic(new TypeError(canary)), 'TypeError');
   assert.equal(diagnostic(Object.assign(new Error(canary), { cause: { code: `bad ${canary}` } })), 'Error/unknown');
   assert.equal(diagnostic(undefined), 'unknown');
+  const located = new TypeError(canary);
+  located.stack = `TypeError: ${canary}\n    at androidRelease (file:///home/runner/work/Sovran/Sovran/controller/release/android.mjs:44:63)\n    at run (file:///x/release/run.mjs:20:5)`;
+  assert.equal(diagnostic(located), 'TypeError@android.mjs:44:63');
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async () => { throw Object.assign(new TypeError(canary), { code: 'UND_ERR_SOCKET' }); };
   try {
-    await assert.rejects(request('https://api.github.com/', { hosts: ['api.github.com'] }), (error) => diagnostic(error) === 'Error/UND_ERR_SOCKET' && !error.message.includes(canary));
-    await assert.rejects(download('https://github.com/', ['github.com']), (error) => diagnostic(error) === 'Error/UND_ERR_SOCKET' && !error.message.includes(canary));
+    await assert.rejects(request('https://api.github.com/', { hosts: ['api.github.com'] }), (error) => /^Error\/UND_ERR_SOCKET@core\.mjs:\d+:\d+$/.test(diagnostic(error)) && !error.message.includes(canary));
+    await assert.rejects(download('https://github.com/', ['github.com']), (error) => /^Error\/UND_ERR_SOCKET@core\.mjs:\d+:\d+$/.test(diagnostic(error)) && !error.message.includes(canary));
   } finally { globalThis.fetch = originalFetch; }
 });


### PR DESCRIPTION
## Summary
- Run 34668520016 printed `Diagnostic: TypeError` (no cause) for the android stage: a null dereference in controller code, not a wrapped fetch failure.
- `diagnostic()` now appends the first controller stack frame as `@<file>.mjs:<line>:<col>` (controller file names and numbers only).
- `androidRelease` treats an empty 2xx body from `tracks/production/releases` as an empty list instead of dereferencing null, the likeliest throw site ~600ms into the stage.

## Verification
- `bun run test:release`: 34 node + 5 python tests pass. Diagnostic tests cover the location suffix and that a canary never leaks.

## Context
Controller-only; release 0.1.2 stays pinned to `148ebd08`. iOS: upload confirmed, ASC version attached to build 175. Android: build 23 ready, Play upload is the blocked step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnhaZJ8CJem2coLy8wr4qR