### PR TITLE
fix(release): keep Freedom catalog PRs minimal and Prettier-formatted

### DIFF
--- a/.github/workflows/release-stage.yml
+++ b/.github/workflows/release-stage.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '22'
-      - if: contains(fromJSON('["build","zapstore"]'), inputs.stage)
+      - if: contains(fromJSON('["build","zapstore","freedom"]'), inputs.stage)
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: '1.3.5'
@@ -49,8 +49,8 @@ jobs:
       - if: inputs.stage == 'build'
         name: Install pinned EAS CLI outside source
         run: npm install --global eas-cli@24.0.0 --ignore-scripts
-      - if: inputs.stage == 'zapstore'
-        name: Install existing Nostr verifier from locked workspace
+      - if: contains(fromJSON('["zapstore","freedom"]'), inputs.stage)
+        name: Install locked workspace tools (Nostr verifier, Prettier)
         working-directory: controller
         run: bun install --frozen-lockfile --ignore-scripts --backend=copyfile
         env:

--- a/release/freedom.mjs
+++ b/release/freedom.mjs
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module';
 import { config, check, GitHub, request, required, published, compareVersion } from './core.mjs';
 import { verifyHosted } from './hosting.mjs';
 
@@ -11,12 +12,20 @@ export function updateSource(source, state) {
   else {
     check(!app.versions.some((v) => v.downloadURL === state.adp.url), 'ADP reused for a different release');
     check(!app.versions.some((v) => compareVersion(v.version, state.version) > 0), 'Freedom already has a newer release');
-    app.versions.unshift({ version: state.version, buildVersion: state.builds.ios.number, date: state.createdAt, downloadURL: state.adp.url, size: state.adp.size, minOSVersion: state.adp.minOSVersion, localizedDescription: `Sovran ${state.version}. Improvements and fixes.` });
+    app.versions.unshift({ version: state.version, buildVersion: state.builds.ios.number, date: state.createdAt.slice(0, 10), downloadURL: state.adp.url, size: state.adp.size, minOSVersion: state.adp.minOSVersion, localizedDescription: `Sovran ${state.version}. Improvements and fixes.` });
   }
   app.screenshots = state.screenshots;
   return result;
 }
 
+// freedomstore/altstore-source.json is Prettier-formatted (default options).
+// Re-serializing with JSON.stringify expands every short array and turns a
+// nine-line release into a whole-file rewrite, so format with the app
+// workspace's pinned Prettier instead of shipping a hand-rolled printer.
+export async function formatSource(source) {
+  const prettier = createRequire(new URL('../app/package.json', import.meta.url))('prettier');
+  return prettier.format(JSON.stringify(source), { parser: 'json' });
+}
 export async function freedomRelease(ledger) {
   const state = ledger.state;
   if (!state.steps.assetsHosted || state.channels.freedomStore?.version === state.version) return;
@@ -64,7 +73,7 @@ export async function freedomRelease(ledger) {
     check(upstreamApp.versions.find((v) => v.version === state.version && String(v.buildVersion) === state.builds.ios.number).downloadURL === state.adp.url, 'Merged Freedom release has a different ADP');
     return;
   }
-  const bytes = Buffer.from(JSON.stringify(updateSource(JSON.parse(base.bytes), state), null, 2) + '\n');
+  const bytes = Buffer.from(await formatSource(updateSource(JSON.parse(base.bytes), state)));
   let ref = await fork.optional(`git/ref/heads/${branch}`);
   if (!ref) {
     await fork.api('git/refs', { method: 'POST', body: { ref: `refs/heads/${branch}`, sha: upstreamHead } });

--- a/release/tests/distribution.test.mjs
+++ b/release/tests/distribution.test.mjs
@@ -1,7 +1,7 @@
 import { test, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import { config, sha256 } from '../core.mjs';
-import { updateSource } from '../freedom.mjs';
+import { updateSource, formatSource } from '../freedom.mjs';
 import { validateManifest, verifyHosted, commitFiles } from '../hosting.mjs';
 import { selectUniversal } from '../android.mjs';
 import { validateBuild } from '../build.mjs';
@@ -108,4 +108,15 @@ test('large publication files go through a partial clone and a non-force git pus
     assert.deepEqual(calls.filter((c) => c[0] === 'add').map((c) => c.at(-1)), ['public/ios/releases/id/variant/a.ipa', 'public/releases/0.1.3-ios.json']);
     const push = calls.find((c) => c[0] === 'push'); assert.deepEqual(push, ['push', '--quiet', 'origin', 'HEAD:main']);
   } finally { handle.mock.restore(); syncBuiltinESMExports(); }
+});
+
+test('Freedom source keeps upstream Prettier formatting and date shape', async () => {
+  const next = updateSource(source(), state());
+  const entry = next.apps[0].versions[0];
+  assert.match(entry.date, /^\d{4}-\d{2}-\d{2}$/, 'catalog dates are plain calendar days like every other entry');
+  const upstream = '{\n  "apps": [\n    {\n      "entitlements": ["com.apple.developer.associated-domains"],\n      "versions": [{ "version": "0.1.0" }]\n    }\n  ]\n}\n';
+  assert.equal(await formatSource(JSON.parse(upstream)), upstream, 'formatting a Prettier-formatted file is a no-op');
+  const formatted = await formatSource(next);
+  assert.ok(!formatted.includes('[\n        "https://'), 'short arrays stay on one line');
+  assert.ok(formatted.endsWith('\n') && !formatted.endsWith('\n\n'));
 });


### PR DESCRIPTION
## Summary
- freedomstore/freedomstore#40 touched 180 lines for a single release: `JSON.stringify(…, null, 2)` expands every short array (`"entitlements": [...]`) that the upstream file keeps on one line, and the `date` was a full ISO timestamp where every catalog entry uses `YYYY-MM-DD`.
- The upstream file is byte-identical to Prettier's default JSON output, so `formatSource()` now formats through the app workspace's pinned Prettier (resolved like `nostr-tools` in the zapstore stage). Regenerating 0.1.3 against upstream `main` yields a 26-line diff: the screenshot list plus the new version entry.
- `release-stage.yml`: the freedom stage now installs the locked workspace tools like the zapstore stage.

## Note on the red check on #40
The upstream validator itself **passed** ("Validated 1 new release successfully"); the job fails only in its final "Comment on pull request" step, which cannot post on fork PRs with the read-only token. That is an upstream workflow issue, not a catalog problem.

## Verification
- `bun run test:release`: 39 node + 5 python tests pass (formatting is a no-op on Prettier-formatted input; dates are plain days).
- Knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnhaZJ8CJem2coLy8wr4qR