### PR TITLE
fix(release): publish large hosted files through git instead of the blob API

### DIFF
--- a/release/hosting.mjs
+++ b/release/hosting.mjs
@@ -10,7 +10,7 @@ const blobId = (bytes) => createHash('sha1').update(`blob ${bytes.length}\0`).up
 // itself accepts up to 100 MB. Apple distribution packages carry ~48 MB device
 // variants, so publish those through a partial clone and a non-force push.
 export const GIT_PUBLISH_THRESHOLD = 25_000_000;
-export async function commitFilesGit(gh, files, message) {
+async function commitFilesGit(gh, files, message) {
   return temporary(async (dir) => {
     const repo = path.join(dir, 'repo');
     // The token travels in git config env, never in argv or the remote URL.

--- a/release/hosting.mjs
+++ b/release/hosting.mjs
@@ -1,11 +1,51 @@
 import { createHash } from 'node:crypto';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { config, check, GitHub, request, required, sha256, command, temporary, download, artifactHosts, uuid } from './core.mjs';
 import { Apple } from './apple.mjs';
 
 const blobId = (bytes) => createHash('sha1').update(`blob ${bytes.length}\0`).update(bytes).digest('hex');
+// GitHub's JSON blob API rejects files above roughly 50 MB even though git
+// itself accepts up to 100 MB. Apple distribution packages carry ~48 MB device
+// variants, so publish those through a partial clone and a non-force push.
+export const GIT_PUBLISH_THRESHOLD = 25_000_000;
+export async function commitFilesGit(gh, files, message) {
+  return temporary(async (dir) => {
+    const repo = path.join(dir, 'repo');
+    // The token travels in git config env, never in argv or the remote URL.
+    const auth = Buffer.from(`x-access-token:${gh.token}`).toString('base64');
+    const env = {
+      PATH: process.env.PATH, HOME: dir, GIT_TERMINAL_PROMPT: '0', GIT_CONFIG_COUNT: '3',
+      GIT_CONFIG_KEY_0: 'http.https://github.com/.extraheader', GIT_CONFIG_VALUE_0: `AUTHORIZATION: basic ${auth}`,
+      GIT_CONFIG_KEY_1: 'user.name', GIT_CONFIG_VALUE_1: 'sovran-release',
+      GIT_CONFIG_KEY_2: 'user.email', GIT_CONFIG_VALUE_2: 'release@sovran.money',
+    };
+    const git = (args) => command('git', args, { cwd: repo, env });
+    // Trees only: no blob download of the multi-gigabyte site history.
+    command('git', ['clone', '--quiet', '--filter=blob:none', '--no-checkout', '--depth', '1', '--single-branch', '--branch', 'main', `https://github.com/${gh.repository}.git`, repo], { env });
+    git(['read-tree', 'HEAD']);
+    const head = git(['rev-parse', 'HEAD']).trim();
+    let changed = 0;
+    for (const file of files) {
+      const entry = git(['ls-tree', 'HEAD', '--', file.path]).trim();
+      const previous = entry ? entry.split(/\s+/)[2] : null;
+      if (file.expectedSha) check(previous === file.expectedSha, 'Website metadata changed concurrently; retry against new state');
+      if (previous === blobId(file.bytes)) continue;
+      if (file.immutable) check(!previous, 'Refusing to overwrite immutable release asset');
+      check(file.bytes.length < 99_000_000, 'Publication file exceeds GitHub limit');
+      const target = path.join(repo, file.path);
+      mkdirSync(path.dirname(target), { recursive: true }); writeFileSync(target, file.bytes, { mode: 0o600 });
+      git(['add', '--', file.path]); changed++;
+    }
+    if (!changed) return head;
+    git(['commit', '--quiet', '-m', message]);
+    // No force: a concurrent site change rejects this push and the next
+    // reconcile recomputes against current main.
+    git(['push', '--quiet', 'origin', 'HEAD:main']);
+    return git(['rev-parse', 'HEAD']).trim();
+  });
+}
 export async function commitFiles(gh, files, message) {
   const unique = new Map();
   for (const file of files) {
@@ -16,6 +56,7 @@ export async function commitFiles(gh, files, message) {
   files = [...unique.values()];
   check(files.length > 0 && files.length <= 10000, 'Invalid publication file count');
   for (const file of files) check(/^(public\/(ios\/(releases|media)\/|releases\/)|src\/releaseMedia\.json$)/.test(file.path) && !file.path.includes('..') && !file.path.includes('\\'), 'Publication path outside allowlist');
+  if (files.some((file) => file.bytes.length > GIT_PUBLISH_THRESHOLD)) return commitFilesGit(gh, files, message);
   const head = (await gh.api('git/ref/heads/main')).object.sha;
   const commit = await gh.api(`git/commits/${head}`);
   const tree = await gh.api(`git/trees/${commit.tree.sha}?recursive=1`);

--- a/release/tests/distribution.test.mjs
+++ b/release/tests/distribution.test.mjs
@@ -79,3 +79,33 @@ test('pending stores preserve old availability; conflicting APK hashes are rejec
   assert.throws(() => mergeChannels(next, { githubApk: { version: '0.1.1', build: '30', sha256: 'b'.repeat(64) } }));
   assert.deepEqual(mergeChannels(next, { appStore: { version: '0.0.9', build: '100' } }), next);
 });
+
+test('large publication files go through a partial clone and a non-force git push', async () => {
+  const childProcess = (await import('node:child_process')).default;
+  const { syncBuiltinESMExports } = await import('node:module');
+  const { mock } = await import('node:test');
+  const { GIT_PUBLISH_THRESHOLD } = await import('../hosting.mjs');
+  const { GitHub } = await import('../core.mjs');
+  const gh = new GitHub('fake-canary-token', 'SovranBitcoin/sovran.money');
+  const big = Buffer.alloc(GIT_PUBLISH_THRESHOLD + 1, 1);
+  const calls = [];
+  const handle = mock.method(childProcess, 'execFileSync', (binary, args, options) => {
+    assert.equal(binary, 'git'); calls.push(args);
+    assert.ok(!args.join(' ').includes('fake-canary-token'), 'token must not appear in argv');
+    assert.ok(String(options.env.GIT_CONFIG_VALUE_0).startsWith('AUTHORIZATION: basic '));
+    if (args[0] === 'rev-parse') return calls.some((c) => c[0] === 'push') ? 'new-head\n' : 'old-head\n';
+    if (args[0] === 'ls-tree') return args.at(-1) === 'public/ios/releases/id/existing.ipa' ? '100644 blob deadbeef\tpublic/ios/releases/id/existing.ipa\n' : '';
+    return '';
+  });
+  syncBuiltinESMExports();
+  try {
+    await assert.rejects(commitFiles(gh, [{ path: 'public/ios/releases/id/existing.ipa', bytes: big, immutable: true }], 'x'), /Refusing to overwrite immutable release asset/);
+    calls.length = 0;
+    const sha = await commitFiles(gh, [{ path: 'public/ios/releases/id/variant/a.ipa', bytes: big, immutable: true }, { path: 'public/releases/0.1.3-ios.json', bytes: Buffer.from('[]'), immutable: true }], 'chore: publish');
+    assert.equal(sha, 'new-head');
+    const clone = calls.find((c) => c[0] === 'clone'); assert.ok(clone.includes('--filter=blob:none') && clone.includes('--no-checkout'));
+    assert.ok(calls.some((c) => c[0] === 'read-tree'));
+    assert.deepEqual(calls.filter((c) => c[0] === 'add').map((c) => c.at(-1)), ['public/ios/releases/id/variant/a.ipa', 'public/releases/0.1.3-ios.json']);
+    const push = calls.find((c) => c[0] === 'push'); assert.deepEqual(push, ['push', '--quiet', 'origin', 'HEAD:main']);
+  } finally { handle.mock.restore(); syncBuiltinESMExports(); }
+});


### PR DESCRIPTION
## Summary
- Assets stage (runs 34712664629, 34713799125): `Provider HTTP 422` while committing the Apple distribution package to `SovranBitcoin/sovran.money`. GitHub's JSON blob endpoint rejects files above ~50 MB in practice; the 0.1.3 package is 34 files / 862 MB with ~48 MB device variants, all under the controller's 99 MB guard.
- The site already hosts the 0.1.0 package (`public/ios/releases/3b88fe9e…`) at identical sizes, committed via git on 2026-06-09.
- Add `commitFilesGit`: `git clone --filter=blob:none --no-checkout --depth 1`, `read-tree HEAD`, per-file `ls-tree` for immutability/identity/expectedSha checks, `add`, `commit`, `push origin HEAD:main` (no force). Token passes via `GIT_CONFIG_*` env, never argv or the URL. `commitFiles` routes any publication with a file over 25 MB there; artwork/metadata keep the API path.

## Verification
- `bun run test:release`: 38 node + 5 python tests pass; new test asserts clone flags, index population, add/commit/push sequence, immutability refusal, and that the token never appears in argv.
- Read-only dry run of the clone/read-tree/ls-tree commands against the real website repo (see session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnhaZJ8CJem2coLy8wr4qR