### PR TITLE
fix(release): surface sanitized provider error codes on 4xx responses

### DIFF
--- a/release/core.mjs
+++ b/release/core.mjs
@@ -26,7 +26,18 @@ export function safeUrl(value, hosts) {
 
 // No provider bodies, URLs, subprocess stderr or raw exceptions in logs: these
 // can contain tokens, signed artifact URLs, private metadata or workflow commands.
-export class HttpError extends Error { constructor(status) { super(`Provider HTTP ${status}`); this.status = status; } }
+export class HttpError extends Error { constructor(status, detail) { super(`Provider HTTP ${status}${detail ? ` ${detail}` : ''}`); this.status = status; } }
+// Reduce a JSON error envelope (Google: error.status/errors[].reason/message;
+// Apple: errors[].code/title/detail) to codes plus a message restricted to the
+// same character set run.mjs allows in logs. Nothing else from the body survives.
+export function errorDetail(body) {
+  let json; try { json = JSON.parse(body); } catch { return ''; }
+  const error = json?.error ?? {};
+  const codes = [error.status, ...(error.errors ?? []).map((e) => e?.reason), ...(json?.errors ?? []).map((e) => e?.code)].filter((c) => /^[A-Za-z0-9_]{1,60}$/.test(String(c ?? '')));
+  const text = [error.message, ...(json?.errors ?? []).map((e) => [e?.title, e?.detail].filter(Boolean).join(' '))].filter(Boolean).join(' ');
+  const message = String(text).replace(/[^A-Za-z0-9 .:;()/_-]+/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 120);
+  return [...new Set(codes)].join('/') + (message ? `: ${message}` : '');
+}
 export async function request(url, { hosts, token, method = 'GET', body, bytes, limit = 8 * 1024 * 1024, type = 'application/json', accept = 'application/json' } = {}) {
   safeUrl(url, hosts);
   const headers = { Accept: accept, 'User-Agent': 'sovran-release' };
@@ -35,7 +46,13 @@ export async function request(url, { hosts, token, method = 'GET', body, bytes, 
   let response;
   try {
     response = await fetch(url, { method, headers, redirect: 'error', signal: AbortSignal.timeout(300_000), body: bytes ?? (body === undefined ? undefined : JSON.stringify(body)) });
-    if (!response.ok) throw new HttpError(response.status);
+    if (!response.ok) {
+      let detail = '';
+      if (response.status >= 400 && response.status < 500 && (response.headers.get('content-type') ?? '').includes('json')) {
+        try { detail = errorDetail((await response.text()).slice(0, 64 * 1024)); } catch { detail = ''; }
+      }
+      throw new HttpError(response.status, detail);
+    }
     const parts = []; let size = 0;
     for await (const chunk of response.body ?? []) { size += chunk.length; check(size <= limit, 'Provider response too large'); parts.push(chunk); }
     const data = Buffer.concat(parts);

--- a/release/tests/core.test.mjs
+++ b/release/tests/core.test.mjs
@@ -1,6 +1,6 @@
 import { test, mock } from 'node:test';
 import assert from 'node:assert/strict';
-import { request, download, safeUrl, GitHub, Ledger, sha256, compareVersion, published, diagnostic } from '../core.mjs';
+import { request, download, safeUrl, GitHub, Ledger, sha256, compareVersion, published, diagnostic, errorDetail } from '../core.mjs';
 
 test('API credentials cannot follow redirects or escape the allowed origin', async () => {
   const calls = [];
@@ -105,4 +105,20 @@ test('diagnostics expose only error classes and codes, never provider text', asy
     await assert.rejects(request('https://api.github.com/', { hosts: ['api.github.com'] }), (error) => /^Error\/UND_ERR_SOCKET@core\.mjs:\d+:\d+$/.test(diagnostic(error)) && !error.message.includes(canary));
     await assert.rejects(download('https://github.com/', ['github.com']), (error) => /^Error\/UND_ERR_SOCKET@core\.mjs:\d+:\d+$/.test(diagnostic(error)) && !error.message.includes(canary));
   } finally { globalThis.fetch = originalFetch; }
+});
+
+test('4xx JSON error envelopes surface only codes and a sanitized message', async () => {
+  const canary = 'fake-canary-secret';
+  const google = { error: { code: 400, message: `Version code 23 has already been used. <a href="https://x/${canary}?token=${canary}">\nsee</a>`, status: 'INVALID_ARGUMENT', errors: [{ reason: 'apkUpgradeVersionConflict', message: 'x' }] } };
+  const detail = errorDetail(JSON.stringify(google));
+  assert.match(detail, /^INVALID_ARGUMENT\/apkUpgradeVersionConflict: Version code 23 has already been used/);
+  assert.ok(!detail.includes('<') && !detail.includes('?') && !detail.includes('='));
+  assert.equal(errorDetail('not json'), '');
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => Response.json(google, { status: 400 });
+  try {
+    await assert.rejects(request('https://api.github.com/', { hosts: ['api.github.com'] }), (error) => error.status === 400 && /^Provider HTTP 400 INVALID_ARGUMENT\/apkUpgradeVersionConflict: Version code 23/.test(error.message) && /^[A-Za-z0-9 .:;()/_-]{1,180}$/.test(error.message));
+  } finally { globalThis.fetch = originalFetch; }
+  globalThis.fetch = async () => new Response('<html>oops</html>', { status: 502, headers: { 'content-type': 'text/html' } });
+  try { await assert.rejects(request('https://api.github.com/', { hosts: ['api.github.com'] }), (error) => error.message === 'Provider HTTP 502'); } finally { globalThis.fetch = originalFetch; }
 });


### PR DESCRIPTION
## Summary
- Run 34669385051: the android stage now passes the release list, uploads the AAB, records the `play-track` intent, then fails with `Provider HTTP 400` (track update or edit validation). The body says why; the controller discards it.
- For 4xx JSON error envelopes, `HttpError` now carries a sanitized detail: enum-like codes (Google `error.status` / `errors[].reason`, Apple `errors[].code`) plus a message reduced to the log-safe charset and capped at 120 chars. Non-JSON or 5xx bodies stay suppressed. The existing `run.mjs` safe-message gate still governs printing.

## Verification
- `bun run test:release`: 35 node + 5 python tests pass. New test feeds a canary with markup, query strings and newlines through the envelope and asserts none survive; HTML 5xx bodies produce no detail.

## Context
Controller-only; release 0.1.2 stays pinned to `148ebd08`. iOS upload confirmed with ASC version attached. Android: AAB uploaded to Play edit `0536...`, blocked at the 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnhaZJ8CJem2coLy8wr4qR