### PR TITLE
fix(release): read GitHub error envelopes in sanitized provider details

### DIFF
--- a/release/core.mjs
+++ b/release/core.mjs
@@ -33,8 +33,9 @@ export class HttpError extends Error { constructor(status, detail) { super(`Prov
 export function errorDetail(body) {
   let json; try { json = JSON.parse(body); } catch { return ''; }
   const error = json?.error ?? {};
+  // GitHub: top-level message plus errors[].resource/field/code(/message).
   const codes = [error.status, ...(error.errors ?? []).map((e) => e?.reason), ...(json?.errors ?? []).map((e) => e?.code)].filter((c) => /^[A-Za-z0-9_]{1,60}$/.test(String(c ?? '')));
-  const text = [error.message, ...(json?.errors ?? []).map((e) => [e?.title, e?.detail].filter(Boolean).join(' '))].filter(Boolean).join(' ');
+  const text = [error.message, json?.message, ...(json?.errors ?? []).map((e) => [e?.resource, e?.field, e?.title, e?.detail, e?.message].filter(Boolean).join(' '))].filter(Boolean).join(' ');
   const message = String(text).replace(/[^A-Za-z0-9 .:;()/_-]+/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 120);
   return [...new Set(codes)].join('/') + (message ? `: ${message}` : '');
 }

--- a/release/tests/core.test.mjs
+++ b/release/tests/core.test.mjs
@@ -114,6 +114,8 @@ test('4xx JSON error envelopes surface only codes and a sanitized message', asyn
   assert.match(detail, /^INVALID_ARGUMENT\/apkUpgradeVersionConflict: Version code 23 has already been used/);
   assert.ok(!detail.includes('<') && !detail.includes('?') && !detail.includes('='));
   assert.equal(errorDetail('not json'), '');
+  const github = { message: 'Validation Failed', errors: [{ resource: 'Blob', code: 'too_large', field: 'content', message: `content is too large ${canary}` }], documentation_url: 'https://docs.github.com/x' };
+  assert.equal(errorDetail(JSON.stringify(github)), 'too_large: Validation Failed Blob content content is too large fake-canary-secret');
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async () => Response.json(google, { status: 400 });
   try {


### PR DESCRIPTION
## Summary
- Run 34712664629 assets stage: locale gate passed (PR #261), then a bare `Provider HTTP 422` ~66s in, during the website-repo commit. GitHub's error envelope (`message` + `errors[].resource/field/code/message`) was not read by `errorDetail`.
- Read those fields under the existing log-safe charset and 120-char cap so the next run names the failing GitHub validation.

## Verification
- `bun run test:release`: 37 node + 5 python tests pass, including a GitHub-envelope case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnhaZJ8CJem2coLy8wr4qR