### PR TITLE
fix(release): replace expired Play edits instead of failing the android stage

### DIFF
--- a/release/android.mjs
+++ b/release/android.mjs
@@ -50,7 +50,8 @@ export async function androidRelease(ledger) {
   if (state.playEdit) {
     try { await play(`edits/${encodeURIComponent(state.playEdit)}`); }
     catch (error) {
-      if (![404, 409].includes(error.status)) throw error;
+      // Expired edits answer 400 FAILED_PRECONDITION rather than 404/409.
+      if (![404, 409].includes(error.status) && !(error.status === 400 && /expired/i.test(error.message))) throw error;
       check(summary || !state.intents['play-commit'], 'Play commit acknowledgement ambiguous; inspect Play before clearing edit');
       delete state.playEdit; await ledger.save();
     }

--- a/release/tests/android.test.mjs
+++ b/release/tests/android.test.mjs
@@ -61,3 +61,34 @@ for (const ownsTrack of [true, false]) {
     }
   });
 }
+
+test('an expired Play edit (400 FAILED_PRECONDITION) is replaced instead of failing the stage', async () => {
+  const oldToken = process.env.GOOGLE_ACCESS_TOKEN;
+  process.env.GOOGLE_ACCESS_TOKEN = 'fake-canary';
+  const state = preparedRelease(true); state.playEdit = 'stale-edit';
+  const saved = [];
+  const ledger = { state, async save() { saved.push(structuredClone(state)); }, async intent(name) { state.intents[name] = '2026-09-10T01:00:00Z'; await this.save(); } };
+  const calls = [];
+  const handle = mock.method(globalThis, 'fetch', async (url, options) => {
+    const route = new URL(url).pathname.split(`/applications/${config.bundleId}/`)[1];
+    calls.push(`${options.method} ${route}`);
+    if (options.method === 'GET' && route === 'tracks/production/releases') return Response.json({ releases: [] });
+    if (options.method === 'GET' && route === 'edits/stale-edit') return Response.json({ error: { code: 400, status: 'FAILED_PRECONDITION', message: 'This edit has expired please create a new Edit.' } }, { status: 400 });
+    if (options.method === 'POST' && route === 'edits') return Response.json({ id: 'fresh-edit' });
+    if (options.method === 'GET' && route === 'edits/fresh-edit/bundles') return Response.json({ bundles: [{ versionCode: 30, sha256: state.aabSha256 }] });
+    if (options.method === 'GET' && route === 'edits/fresh-edit/tracks/production') return Response.json({ releases: [{ name: '0.1.1', status: 'completed', versionCodes: ['30'] }] });
+    if (options.method === 'POST' && route === 'edits/fresh-edit:validate') return Response.json({});
+    if (options.method === 'POST' && route === 'edits/fresh-edit:commit') return Response.json({ id: 'fresh-edit' });
+    if (options.method === 'GET' && route === 'generatedApks/30') return new Response(null, { status: 404 });
+    throw new Error(`Unexpected provider operation ${options.method} ${route}`);
+  });
+  try {
+    await androidRelease(ledger);
+    assert.ok(calls.includes('POST edits'), 'a replacement edit is created');
+    assert.equal(state.steps.playSubmitted, true);
+    assert.equal(state.playEdit, undefined);
+  } finally {
+    handle.mock.restore();
+    if (oldToken === undefined) delete process.env.GOOGLE_ACCESS_TOKEN; else process.env.GOOGLE_ACCESS_TOKEN = oldToken;
+  }
+});


### PR DESCRIPTION
## Summary
- Run 34707770396 android stage: `Provider HTTP 400 FAILED_PRECONDITION: This edit has expired please create a new Edit.` The stage only tolerated 404/409 when re-reading a saved edit.
- Treat an expired-edit 400 like a missing edit (same `play-commit` acknowledgement guard), so hourly resumes replace it instead of failing.

## Verification
- `bun run test:release`: 36 node + 5 python tests pass, including a new expired-edit scenario.

## Context
Release 0.1.3 is active. iOS is Ready for Distribution. Play's first production release was created manually (draft-app rule) and is in Google review; a reviewed state correction records that (`playSubmitted`, `play-track` intent) so this stage waits on review instead of trying to re-create the track. `ARTIFACT_DOWNLOAD_HOSTS` gained the AltStore download host so the assets stage can host the Apple package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnhaZJ8CJem2coLy8wr4qR