### PR TITLE
fix(release): host the App Store listing's screenshot set, not the largest one

### DIFF
--- a/release/config.json
+++ b/release/config.json
@@ -15,6 +15,7 @@
   "freedomSource": "https://source.freedomstore.io/",
   "locale": "en-US",
   "appleLocale": "en-GB",
+  "appleScreenshotSet": "APP_IPHONE_65",
   "zsp": {
     "version": "0.4.17",
     "sha256": "3f241da6a5dc7a85fe851d3b42b77790b651bd36c7029382a701262bda832d20"

--- a/release/hosting.mjs
+++ b/release/hosting.mjs
@@ -103,7 +103,11 @@ async function mediaFiles(state, apple) {
   const locale = locales.find((l) => l.attributes.locale === wanted);
   check(locale, 'Configured ASC screenshot locale missing');
   const sets = await apple.list(`appStoreVersionLocalizations/${locale.id}/appScreenshotSets`);
-  const preference = ['APP_IPHONE_69', 'APP_IPHONE_67', 'APP_IPHONE_65', 'APP_IPHONE_61', 'APP_IPHONE_58', 'APP_IPHONE_55'];
+  // App Store Connect keeps every historical size; the set Apple serves on the
+  // public listing is the one the catalog should mirror. Pin it in config
+  // (0.1.3: the 6.9" set held stale 2025 screenshots while 6.5" was current)
+  // and fall back to the largest set only when the configured one is absent.
+  const preference = [config.appleScreenshotSet, 'APP_IPHONE_69', 'APP_IPHONE_67', 'APP_IPHONE_65', 'APP_IPHONE_61', 'APP_IPHONE_58', 'APP_IPHONE_55'].filter(Boolean);
   const set = preference.map((type) => sets.find((s) => s.attributes.screenshotDisplayType === type)).find(Boolean);
   check(set, 'No iPhone screenshot set');
   const shots = await apple.list(`appScreenshotSets/${set.id}/appScreenshots`);

--- a/release/tests/core.test.mjs
+++ b/release/tests/core.test.mjs
@@ -129,4 +129,5 @@ test('Apple and Play locales are configured separately and valid', async () => {
   const { config } = await import('../core.mjs');
   assert.match(config.locale, /^[a-z]{2}-[A-Z]{2}$/);
   assert.match(config.appleLocale, /^[a-z]{2}-[A-Z]{2}$/);
+  assert.match(config.appleScreenshotSet, /^APP_IPHONE_\d{2}$/, 'the hosted screenshot set is pinned to the one the App Store listing serves');
 });


### PR DESCRIPTION
## Summary
- freedomstore#40 and sovran.money received seven 2025-era screenshots (1320×2868): the assets stage prefers `APP_IPHONE_69`, but that App Store Connect set is stale. The `APP_IPHONE_65` set holds the current design and is the one Apple serves on the public listing (the page exposes only `iphone_6_5`).
- Add `config.appleScreenshotSet` (`APP_IPHONE_65`) and try it first; the size ladder remains as a fallback if the configured set is absent.

## Follow-up
The 0.1.3 checkpoint will be corrected (drop `inventory`/`screenshots`, clear `assetsHosted`) so the next resume re-hosts media from the right set and regenerates the Freedom PR file; the stale PNGs stay as immutable orphans on the site.

## Verification
- `bun run test:release`: 39 node + 5 python tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnhaZJ8CJem2coLy8wr4qR