### PR TITLE
fix(release): install controller workspace tools before validate tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,11 @@ jobs:
         run: bun install --frozen-lockfile --backend=copyfile
         env:
           GITHUB_TOKEN: ${{ secrets.SOVRAN_CI_TOKEN || github.token }}
+      - name: Install locked controller workspace tools (Prettier for Freedom tests)
+        working-directory: controller
+        run: bun install --frozen-lockfile --ignore-scripts --backend=copyfile
+        env:
+          GITHUB_TOKEN: ${{ secrets.SOVRAN_CI_TOKEN || github.token }}
       - name: Validate release failure paths and source archive policy
         run: |
           node --test ../controller/release/tests/*.test.mjs


### PR DESCRIPTION
## Summary
- Run 34720720937 failed in `validate` at "Validate release failure paths and source archive policy": `Freedom source keeps upstream Prettier formatting and date shape` cannot resolve Prettier because the test runs against the `controller/` checkout, where the workflow never ran `bun install` (only `source/` is installed).
- Add the same locked, script-free install the zapstore and freedom stages already perform, before the controller tests.

## Verification
- `bun run test:release` passes locally (39 node + 5 python). The CI path is the one this fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnhaZJ8CJem2coLy8wr4qR