### PR TITLE
fix(release): host screenshots from the en-GB App Store localization

### DIFF
--- a/release/config.json
+++ b/release/config.json
@@ -14,6 +14,7 @@
   "freedomRepository": "freedomstore/freedomstore",
   "freedomSource": "https://source.freedomstore.io/",
   "locale": "en-US",
+  "appleLocale": "en-GB",
   "zsp": {
     "version": "0.4.17",
     "sha256": "3f241da6a5dc7a85fe851d3b42b77790b651bd36c7029382a701262bda832d20"

--- a/release/hosting.mjs
+++ b/release/hosting.mjs
@@ -56,7 +56,10 @@ export async function verifyHosted(inventory) {
 }
 async function mediaFiles(state, apple) {
   const locales = await apple.list(`appStoreVersions/${state.appleVersionId}/appStoreVersionLocalizations`);
-  const locale = locales.find((l) => l.attributes.locale === config.locale);
+  // App Store Connect localizations (en-GB) differ from the Play release-notes
+  // language (en-US); each is configured explicitly.
+  const wanted = config.appleLocale ?? config.locale;
+  const locale = locales.find((l) => l.attributes.locale === wanted);
   check(locale, 'Configured ASC screenshot locale missing');
   const sets = await apple.list(`appStoreVersionLocalizations/${locale.id}/appScreenshotSets`);
   const preference = ['APP_IPHONE_69', 'APP_IPHONE_67', 'APP_IPHONE_65', 'APP_IPHONE_61', 'APP_IPHONE_58', 'APP_IPHONE_55'];

--- a/release/tests/core.test.mjs
+++ b/release/tests/core.test.mjs
@@ -122,3 +122,9 @@ test('4xx JSON error envelopes surface only codes and a sanitized message', asyn
   globalThis.fetch = async () => new Response('<html>oops</html>', { status: 502, headers: { 'content-type': 'text/html' } });
   try { await assert.rejects(request('https://api.github.com/', { hosts: ['api.github.com'] }), (error) => error.message === 'Provider HTTP 502'); } finally { globalThis.fetch = originalFetch; }
 });
+
+test('Apple and Play locales are configured separately and valid', async () => {
+  const { config } = await import('../core.mjs');
+  assert.match(config.locale, /^[a-z]{2}-[A-Z]{2}$/);
+  assert.match(config.appleLocale, /^[a-z]{2}-[A-Z]{2}$/);
+});


### PR DESCRIPTION
## Summary
- Run 34711585740 assets stage: `Configured ASC screenshot locale missing`. The App Store listing's only localization is English (U.K.) (`en-GB`); the controller looked for `config.locale` (`en-US`), which is also the Play release-notes language.
- Add `config.appleLocale` (`en-GB`) and use it in `hosting.mjs` when choosing the screenshot set to host on sovran.money.

## Verification
- `bun run test:release`: 37 node + 5 python tests pass.
- AltStore package download and extraction already succeed in that run (the failure is after them), so the next resume should host the package and open the Freedom PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnhaZJ8CJem2coLy8wr4qR