### PR TITLE
fix(release): allow the Zapstore CDN redirect host during read-back

### DIFF
--- a/release/publish.mjs
+++ b/release/publish.mjs
@@ -75,7 +75,8 @@ export async function zapstoreRelease(ledger) {
     if (!applications.length) return false;
     const blobUrl = asset.tags.find((t) => t[0] === 'url')?.[1]; check(blobUrl, 'Zapstore APK URL missing');
     try {
-      const blob = await download(blobUrl, ['cdn.zapstore.dev', 'blossom.zapstore.dev', 'github.com', 'release-assets.githubusercontent.com', 'objects.githubusercontent.com']);
+      // cdn.zapstore.dev answers GET with a 307 to its Bunny CDN origin.
+      const blob = await download(blobUrl, ['cdn.zapstore.dev', 'blossom.zapstore.dev', 'zsapk.b-cdn.net', 'github.com', 'release-assets.githubusercontent.com', 'objects.githubusercontent.com']);
       check(sha256(blob) === state.apk.sha256, 'Zapstore served APK hash mismatch');
     } catch (e) { if (e.status === 404) return false; throw e; }
     state.zapstoreEventId = release.id; return true;


### PR DESCRIPTION
## Summary
- Zapstore stage in run 34711585740 published all three 0.1.3 events (verified on relay.zapstore.dev: asset `x` = Play APK sha256, cert hash `b598…`, versionCode 24), then failed read-back with `Unapproved remote URL`.
- `cdn.zapstore.dev` answers GET with `307 → https://zsapk.b-cdn.net/blobs/<sha>.apk` (HEAD returns 200 directly, which is why it looked fine). Add `zsapk.b-cdn.net` to the read-back allow list.

## Verification
- `bun run test:release`: 37 node + 5 python tests pass.
- `curl -r 0-0` against the blob URL shows the 307 target host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnhaZJ8CJem2coLy8wr4qR